### PR TITLE
Add AGENTS documentation

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,4 @@
+# GitHub Configuration
+
+Continuous integration workflows live in `workflows/`.
+`build.yml` compiles the tree with GCC and Clang using the C23 standard.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,4 @@
+# CI Workflows
+
+This directory contains automation files used by GitHub Actions.
+`build.yml` builds the userland with both GCC and Clang.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Guide
+
+This repository contains the historical 4.4BSD-Lite2 tree along with modernization notes.
+It mirrors a BSD root filesystem layout.
+
+## Key Documentation
+- `SOURCE_TREE_OVERVIEW.md` gives a summary of the top-level directories.
+- The `docs/` directory holds build instructions and modernization plans.
+
+Each major subdirectory includes its own `AGENTS.md` describing that area.
+
+## Workflow Guidelines
+- Keep commits focused and update `docs/` when relevant.
+- Documentation changes require no automated tests.
+- For code changes, try building using the steps in `docs/building_kernel.md`.

--- a/Domestic/AGENTS.md
+++ b/Domestic/AGENTS.md
@@ -1,0 +1,5 @@
+# Domestic Sources
+
+This directory contains the "domestic" version of the 4.4BSD-Lite2 userland,
+including cryptographic software such as Kerberos IV and `bdes`.
+Preserve original file paths and comments for historical reference.

--- a/Foreign/AGENTS.md
+++ b/Foreign/AGENTS.md
@@ -1,0 +1,4 @@
+# Foreign Sources
+
+This tree mirrors `Domestic` but omits U.S. cryptographic software.
+Use it when building without the domestic crypto components.

--- a/dev/AGENTS.md
+++ b/dev/AGENTS.md
@@ -1,0 +1,4 @@
+# Device Scripts
+
+`MAKEDEV` and related scripts for creating device nodes under `/dev`.
+They are historical examples and do not require automated tests.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,9 @@
+# Documentation Directory
+
+This folder stores notes about building and modernizing the tree.
+Key references:
+- `building_kernel.md` – instructions for compiling the kernel.
+- `modernization_plan.md` – high level refactor roadmap.
+- `refactor_c23_tasks.md` – ongoing task list.
+- `file_tree.txt` – snapshot of the original layout.
+No tests are required when editing documentation.

--- a/etc/AGENTS.md
+++ b/etc/AGENTS.md
@@ -1,0 +1,4 @@
+# System Configuration Samples
+
+Historic `/etc` files such as crontabs and rc scripts.
+These are for reference and may not match modern systems.

--- a/root/AGENTS.md
+++ b/root/AGENTS.md
@@ -1,0 +1,4 @@
+# Root Account Placeholder
+
+This directory represents the root user's home in the distribution.
+It is mostly empty and rarely changed.

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,8 @@
+# Utility Scripts
+
+Scripts for analyzing and working with the source tree.
+Examples:
+- `analyze_codebase.py` – count source files.
+- `generate_cscope.sh` and `generate_ctags.sh` – index helpers.
+- `build_collect_warnings.sh` – build and capture warnings.
+No automated tests are required to modify these scripts.

--- a/usr/AGENTS.md
+++ b/usr/AGENTS.md
@@ -1,0 +1,4 @@
+# Userland Tree
+
+Sources for utilities, libraries and manual pages.
+It mirrors the classic `/usr` hierarchy. Build using the provided makefiles.

--- a/usr/src/AGENTS.md
+++ b/usr/src/AGENTS.md
@@ -1,0 +1,3 @@
+# Source Tree
+
+This directory mirrors the original 4.4BSD-Lite2 `src` hierarchy. It contains the sources for userland programs, libraries and the kernel (under `sys/`).

--- a/usr/src/sys/AGENTS.md
+++ b/usr/src/sys/AGENTS.md
@@ -1,0 +1,4 @@
+# Kernel Sources
+
+This directory holds the kernel code for multiple architectures.
+Follow existing style when modifying C files and see `../docs/building_kernel.md` for build steps.

--- a/var/AGENTS.md
+++ b/var/AGENTS.md
@@ -1,0 +1,4 @@
+# Runtime Data
+
+Example layout for `/var` including subdirectories like `log/` and `run/`.
+Usually untouched during development.


### PR DESCRIPTION
## Summary
- add root AGENTS file with high-level instructions
- document each major subdirectory with its own AGENTS

## Testing
- `git status --short`