### PR TITLE
Fix warnings script quoting

### DIFF
--- a/tools/build_collect_warnings.sh
+++ b/tools/build_collect_warnings.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 # Build userland with optional CSTD and ARCH flags and store warnings.
-set -e
+set -euo pipefail
 LOGDIR="build_logs"
 mkdir -p "$LOGDIR"
-ARCH_FLAGS=""
-case "${ARCH}" in
+ARCH_FLAGS=""   # -m32 or -m64 passed to the compiler
+case "${ARCH:-}" in
     i686)
-        ARCH_FLAGS="-m32"
+        ARCH_FLAGS="-m32"  # build 32-bit binaries
         ;;
     x86_64)
-        ARCH_FLAGS="-m64"
+        ARCH_FLAGS="-m64"  # build 64-bit binaries
         ;;
 esac
 
-make -C usr/src CC="${CC:-cc}" CSTD="${CSTD:--std=c2x}" CFLAGS="${CFLAGS} ${ARCH_FLAGS}" \
+make -C usr/src CC="${CC:-cc}" CSTD="${CSTD:--std=c2x}" CFLAGS="${CFLAGS:-} ${ARCH_FLAGS}" \
     2>&1 | tee "$LOGDIR/build_${ARCH:-native}.log"


### PR DESCRIPTION
## Summary
- sanitize build_collect_warnings script
  - add `set -euo pipefail`
  - quote `${ARCH}` and `${CFLAGS}` safely
  - document `ARCH_FLAGS`

## Testing
- `bash -n tools/build_collect_warnings.sh`