### PR TITLE
Add FHS migration doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Downloaded from: ftp://alge.anart.no/pub/BSD/4.4BSD-Lite/4.4BSD-Lite2.tar.gz
 
 For kernel build instructions see [docs/building_kernel.md](docs/building_kernel.md).
 For GitHub CI examples see [docs/ci_workflows.md](docs/ci_workflows.md).
+For FHS migration steps see [docs/fhs_migration.md](docs/fhs_migration.md).
 # Documentation
 
 ### User's Supplementary Documents

--- a/docs/fhs_migration.md
+++ b/docs/fhs_migration.md
@@ -1,0 +1,41 @@
+# FHS Migration Guide
+
+This document expands on the tasks in [reorg_plan.md](reorg_plan.md) to show how
+the historical 4.4BSD-Lite2 layout maps onto a modern Filesystem Hierarchy
+Standard (FHS) structure.
+
+## Background
+
+`reorg_plan.md` lists generating an inventory, drafting new makefiles and
+restructuring directories as key steps. After cataloging files the next phase is
+to place them under directories that match the FHS while retaining references to
+the original locations.
+
+## Example directory mappings
+
+- `/usr/adm` &rarr; `/var/log` – system logs and accounting data
+- `/usr/spool` &rarr; `/var/spool` – generic spool directories
+- `/usr/spool/mail` &rarr; `/var/mail` – user mailboxes
+- `/usr/tmp` &rarr; `/var/tmp` – preserved temporary files
+- `/tmp` &rarr; `/tmp` – volatile temporary files
+- `/etc` &rarr; `/etc` – configuration files
+- `/usr/libexec` &rarr; `/usr/libexec` – helper daemons
+- `/usr/local` &rarr; `/usr/local` – site-specific programs
+- `/root` &rarr; `/root` – superuser home directory
+
+Additional mappings may be required for subsystems like print spooling or
+Kerberos databases, but the above examples cover common directories encountered
+when modernizing historic BSD trees.
+
+## Migration steps
+
+1. Create the target directories following the FHS layout.
+2. Move files from their historical paths while preserving ownership and
+   permissions.
+3. Provide compatibility symlinks from the old locations to the new ones during
+   the transition period.
+4. Update makefiles and scripts to use the new paths.
+5. Document each mapping for future developers.
+
+Following these steps alongside the broader plan in `reorg_plan.md` helps turn
+the BSD distribution into a structure that is familiar to modern systems.

--- a/docs/modernization_plan.md
+++ b/docs/modernization_plan.md
@@ -4,6 +4,9 @@ This document outlines initial steps toward analyzing and updating the 4.4BSD-Li
 codebase. It does not constitute a complete refactor, but provides guidance for
 future work.
 
+For a summary of directory mappings during the reorganization see
+[fhs_migration.md](fhs_migration.md).
+
 ## Phase 1: Codebase Analysis
 - Generate cross-reference databases using `cscope` and `ctags`.
 - Use `tools/analyze_codebase.py` to count source files by extension.


### PR DESCRIPTION
## Summary
- document directory mappings when migrating to FHS
- link to the new guide from the main README
- cross-link from the modernization plan

## Testing
- `git status --short`