### PR TITLE
Implement early modernization tasks

### DIFF
--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -1,6 +1,14 @@
 # Building the 4.4BSD-Lite2 kernel
 
 This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `make`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
+If your host lacks `yacc` or `bison`, build the repository's bundled version first:
+```sh
+cd usr/src/usr.bin/yacc
+make clean && make
+export YACC=$(pwd)/yacc
+```
+Then proceed with the steps below.
+
 
 1. **Build the `config` utility**
    ```sh

--- a/docs/fhs_migration.md
+++ b/docs/fhs_migration.md
@@ -62,4 +62,11 @@ when modernizing historic BSD trees.
 
 Following these steps alongside the broader plan in `reorg_plan.md` helps turn
 the BSD distribution into a structure that is familiar to modern systems.
+## Remaining Manual Symlinks
+Some directories are not handled by `migrate_to_fhs.sh` and must be linked manually:
+- `sys` - kernel sources remain at the repository root
+- `Domestic` - U.S. cryptography sources
+- `Foreign` - externally maintained utilities
+Record additional directories here as they are discovered.
+
 

--- a/docs/file_inventory.txt
+++ b/docs/file_inventory.txt
@@ -136,10 +136,13 @@ dev/MAKEDEV.hpux
 dev/MAKEDEV.local
 docs/AGENTS.md
 docs/building_kernel.md
+docs/ci_workflows.md
+docs/fhs_migration.md
 docs/file_inventory.txt
 docs/file_tree.txt
 docs/modernization_plan.md
 docs/refactor_c23_tasks.md
+docs/reorg_continuation_tasks.md
 docs/reorg_plan.md
 etc/AGENTS.md
 etc/aliases
@@ -209,6 +212,7 @@ tools/create_inventory.py
 tools/generate_cscope.sh
 tools/generate_ctags.sh
 tools/generate_dependency_graph.py
+tools/migrate_to_fhs.sh
 usr/AGENTS.md
 usr/X11
 usr/bin/X11
@@ -14190,6 +14194,8 @@ usr/src/libpathtrans/src/pathtrans.c
 usr/src/libpathtrans/tests/.gitkeep
 usr/src/libpathtrans/tests/Makefile
 usr/src/libpathtrans/tests/run_tests.sh
+usr/src/libpathtrans/tests/test_disable_env.c
+usr/src/libpathtrans/tests/test_path_database.c
 usr/src/libpathtrans/tests/test_translation.c
 usr/src/libpathtrans/tools/.gitkeep
 usr/src/libpathtrans/tools/Makefile

--- a/docs/modernization_plan.md
+++ b/docs/modernization_plan.md
@@ -16,6 +16,7 @@ For a summary of directory mappings during the reorganization see
 - Configure modern compilers (e.g., GCC or Clang) with `-std=c2x`.
 - Maintain compatibility with existing BSD makefiles while introducing
   modern build options.
+- Prototype CMake build files using **CMake 3.16+** to evaluate a cross-platform build system.
 - Integrate static analysis tools such as `clang-tidy`.
 
 ## Phase 3: Userland Modernization

--- a/docs/reorg_continuation_tasks.md
+++ b/docs/reorg_continuation_tasks.md
@@ -1,0 +1,38 @@
+# Directory Restructure and Modernization: Next Steps
+
+This document outlines tasks for agents to continue migrating the 4.4BSD-Lite2 tree to a modern layout while preserving historical context.
+
+
+## Short-Term Goals
+
+- [ ] **Finalize FHS Mapping**
+  - [x] Document any remaining directories that require manual symlink creation
+  - [ ] Verify that all top-level directories are mapped to their FHS equivalents
+- [ ] **Update Build Scripts**
+  - [ ] Adjust makefiles under `usr/src` to reference the new paths created during the migration
+  - [x] Ensure `tools/migrate_to_fhs.sh` updates symlinks when rerun
+- [ ] **Inventory Remaining Legacy Files**
+  - [x] Use `tools/create_inventory.py` to produce an updated file list
+  - [ ] Mark files that are deprecated or replaced in the modern layout
+## Mid-Term Goals
+
+1. **Library Consolidation**
+   - Merge duplicated libraries found in `lib/` and `usr/src/lib`.
+   - Create a unified `lib` directory and update dependent makefiles.
+2. **Kernel Source Cleanup**
+   - Move architecture-specific kernel code under `sys/arch`.
+   - Introduce a hardware abstraction layer stub for future expansion.
+3. **CI Integration**
+   - Expand the existing workflow to test both the historical and restructured layouts.
+   - Record build metrics and warnings for each configuration.
+
+## Long-Term Goals
+
+1. **Remove Obsolete Utilities**
+   - Identify userland tools superseded by modern counterparts.
+   - Provide stubs or compatibility wrappers where required for historical builds.
+2. **Update Documentation**
+   - Continue updating manuals and README files as directories move.
+   - Cross-reference original paths in comments for archival purposes.
+
+These tasks build upon `reorg_plan.md` and `modernization_plan.md`. Agents should update this list as progress is made.

--- a/tools/migrate_to_fhs.sh
+++ b/tools/migrate_to_fhs.sh
@@ -31,16 +31,15 @@ if ! in_chroot && [ "$FORCE" -ne 1 ]; then
 fi
 
 # Ensure target directories exist
+
+# Handle common directories in a loop so the script can be rerun
 mkdir -p usr/bin usr/sbin usr/lib usr/libexec
 
-rsync -a bin/ usr/bin/
-rsync -a sbin/ usr/sbin/
-rsync -a lib/ usr/lib/
-rsync -a libexec/ usr/libexec/
-
-ln -snf usr/bin bin
-ln -snf usr/sbin sbin
-ln -snf usr/lib lib
-ln -snf usr/libexec libexec
+for d in bin sbin lib libexec; do
+    if [ -d "$d" ]; then
+        rsync -a "$d/" "usr/$d/"
+        ln -snf "usr/$d" "$d"
+    fi
+done
 
 echo "FHS migration complete."

--- a/usr/src/usr.sbin/config/Makefile
+++ b/usr/src/usr.sbin/config/Makefile
@@ -1,12 +1,22 @@
-#	@(#)Makefile	8.1 (Berkeley) 6/6/93
+# Simplified GNU makefile for the config utility
+PROG = config
+CFLAGS += -I. -I$(CURDIR)
+SRCS = config.c main.c lang.c mkioconf.c mkmakefile.c mkglue.c mkheaders.c \
+       mkswapconf.c
+LDADD = -ll
+CLEANFILES = y.tab.h lang.c config.c y.tab.c
 
-PROG=	config
-CFLAGS+=-I. -I${.CURDIR}
-SRCS=	config.c main.c lang.c mkioconf.c mkmakefile.c mkglue.c mkheaders.c \
-	mkswapconf.c
-MAN8=	config.0
-DPADD=	${LIBL}
-LDADD=	-ll
-CLEANFILES+=y.tab.h lang.c config.c y.tab.c
+OBJS = $(SRCS:.c=.o)
 
-.include <bsd.prog.mk>
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) $(LDADD) -o $@
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(PROG) $(OBJS) $(CLEANFILES)
+
+.PHONY: all clean


### PR DESCRIPTION
## Summary
- describe building bundled yacc when missing
- prototype cmake builds in modernization plan
- add manual symlinks section for FHS migration
- mark progress with checkboxes in continuation tasks
- loop over directories in migration script
- simplify config Makefile for GNU make
- regenerate `file_inventory.txt`

## Testing
- `python3 tools/create_inventory.py`
- `make clean` in `usr/src/usr.sbin/config`