### PR TITLE
Add source organization script

### DIFF
--- a/docs/fhs_migration.md
+++ b/docs/fhs_migration.md
@@ -61,21 +61,25 @@ when modernizing historic BSD trees.
    `tools/migrate_to_fhs.sh --dry-run` to review the planned actions.
 3. Execute `tools/migrate_to_fhs.sh` without `--dry-run` to copy directories
    under `/usr` and replace the originals with symlinks.
-4. Verify the new symlinks by running `ls -l` on `bin`, `sbin` and related
+4. Run `tools/organize_sources.sh` to relocate the source tree. This moves
+   the kernel into `src-kernel`, user programs into `src-uland`, headers into
+   `src-headers` and library objects into `src-lib`.
+5. Verify the new symlinks by running `ls -l` on `bin`, `sbin` and related
    directories.
-5. Update makefiles and scripts to reference the new paths. `grep -r "/bin"`
+6. Update makefiles and scripts to reference the new paths. `grep -r "/bin"`
    can help locate hard-coded locations.
-6. Once the build succeeds with the new layout, remove any compatibility links
+7. Once the build succeeds with the new layout, remove any compatibility links
    that are no longer needed.
-7. Re-run `tools/create_inventory.py` so that `docs/file_inventory.txt` reflects
+8. Re-run `tools/create_inventory.py` so that `docs/file_inventory.txt` reflects
    the updated structure and commit the results alongside documentation notes.
-8. Keep a log of each mapping for future developers.
+9. Keep a log of each mapping for future developers.
 
 Following these steps alongside the broader plan in `reorg_plan.md` helps turn
 the BSD distribution into a structure that is familiar to modern systems.
 ## Remaining Manual Symlinks
-Some directories are not handled by `migrate_to_fhs.sh` and must be linked manually:
-- `sys` - kernel sources remain at the repository root
+Some directories are not handled by `migrate_to_fhs.sh` and must be linked manually.
+After running `tools/organize_sources.sh` the kernel sources live in `src-kernel`.
+Directories that still require manual handling include:
 - `Domestic` - U.S. cryptography sources
 - `Foreign` - externally maintained utilities
 Record additional directories here as they are discovered.

--- a/tools/organize_sources.sh
+++ b/tools/organize_sources.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Post-FHS source tree reorganization
+# Moves kernel and userland sources into consolidated directories.
+# Usage: organize_sources.sh [--force] [--dry-run]
+
+set -e
+
+usage() {
+    echo "Usage: $0 [--force] [--dry-run]" >&2
+    exit 1
+}
+
+in_chroot() {
+    if [ "$(stat -c %d:%i / 2>/dev/null)" != "$(stat -c %d:%i /proc/1/root 2>/dev/null)" ]; then
+        return 0
+    fi
+    return 1
+}
+
+FORCE=0
+DRYRUN=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force)
+            FORCE=1
+            ;;
+        --dry-run)
+            DRYRUN=1
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+run_cmd() {
+    if [ "$DRYRUN" -eq 1 ]; then
+        echo "$*"
+    else
+        eval "$*"
+    fi
+}
+
+move_and_link() {
+    src="$1"
+    dst="$2"
+    [ -e "$src" ] || return 0
+
+    run_cmd "mkdir -p \"$(dirname "$dst")\""
+    run_cmd "rsync -a \"$src/\" \"$dst/\""
+    run_cmd "rm -rf \"$src\""
+    run_cmd "ln -snf \"$dst\" \"$src\""
+}
+
+move_artifacts() {
+    base="$1"
+    [ -d "$base" ] || return 0
+    find "$base" -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.so.*' \) | while read f; do
+        rel="${f#$base/}"
+        dest="src-lib/$rel"
+        run_cmd "mkdir -p \"$(dirname "$dest")\""
+        run_cmd "mv \"$f\" \"$dest\""
+    done
+}
+
+if ! in_chroot && [ "$FORCE" -ne 1 ]; then
+    echo "Error: not running inside a chroot. Use --force to override." >&2
+    exit 1
+fi
+
+move_and_link sys src-kernel
+move_and_link usr/src src-uland
+move_and_link src-uland/include src-headers
+
+move_artifacts src-uland
+move_artifacts src-kernel
+
+echo "Source tree organization complete."


### PR DESCRIPTION
## Summary
- add `tools/organize_sources.sh` for moving sources after FHS conversion
- document script use in `docs/fhs_migration.md`

## Testing
- `git status --short`
