### PR TITLE
Simplify FHS migration helper mkdir logic

### DIFF
--- a/tools/migrate_to_fhs.sh
+++ b/tools/migrate_to_fhs.sh
@@ -65,7 +65,6 @@ fi
 # Ensure target directories exist
 
 # Handle common directories in a loop so the script can be rerun
-mkdir -p usr/bin usr/sbin usr/lib usr/libexec
 
 for d in bin sbin lib libexec; do
     if [ -d "$d" ]; then


### PR DESCRIPTION
## Summary
- remove unconditional directory creation
- rely on one `run_cmd mkdir -p` before `move_and_link`

## Testing
- `bash tools/migrate_to_fhs.sh --dry-run`
- `bash tools/migrate_to_fhs.sh`