### PR TITLE
Move scheduling, VM, and VFS code to userland

### DIFF
--- a/SOURCE_TREE_OVERVIEW.md
+++ b/SOURCE_TREE_OVERVIEW.md
@@ -7,6 +7,8 @@ This repository contains the 4.4BSD-Lite2 sources as released by the University 
 - `bin/`, `sbin/`, `usr.bin/`, `usr.sbin/` – user and system utilities
 - `lib/`, `libexec/`, `games/`, `share/` – libraries, daemons, games and shared data
 - `sys/` – kernel sources
+- `src-kernel/` – microkernel stubs and low-level hooks
+- `src-uland/` – user-level libraries and servers replacing kernel subsystems
 - `etc/`, `dev/`, `root/` – system configuration, device files and root account files
 - `usr/` – userland programs and manual pages
 - `var/` – runtime data

--- a/src-kernel/AGENTS.md
+++ b/src-kernel/AGENTS.md
@@ -1,0 +1,4 @@
+# Microkernel Stubs
+
+Stub syscall hooks live here and delegate to user-space libraries.
+They compile into `libkern_stubs.a` using the local makefile.

--- a/src-kernel/Makefile
+++ b/src-kernel/Makefile
@@ -1,0 +1,17 @@
+OBJS = sched_hooks.o vm_hooks.o vfs_hooks.o
+LIB = libkern_stubs.a
+
+CC ?= cc
+AR ?= ar
+CFLAGS ?= -O2
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $(OBJS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(LIB)

--- a/src-kernel/sched_hooks.c
+++ b/src-kernel/sched_hooks.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+/* Stubs delegating to user-space scheduler */
+extern void uland_sched_init(void);
+void
+kern_sched_init(void)
+{
+    uland_sched_init();
+}

--- a/src-kernel/vfs_hooks.c
+++ b/src-kernel/vfs_hooks.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+/* Stubs delegating to user-space file server */
+extern int fs_open(const char *path, int flags);
+int
+kern_open(const char *path, int flags)
+{
+    return fs_open(path, flags);
+}

--- a/src-kernel/vm_hooks.c
+++ b/src-kernel/vm_hooks.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+/* Stubs delegating to user-space VM library */
+extern int uland_vm_fault(void *addr);
+int
+kern_vm_fault(void *addr)
+{
+    return uland_vm_fault(addr);
+}

--- a/src-uland/AGENTS.md
+++ b/src-uland/AGENTS.md
@@ -1,0 +1,5 @@
+# Userland Servers and Libraries
+
+This directory holds user-space replacements for kernel functionality.
+Files are copied from the historical `sys/` tree. Keep comments noting their origins.
+Use the provided makefiles to build `libkern_sched`, `libvm`, and the `fs_server` program.

--- a/src-uland/fs-server/Makefile
+++ b/src-uland/fs-server/Makefile
@@ -1,0 +1,13 @@
+SRCS = $(wildcard vfs_*.c)
+OBJS = $(SRCS:.c=.o)
+PROG = fs_server
+CC?=cc
+CFLAGS?=-O2
+
+all: $(PROG)
+
+	$(PROG): $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -o $@
+
+	clean:
+	rm -f $(OBJS) $(PROG)

--- a/src-uland/fs-server/vfs_bio.c
+++ b/src-uland/fs-server/vfs_bio.c
@@ -1,0 +1,340 @@
+/* Copied from sys/kern/vfs_bio.c */
+/*-
+ * Copyright (c) 1982, 1986, 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	from: @(#)vfs_bio.c	8.6 (Berkeley) 1/11/94
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/buf.h>
+#include <sys/vnode.h>
+#include <sys/mount.h>
+#include <sys/trace.h>
+#include <sys/malloc.h>
+#include <sys/resourcevar.h>
+
+/*
+ * Definitions for the buffer hash lists.
+ */
+#define	BUFHASH(dvp, lbn)	\
+	(&bufhashtbl[((int)(dvp) / sizeof(*(dvp)) + (int)(lbn)) & bufhash])
+LIST_HEAD(bufhashhdr, buf) *bufhashtbl, invalhash;
+u_long	bufhash;
+
+/*
+ * Insq/Remq for the buffer hash lists.
+ */
+#define	binshash(bp, dp)	LIST_INSERT_HEAD(dp, bp, b_hash)
+#define	bremhash(bp)		LIST_REMOVE(bp, b_hash)
+
+/*
+ * Definitions for the buffer free lists.
+ */
+#define	BQUEUES		4		/* number of free buffer queues */
+
+#define	BQ_LOCKED	0		/* super-blocks &c */
+#define	BQ_LRU		1		/* lru, useful buffers */
+#define	BQ_AGE		2		/* rubbish */
+#define	BQ_EMPTY	3		/* buffer headers with no memory */
+
+TAILQ_HEAD(bqueues, buf) bufqueues[BQUEUES];
+int needbuffer;
+
+/*
+ * Insq/Remq for the buffer free lists.
+ */
+#define	binsheadfree(bp, dp)	TAILQ_INSERT_HEAD(dp, bp, b_freelist)
+#define	binstailfree(bp, dp)	TAILQ_INSERT_TAIL(dp, bp, b_freelist)
+
+void
+bremfree(bp)
+	struct buf *bp;
+{
+	struct bqueues *dp = NULL;
+
+	/*
+	 * We only calculate the head of the freelist when removing
+	 * the last element of the list as that is the only time that
+	 * it is needed (e.g. to reset the tail pointer).
+	 *
+	 * NB: This makes an assumption about how tailq's are implemented.
+	 */
+	if (bp->b_freelist.tqe_next == NULL) {
+		for (dp = bufqueues; dp < &bufqueues[BQUEUES]; dp++)
+			if (dp->tqh_last == &bp->b_freelist.tqe_next)
+				break;
+		if (dp == &bufqueues[BQUEUES])
+			panic("bremfree: lost tail");
+	}
+	TAILQ_REMOVE(dp, bp, b_freelist);
+}
+
+/*
+ * Initialize buffers and hash links for buffers.
+ */
+void
+bufinit()
+{
+	register struct buf *bp;
+	struct bqueues *dp;
+	register int i;
+	int base, residual;
+
+	for (dp = bufqueues; dp < &bufqueues[BQUEUES]; dp++)
+		TAILQ_INIT(dp);
+	bufhashtbl = hashinit(nbuf, M_CACHE, &bufhash);
+	base = bufpages / nbuf;
+	residual = bufpages % nbuf;
+	for (i = 0; i < nbuf; i++) {
+		bp = &buf[i];
+		bzero((char *)bp, sizeof *bp);
+		bp->b_dev = NODEV;
+		bp->b_rcred = NOCRED;
+		bp->b_wcred = NOCRED;
+		bp->b_vnbufs.le_next = NOLIST;
+		bp->b_data = buffers + i * MAXBSIZE;
+		if (i < residual)
+			bp->b_bufsize = (base + 1) * CLBYTES;
+		else
+			bp->b_bufsize = base * CLBYTES;
+		bp->b_flags = B_INVAL;
+		dp = bp->b_bufsize ? &bufqueues[BQ_AGE] : &bufqueues[BQ_EMPTY];
+		binsheadfree(bp, dp);
+		binshash(bp, &invalhash);
+	}
+}
+
+bread(a1, a2, a3, a4, a5)
+	struct vnode *a1;
+	daddr_t a2;
+	int a3;
+	struct ucred *a4;
+	struct buf **a5;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return (EIO);
+}
+
+breadn(a1, a2, a3, a4, a5, a6, a7, a8)
+	struct vnode *a1;
+	daddr_t a2; int a3;
+	daddr_t a4[]; int a5[];
+	int a6;
+	struct ucred *a7;
+	struct buf **a8;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return (EIO);
+}
+
+bwrite(a1)
+	struct buf *a1;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return (EIO);
+}
+
+int
+vn_bwrite(ap)
+	struct vop_bwrite_args *ap;
+{
+	return (bwrite(ap->a_bp));
+}
+
+bdwrite(a1)
+	struct buf *a1;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return;
+}
+
+bawrite(a1)
+	struct buf *a1;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return;
+}
+
+brelse(a1)
+	struct buf *a1;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return;
+}
+
+struct buf *
+incore(a1, a2)
+	struct vnode *a1;
+	daddr_t a2;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return (0);
+}
+
+struct buf *
+getblk(a1, a2, a3, a4, a5)
+	struct vnode *a1;
+	daddr_t a2;
+	int a3, a4, a5;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return ((struct buf *)0);
+}
+
+struct buf *
+geteblk(a1)
+	int a1;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return ((struct buf *)0);
+}
+
+allocbuf(a1, a2)
+	struct buf *a1;
+	int a2;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return (0);
+}
+
+struct buf *
+getnewbuf(a1, a2)
+	int a1, a2;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return ((struct buf *)0);
+}
+
+biowait(a1)
+	struct buf *a1;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return (EIO);
+}
+
+void
+biodone(a1)
+	struct buf *a1;
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return;
+}
+
+int
+count_lock_queue()
+{
+
+	/*
+	 * Body deleted.
+	 */
+	return (0);
+}
+
+#ifdef DIAGNOSTIC
+/*
+ * Print out statistics on the current allocation of the buffer pool.
+ * Can be enabled to print out on every ``sync'' by setting "syncprt"
+ * in vfs_syscalls.c using sysctl.
+ */
+void
+vfs_bufstats()
+{
+	int s, i, j, count;
+	register struct buf *bp;
+	register struct bqueues *dp;
+	int counts[MAXBSIZE/CLBYTES+1];
+	static char *bname[BQUEUES] = { "LOCKED", "LRU", "AGE", "EMPTY" };
+
+	for (dp = bufqueues, i = 0; dp < &bufqueues[BQUEUES]; dp++, i++) {
+		count = 0;
+		for (j = 0; j <= MAXBSIZE/CLBYTES; j++)
+			counts[j] = 0;
+		s = splbio();
+		for (bp = dp->tqh_first; bp; bp = bp->b_freelist.tqe_next) {
+			counts[bp->b_bufsize/CLBYTES]++;
+			count++;
+		}
+		splx(s);
+		printf("%s: total-%d", bname[i], count);
+		for (j = 0; j <= MAXBSIZE/CLBYTES; j++)
+			if (counts[j] != 0)
+				printf(", %d-%d", j * CLBYTES, counts[j]);
+		printf("\n");
+	}
+}
+#endif /* DIAGNOSTIC */

--- a/src-uland/fs-server/vfs_cache.c
+++ b/src-uland/fs-server/vfs_cache.c
@@ -1,0 +1,321 @@
+/* Copied from sys/kern/vfs_cache.c */
+/*
+ * Copyright (c) 1989, 1993, 1995
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Poul-Henning Kamp of the FreeBSD Project.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * from: vfs_cache.c,v 1.11 1995/03/12 02:01:20 phk Exp $
+ *
+ *	@(#)vfs_cache.c	8.5 (Berkeley) 3/22/95
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/time.h>
+#include <sys/mount.h>
+#include <sys/vnode.h>
+#include <sys/namei.h>
+#include <sys/errno.h>
+#include <sys/malloc.h>
+
+/*
+ * Name caching works as follows:
+ *
+ * Names found by directory scans are retained in a cache
+ * for future reference.  It is managed LRU, so frequently
+ * used names will hang around.  Cache is indexed by hash value
+ * obtained from (vp, name) where vp refers to the directory
+ * containing name.
+ *
+ * If it is a "negative" entry, (i.e. for a name that is known NOT to
+ * exist) the vnode pointer will be NULL.
+ *
+ * For simplicity (and economy of storage), names longer than
+ * a maximum length of NCHNAMLEN are not cached; they occur
+ * infrequently in any case, and are almost never of interest.
+ *
+ * Upon reaching the last segment of a path, if the reference
+ * is for DELETE, or NOCACHE is set (rewrite), and the
+ * name is located in the cache, it will be dropped.
+ */
+
+/*
+ * Structures associated with name cacheing.
+ */
+#define NCHHASH(dvp, cnp) \
+	(&nchashtbl[((dvp)->v_id + (cnp)->cn_hash) & nchash])
+LIST_HEAD(nchashhead, namecache) *nchashtbl;	/* Hash Table */
+u_long	nchash;				/* size of hash table - 1 */
+long	numcache;			/* number of cache entries allocated */
+TAILQ_HEAD(, namecache) nclruhead;	/* LRU chain */
+struct	nchstats nchstats;		/* cache effectiveness statistics */
+
+int doingcache = 1;			/* 1 => enable the cache */
+
+/*
+ * Delete an entry from its hash list and move it to the front
+ * of the LRU list for immediate reuse.
+ */
+#define PURGE(ncp)  {						\
+	LIST_REMOVE(ncp, nc_hash);				\
+	ncp->nc_hash.le_prev = 0;				\
+	TAILQ_REMOVE(&nclruhead, ncp, nc_lru);			\
+	TAILQ_INSERT_HEAD(&nclruhead, ncp, nc_lru);		\
+}
+
+/*
+ * Move an entry that has been used to the tail of the LRU list
+ * so that it will be preserved for future use.
+ */
+#define TOUCH(ncp)  {						\
+	if (ncp->nc_lru.tqe_next != 0) {			\
+		TAILQ_REMOVE(&nclruhead, ncp, nc_lru);		\
+		TAILQ_INSERT_TAIL(&nclruhead, ncp, nc_lru);	\
+	}							\
+}
+
+/*
+ * Lookup an entry in the cache 
+ *
+ * We don't do this if the segment name is long, simply so the cache 
+ * can avoid holding long names (which would either waste space, or
+ * add greatly to the complexity).
+ *
+ * Lookup is called with dvp pointing to the directory to search,
+ * cnp pointing to the name of the entry being sought. If the lookup
+ * succeeds, the vnode is returned in *vpp, and a status of -1 is
+ * returned. If the lookup determines that the name does not exist
+ * (negative cacheing), a status of ENOENT is returned. If the lookup
+ * fails, a status of zero is returned.
+ */
+
+int
+cache_lookup(dvp, vpp, cnp)
+	struct vnode *dvp;
+	struct vnode **vpp;
+	struct componentname *cnp;
+{
+	register struct namecache *ncp, *nnp;
+	register struct nchashhead *ncpp;
+
+	if (!doingcache) {
+		cnp->cn_flags &= ~MAKEENTRY;
+		return (0);
+	}
+	if (cnp->cn_namelen > NCHNAMLEN) {
+		nchstats.ncs_long++;
+		cnp->cn_flags &= ~MAKEENTRY;
+		return (0);
+	}
+
+	ncpp = NCHHASH(dvp, cnp);
+	for (ncp = ncpp->lh_first; ncp != 0; ncp = nnp) {
+		nnp = ncp->nc_hash.le_next;
+		/* If one of the vp's went stale, don't bother anymore. */
+		if ((ncp->nc_dvpid != ncp->nc_dvp->v_id) ||
+		    (ncp->nc_vp && ncp->nc_vpid != ncp->nc_vp->v_id)) {
+			nchstats.ncs_falsehits++;
+			PURGE(ncp);
+			continue;
+		}
+		/* Now that we know the vp's to be valid, is it ours ? */
+		if (ncp->nc_dvp == dvp &&
+		    ncp->nc_nlen == cnp->cn_namelen &&
+		    !bcmp(ncp->nc_name, cnp->cn_nameptr, (u_int)ncp->nc_nlen))
+			break;
+	}
+
+	/* We failed to find an entry */
+	if (ncp == 0) {
+		nchstats.ncs_miss++;
+		return (0);
+	}
+
+	/* We don't want to have an entry, so dump it */
+	if ((cnp->cn_flags & MAKEENTRY) == 0) {
+		nchstats.ncs_badhits++;
+		PURGE(ncp);
+		return (0);
+	} 
+
+	/* We found a "positive" match, return the vnode */
+        if (ncp->nc_vp) {
+		nchstats.ncs_goodhits++;
+		TOUCH(ncp);
+		*vpp = ncp->nc_vp;
+		return (-1);
+	}
+
+	/* We found a negative match, and want to create it, so purge */
+	if (cnp->cn_nameiop == CREATE) {
+		nchstats.ncs_badhits++;
+		PURGE(ncp);
+		return (0);
+	}
+
+	/*
+	 * We found a "negative" match, ENOENT notifies client of this match.
+	 * The nc_vpid field records whether this is a whiteout.
+	 */
+	nchstats.ncs_neghits++;
+	TOUCH(ncp);
+	cnp->cn_flags |= ncp->nc_vpid;
+	return (ENOENT);
+}
+
+/*
+ * Add an entry to the cache.
+ */
+void
+cache_enter(dvp, vp, cnp)
+	struct vnode *dvp;
+	struct vnode *vp;
+	struct componentname *cnp;
+{
+	register struct namecache *ncp;
+	register struct nchashhead *ncpp;
+
+	if (!doingcache)
+		return;
+
+#ifdef DIAGNOSTIC
+	if (cnp->cn_namelen > NCHNAMLEN)
+		panic("cache_enter: name too long");
+#endif
+
+	/*
+	 * We allocate a new entry if we are less than the maximum
+	 * allowed and the one at the front of the LRU list is in use.
+	 * Otherwise we use the one at the front of the LRU list.
+	 */
+	if (numcache < desiredvnodes &&
+	    ((ncp = nclruhead.tqh_first) == NULL ||
+	    ncp->nc_hash.le_prev != 0)) {
+		/* Add one more entry */
+		ncp = (struct namecache *)
+			malloc((u_long)sizeof *ncp, M_CACHE, M_WAITOK);
+		bzero((char *)ncp, sizeof *ncp);
+		numcache++;
+	} else if (ncp = nclruhead.tqh_first) {
+		/* reuse an old entry */
+		TAILQ_REMOVE(&nclruhead, ncp, nc_lru);
+		if (ncp->nc_hash.le_prev != 0) {
+			LIST_REMOVE(ncp, nc_hash);
+			ncp->nc_hash.le_prev = 0;
+		}
+	} else {
+		/* give up */
+		return;
+	}
+
+	/*
+	 * Fill in cache info, if vp is NULL this is a "negative" cache entry.
+	 * For negative entries, we have to record whether it is a whiteout.
+	 * the whiteout flag is stored in the nc_vpid field which is
+	 * otherwise unused.
+	 */
+	ncp->nc_vp = vp;
+	if (vp)
+		ncp->nc_vpid = vp->v_id;
+	else
+		ncp->nc_vpid = cnp->cn_flags & ISWHITEOUT;
+	ncp->nc_dvp = dvp;
+	ncp->nc_dvpid = dvp->v_id;
+	ncp->nc_nlen = cnp->cn_namelen;
+	bcopy(cnp->cn_nameptr, ncp->nc_name, (unsigned)ncp->nc_nlen);
+	TAILQ_INSERT_TAIL(&nclruhead, ncp, nc_lru);
+	ncpp = NCHHASH(dvp, cnp);
+	LIST_INSERT_HEAD(ncpp, ncp, nc_hash);
+}
+
+/*
+ * Name cache initialization, from vfs_init() when we are booting
+ */
+void
+nchinit()
+{
+
+	TAILQ_INIT(&nclruhead);
+	nchashtbl = hashinit(desiredvnodes, M_CACHE, &nchash);
+}
+
+/*
+ * Invalidate a all entries to particular vnode.
+ * 
+ * We actually just increment the v_id, that will do it. The entries will
+ * be purged by lookup as they get found. If the v_id wraps around, we
+ * need to ditch the entire cache, to avoid confusion. No valid vnode will
+ * ever have (v_id == 0).
+ */
+void
+cache_purge(vp)
+	struct vnode *vp;
+{
+	struct namecache *ncp;
+	struct nchashhead *ncpp;
+
+	vp->v_id = ++nextvnodeid;
+	if (nextvnodeid != 0)
+		return;
+	for (ncpp = &nchashtbl[nchash]; ncpp >= nchashtbl; ncpp--) {
+		while (ncp = ncpp->lh_first)
+			PURGE(ncp);
+	}
+	vp->v_id = ++nextvnodeid;
+}
+
+/*
+ * Flush all entries referencing a particular filesystem.
+ *
+ * Since we need to check it anyway, we will flush all the invalid
+ * entriess at the same time.
+ */
+void
+cache_purgevfs(mp)
+	struct mount *mp;
+{
+	struct nchashhead *ncpp;
+	struct namecache *ncp, *nnp;
+
+	/* Scan hash tables for applicable entries */
+	for (ncpp = &nchashtbl[nchash]; ncpp >= nchashtbl; ncpp--) {
+		for (ncp = ncpp->lh_first; ncp != 0; ncp = nnp) {
+			nnp = ncp->nc_hash.le_next;
+			if (ncp->nc_dvpid != ncp->nc_dvp->v_id ||
+			    (ncp->nc_vp && ncp->nc_vpid != ncp->nc_vp->v_id) ||
+			    ncp->nc_dvp->v_mount == mp) {
+				PURGE(ncp);
+			}
+		}
+	}
+}

--- a/src-uland/fs-server/vfs_cluster.c
+++ b/src-uland/fs-server/vfs_cluster.c
@@ -1,0 +1,757 @@
+/* Copied from sys/kern/vfs_cluster.c */
+/*-
+ * Copyright (c) 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vfs_cluster.c	8.10 (Berkeley) 3/28/95
+ */
+
+#include <sys/param.h>
+#include <sys/proc.h>
+#include <sys/buf.h>
+#include <sys/vnode.h>
+#include <sys/mount.h>
+#include <sys/trace.h>
+#include <sys/malloc.h>
+#include <sys/resourcevar.h>
+#include <libkern/libkern.h>
+
+/*
+ * Local declarations
+ */
+struct buf *cluster_newbuf __P((struct vnode *, struct buf *, long, daddr_t,
+	    daddr_t, long, int));
+struct buf *cluster_rbuild __P((struct vnode *, u_quad_t, struct buf *,
+	    daddr_t, daddr_t, long, int, long));
+void	    cluster_wbuild __P((struct vnode *, struct buf *, long,
+	    daddr_t, int, daddr_t));
+struct cluster_save *cluster_collectbufs __P((struct vnode *, struct buf *));
+
+#ifdef DIAGNOSTIC
+/*
+ * Set to 1 if reads of block zero should cause readahead to be done.
+ * Set to 0 treats a read of block zero as a non-sequential read.
+ *
+ * Setting to one assumes that most reads of block zero of files are due to
+ * sequential passes over the files (e.g. cat, sum) where additional blocks
+ * will soon be needed.  Setting to zero assumes that the majority are
+ * surgical strikes to get particular info (e.g. size, file) where readahead
+ * blocks will not be used and, in fact, push out other potentially useful
+ * blocks from the cache.  The former seems intuitive, but some quick tests
+ * showed that the latter performed better from a system-wide point of view.
+ */
+int	doclusterraz = 0;
+#define ISSEQREAD(vp, blk) \
+	(((blk) != 0 || doclusterraz) && \
+	 ((blk) == (vp)->v_lastr + 1 || (blk) == (vp)->v_lastr))
+#else
+#define ISSEQREAD(vp, blk) \
+	((blk) != 0 && ((blk) == (vp)->v_lastr + 1 || (blk) == (vp)->v_lastr))
+#endif
+
+/*
+ * This replaces bread.  If this is a bread at the beginning of a file and
+ * lastr is 0, we assume this is the first read and we'll read up to two
+ * blocks if they are sequential.  After that, we'll do regular read ahead
+ * in clustered chunks.
+ *
+ * There are 4 or 5 cases depending on how you count:
+ *	Desired block is in the cache:
+ *	    1 Not sequential access (0 I/Os).
+ *	    2 Access is sequential, do read-ahead (1 ASYNC).
+ *	Desired block is not in cache:
+ *	    3 Not sequential access (1 SYNC).
+ *	    4 Sequential access, next block is contiguous (1 SYNC).
+ *	    5 Sequential access, next block is not contiguous (1 SYNC, 1 ASYNC)
+ *
+ * There are potentially two buffers that require I/O.
+ * 	bp is the block requested.
+ *	rbp is the read-ahead block.
+ *	If either is NULL, then you don't have to do the I/O.
+ */
+cluster_read(vp, filesize, lblkno, size, cred, bpp)
+	struct vnode *vp;
+	u_quad_t filesize;
+	daddr_t lblkno;
+	long size;
+	struct ucred *cred;
+	struct buf **bpp;
+{
+	struct buf *bp, *rbp;
+	daddr_t blkno, ioblkno;
+	long flags;
+	int error, num_ra, alreadyincore;
+
+#ifdef DIAGNOSTIC
+	if (size == 0)
+		panic("cluster_read: size = 0");
+#endif
+
+	error = 0;
+	flags = B_READ;
+	*bpp = bp = getblk(vp, lblkno, size, 0, 0);
+	if (bp->b_flags & B_CACHE) {
+		/*
+		 * Desired block is in cache; do any readahead ASYNC.
+		 * Case 1, 2.
+		 */
+		trace(TR_BREADHIT, pack(vp, size), lblkno);
+		flags |= B_ASYNC;
+		ioblkno = lblkno + (vp->v_ralen ? vp->v_ralen : 1);
+		alreadyincore = incore(vp, ioblkno) != NULL;
+		bp = NULL;
+	} else {
+		/* Block wasn't in cache, case 3, 4, 5. */
+		trace(TR_BREADMISS, pack(vp, size), lblkno);
+		bp->b_flags |= B_READ;
+		ioblkno = lblkno;
+		alreadyincore = 0;
+		curproc->p_stats->p_ru.ru_inblock++;		/* XXX */
+	}
+	/*
+	 * XXX
+	 * Replace 1 with a window size based on some permutation of
+	 * maxcontig and rot_delay.  This will let you figure out how
+	 * many blocks you should read-ahead (case 2, 4, 5).
+	 *
+	 * If the access isn't sequential, reset the window to 1.
+	 * Note that a read to the same block is considered sequential.
+	 * This catches the case where the file is being read sequentially,
+	 * but at smaller than the filesystem block size.
+	 */
+	rbp = NULL;
+	if (!ISSEQREAD(vp, lblkno)) {
+		vp->v_ralen = 0;
+		vp->v_maxra = lblkno;
+	} else if ((ioblkno + 1) * size <= filesize && !alreadyincore &&
+	    !(error = VOP_BMAP(vp, ioblkno, NULL, &blkno, &num_ra)) &&
+	    blkno != -1) {
+		/*
+		 * Reading sequentially, and the next block is not in the
+		 * cache.  We are going to try reading ahead.
+		 */
+		if (num_ra) {
+			/*
+			 * If our desired readahead block had been read
+			 * in a previous readahead but is no longer in
+			 * core, then we may be reading ahead too far
+			 * or are not using our readahead very rapidly.
+			 * In this case we scale back the window.
+			 */
+			if (!alreadyincore && ioblkno <= vp->v_maxra)
+				vp->v_ralen = max(vp->v_ralen >> 1, 1);
+			/*
+			 * There are more sequential blocks than our current
+			 * window allows, scale up.  Ideally we want to get
+			 * in sync with the filesystem maxcontig value.
+			 */
+			else if (num_ra > vp->v_ralen && lblkno != vp->v_lastr)
+				vp->v_ralen = vp->v_ralen ?
+					min(num_ra, vp->v_ralen << 1) : 1;
+
+			if (num_ra > vp->v_ralen)
+				num_ra = vp->v_ralen;
+		}
+
+		if (num_ra)				/* case 2, 4 */
+			rbp = cluster_rbuild(vp, filesize,
+			    bp, ioblkno, blkno, size, num_ra, flags);
+		else if (ioblkno == lblkno) {
+			bp->b_blkno = blkno;
+			/* Case 5: check how many blocks to read ahead */
+			++ioblkno;
+			if ((ioblkno + 1) * size > filesize ||
+			    incore(vp, ioblkno) || (error = VOP_BMAP(vp,
+			     ioblkno, NULL, &blkno, &num_ra)) || blkno == -1)
+				goto skip_readahead;
+			/*
+			 * Adjust readahead as above.
+			 * Don't check alreadyincore, we know it is 0 from
+			 * the previous conditional.
+			 */
+			if (num_ra) {
+				if (ioblkno <= vp->v_maxra)
+					vp->v_ralen = max(vp->v_ralen >> 1, 1);
+				else if (num_ra > vp->v_ralen &&
+					 lblkno != vp->v_lastr)
+					vp->v_ralen = vp->v_ralen ?
+						min(num_ra,vp->v_ralen<<1) : 1;
+				if (num_ra > vp->v_ralen)
+					num_ra = vp->v_ralen;
+			}
+			flags |= B_ASYNC;
+			if (num_ra)
+				rbp = cluster_rbuild(vp, filesize,
+				    NULL, ioblkno, blkno, size, num_ra, flags);
+			else {
+				rbp = getblk(vp, ioblkno, size, 0, 0);
+				rbp->b_flags |= flags;
+				rbp->b_blkno = blkno;
+			}
+		} else {
+			/* case 2; read ahead single block */
+			rbp = getblk(vp, ioblkno, size, 0, 0);
+			rbp->b_flags |= flags;
+			rbp->b_blkno = blkno;
+		}
+
+		if (rbp == bp)			/* case 4 */
+			rbp = NULL;
+		else if (rbp) {			/* case 2, 5 */
+			trace(TR_BREADMISSRA,
+			    pack(vp, (num_ra + 1) * size), ioblkno);
+			curproc->p_stats->p_ru.ru_inblock++;	/* XXX */
+		}
+	}
+
+	/* XXX Kirk, do we need to make sure the bp has creds? */
+skip_readahead:
+	if (bp)
+		if (bp->b_flags & (B_DONE | B_DELWRI))
+			panic("cluster_read: DONE bp");
+		else 
+			error = VOP_STRATEGY(bp);
+
+	if (rbp)
+		if (error || rbp->b_flags & (B_DONE | B_DELWRI)) {
+			rbp->b_flags &= ~(B_ASYNC | B_READ);
+			brelse(rbp);
+		} else
+			(void) VOP_STRATEGY(rbp);
+
+	/*
+	 * Recalculate our maximum readahead
+	 */
+	if (rbp == NULL)
+		rbp = bp;
+	if (rbp)
+		vp->v_maxra = rbp->b_lblkno + (rbp->b_bufsize / size) - 1;
+
+	if (bp)
+		return(biowait(bp));
+	return(error);
+}
+
+/*
+ * If blocks are contiguous on disk, use this to provide clustered
+ * read ahead.  We will read as many blocks as possible sequentially
+ * and then parcel them up into logical blocks in the buffer hash table.
+ */
+struct buf *
+cluster_rbuild(vp, filesize, bp, lbn, blkno, size, run, flags)
+	struct vnode *vp;
+	u_quad_t filesize;
+	struct buf *bp;
+	daddr_t lbn;
+	daddr_t blkno;
+	long size;
+	int run;
+	long flags;
+{
+	struct cluster_save *b_save;
+	struct buf *tbp;
+	daddr_t bn;
+	int i, inc;
+
+#ifdef DIAGNOSTIC
+	if (size != vp->v_mount->mnt_stat.f_iosize)
+		panic("cluster_rbuild: size %d != filesize %d\n",
+			size, vp->v_mount->mnt_stat.f_iosize);
+#endif
+	if (size * (lbn + run + 1) > filesize)
+		--run;
+	if (run == 0) {
+		if (!bp) {
+			bp = getblk(vp, lbn, size, 0, 0);
+			bp->b_blkno = blkno;
+			bp->b_flags |= flags;
+		}
+		return(bp);
+	}
+
+	bp = cluster_newbuf(vp, bp, flags, blkno, lbn, size, run + 1);
+	if (bp->b_flags & (B_DONE | B_DELWRI))
+		return (bp);
+
+	b_save = malloc(sizeof(struct buf *) * run + sizeof(struct cluster_save),
+	    M_SEGMENT, M_WAITOK);
+	b_save->bs_bufsize = b_save->bs_bcount = size;
+	b_save->bs_nchildren = 0;
+	b_save->bs_children = (struct buf **)(b_save + 1);
+	b_save->bs_saveaddr = bp->b_saveaddr;
+	bp->b_saveaddr = (caddr_t) b_save;
+
+	inc = btodb(size);
+	for (bn = blkno + inc, i = 1; i <= run; ++i, bn += inc) {
+		/*
+		 * A component of the cluster is already in core,
+		 * terminate the cluster early.
+		 */
+		if (incore(vp, lbn + i))
+			break;
+		tbp = getblk(vp, lbn + i, 0, 0, 0);
+		/*
+		 * getblk may return some memory in the buffer if there were
+		 * no empty buffers to shed it to.  If there is currently
+		 * memory in the buffer, we move it down size bytes to make
+		 * room for the valid pages that cluster_callback will insert.
+		 * We do this now so we don't have to do it at interrupt time
+		 * in the callback routine.
+		 */
+		if (tbp->b_bufsize != 0) {
+			caddr_t bdata = (char *)tbp->b_data;
+
+			/*
+			 * No room in the buffer to add another page,
+			 * terminate the cluster early.
+			 */
+			if (tbp->b_bufsize + size > MAXBSIZE) {
+#ifdef DIAGNOSTIC
+				if (tbp->b_bufsize != MAXBSIZE)
+					panic("cluster_rbuild: too much memory");
+#endif
+				brelse(tbp);
+				break;
+			}
+			if (tbp->b_bufsize > size) {
+				/*
+				 * XXX if the source and destination regions
+				 * overlap we have to copy backward to avoid
+				 * clobbering any valid pages (i.e. pagemove
+				 * implementations typically can't handle
+				 * overlap).
+				 */
+				bdata += tbp->b_bufsize;
+				while (bdata > (char *)tbp->b_data) {
+					bdata -= CLBYTES;
+					pagemove(bdata, bdata + size, CLBYTES);
+				}
+			} else 
+				pagemove(bdata, bdata + size, tbp->b_bufsize);
+		}
+		tbp->b_blkno = bn;
+		tbp->b_flags |= flags | B_READ | B_ASYNC;
+		++b_save->bs_nchildren;
+		b_save->bs_children[i - 1] = tbp;
+	}
+	/*
+	 * The cluster may have been terminated early, adjust the cluster
+	 * buffer size accordingly.  If no cluster could be formed,
+	 * deallocate the cluster save info.
+	 */
+	if (i <= run) {
+		if (i == 1) {
+			bp->b_saveaddr = b_save->bs_saveaddr;
+			bp->b_flags &= ~B_CALL;
+			bp->b_iodone = NULL;
+			free(b_save, M_SEGMENT);
+		}
+		allocbuf(bp, size * i);
+	}
+	return(bp);
+}
+
+/*
+ * Either get a new buffer or grow the existing one.
+ */
+struct buf *
+cluster_newbuf(vp, bp, flags, blkno, lblkno, size, run)
+	struct vnode *vp;
+	struct buf *bp;
+	long flags;
+	daddr_t blkno;
+	daddr_t lblkno;
+	long size;
+	int run;
+{
+	if (!bp) {
+		bp = getblk(vp, lblkno, size, 0, 0);
+		if (bp->b_flags & (B_DONE | B_DELWRI)) {
+			bp->b_blkno = blkno;
+			return(bp);
+		}
+	}
+	allocbuf(bp, run * size);
+	bp->b_blkno = blkno;
+	bp->b_iodone = cluster_callback;
+	bp->b_flags |= flags | B_CALL;
+	return(bp);
+}
+
+/*
+ * Cleanup after a clustered read or write.
+ * This is complicated by the fact that any of the buffers might have
+ * extra memory (if there were no empty buffer headers at allocbuf time)
+ * that we will need to shift around.
+ */
+void
+cluster_callback(bp)
+	struct buf *bp;
+{
+	struct cluster_save *b_save;
+	struct buf **bpp, *tbp;
+	long bsize;
+	caddr_t cp;
+	int error = 0;
+
+	/*
+	 * Must propogate errors to all the components.
+	 */
+	if (bp->b_flags & B_ERROR)
+		error = bp->b_error;
+
+	b_save = (struct cluster_save *)(bp->b_saveaddr);
+	bp->b_saveaddr = b_save->bs_saveaddr;
+
+	bsize = b_save->bs_bufsize;
+	cp = (char *)bp->b_data + bsize;
+	/*
+	 * Move memory from the large cluster buffer into the component
+	 * buffers and mark IO as done on these.
+	 */
+	for (bpp = b_save->bs_children; b_save->bs_nchildren--; ++bpp) {
+		tbp = *bpp;
+		pagemove(cp, tbp->b_data, bsize);
+		tbp->b_bufsize += bsize;
+		tbp->b_bcount = bsize;
+		if (error) {
+			tbp->b_flags |= B_ERROR;
+			tbp->b_error = error;
+		}
+		biodone(tbp);
+		bp->b_bufsize -= bsize;
+		cp += bsize;
+	}
+	/*
+	 * If there was excess memory in the cluster buffer,
+	 * slide it up adjacent to the remaining valid data.
+	 */
+	if (bp->b_bufsize != bsize) {
+		if (bp->b_bufsize < bsize)
+			panic("cluster_callback: too little memory");
+		pagemove(cp, (char *)bp->b_data + bsize, bp->b_bufsize - bsize);
+	}
+	bp->b_bcount = bsize;
+	bp->b_iodone = NULL;
+	free(b_save, M_SEGMENT);
+	if (bp->b_flags & B_ASYNC)
+		brelse(bp);
+	else {
+		bp->b_flags &= ~B_WANTED;
+		wakeup((caddr_t)bp);
+	}
+}
+
+/*
+ * Do clustered write for FFS.
+ *
+ * Three cases:
+ *	1. Write is not sequential (write asynchronously)
+ *	Write is sequential:
+ *	2.	beginning of cluster - begin cluster
+ *	3.	middle of a cluster - add to cluster
+ *	4.	end of a cluster - asynchronously write cluster
+ */
+void
+cluster_write(bp, filesize)
+        struct buf *bp;
+	u_quad_t filesize;
+{
+        struct vnode *vp;
+        daddr_t lbn;
+        int maxclen, cursize;
+
+        vp = bp->b_vp;
+        lbn = bp->b_lblkno;
+
+	/* Initialize vnode to beginning of file. */
+	if (lbn == 0)
+		vp->v_lasta = vp->v_clen = vp->v_cstart = vp->v_lastw = 0;
+
+        if (vp->v_clen == 0 || lbn != vp->v_lastw + 1 ||
+	    (bp->b_blkno != vp->v_lasta + btodb(bp->b_bcount))) {
+		maxclen = MAXBSIZE / vp->v_mount->mnt_stat.f_iosize - 1;
+		if (vp->v_clen != 0) {
+			/*
+			 * Next block is not sequential.
+			 *
+			 * If we are not writing at end of file, the process
+			 * seeked to another point in the file since its
+			 * last write, or we have reached our maximum
+			 * cluster size, then push the previous cluster.
+			 * Otherwise try reallocating to make it sequential.
+			 */
+			cursize = vp->v_lastw - vp->v_cstart + 1;
+			if ((lbn + 1) * bp->b_bcount != filesize ||
+			    lbn != vp->v_lastw + 1 || vp->v_clen <= cursize) {
+				cluster_wbuild(vp, NULL, bp->b_bcount,
+				    vp->v_cstart, cursize, lbn);
+			} else {
+				struct buf **bpp, **endbp;
+				struct cluster_save *buflist;
+
+				buflist = cluster_collectbufs(vp, bp);
+				endbp = &buflist->bs_children
+				    [buflist->bs_nchildren - 1];
+				if (VOP_REALLOCBLKS(vp, buflist)) {
+					/*
+					 * Failed, push the previous cluster.
+					 */
+					for (bpp = buflist->bs_children;
+					     bpp < endbp; bpp++)
+						brelse(*bpp);
+					free(buflist, M_SEGMENT);
+					cluster_wbuild(vp, NULL, bp->b_bcount,
+					    vp->v_cstart, cursize, lbn);
+				} else {
+					/*
+					 * Succeeded, keep building cluster.
+					 */
+					for (bpp = buflist->bs_children;
+					     bpp <= endbp; bpp++)
+						bdwrite(*bpp);
+					free(buflist, M_SEGMENT);
+					vp->v_lastw = lbn;
+					vp->v_lasta = bp->b_blkno;
+					return;
+				}
+			}
+		}
+		/*
+		 * Consider beginning a cluster.
+		 * If at end of file, make cluster as large as possible,
+		 * otherwise find size of existing cluster.
+		 */
+		if ((lbn + 1) * bp->b_bcount != filesize &&
+		    (VOP_BMAP(vp, lbn, NULL, &bp->b_blkno, &maxclen) ||
+		     bp->b_blkno == -1)) {
+			bawrite(bp);
+			vp->v_clen = 0;
+			vp->v_lasta = bp->b_blkno;
+			vp->v_cstart = lbn + 1;
+			vp->v_lastw = lbn;
+			return;
+		}
+                vp->v_clen = maxclen;
+                if (maxclen == 0) {		/* I/O not contiguous */
+			vp->v_cstart = lbn + 1;
+                        bawrite(bp);
+                } else {			/* Wait for rest of cluster */
+			vp->v_cstart = lbn;
+                        bdwrite(bp);
+		}
+	} else if (lbn == vp->v_cstart + vp->v_clen) {
+		/*
+		 * At end of cluster, write it out.
+		 */
+		cluster_wbuild(vp, bp, bp->b_bcount, vp->v_cstart,
+		    vp->v_clen + 1, lbn);
+		vp->v_clen = 0;
+		vp->v_cstart = lbn + 1;
+	} else
+		/*
+		 * In the middle of a cluster, so just delay the
+		 * I/O for now.
+		 */
+		bdwrite(bp);
+	vp->v_lastw = lbn;
+	vp->v_lasta = bp->b_blkno;
+}
+
+
+/*
+ * This is an awful lot like cluster_rbuild...wish they could be combined.
+ * The last lbn argument is the current block on which I/O is being
+ * performed.  Check to see that it doesn't fall in the middle of
+ * the current block (if last_bp == NULL).
+ */
+void
+cluster_wbuild(vp, last_bp, size, start_lbn, len, lbn)
+	struct vnode *vp;
+	struct buf *last_bp;
+	long size;
+	daddr_t start_lbn;
+	int len;
+	daddr_t	lbn;
+{
+	struct cluster_save *b_save;
+	struct buf *bp, *tbp;
+	caddr_t	cp;
+	int i, s;
+
+#ifdef DIAGNOSTIC
+	if (size != vp->v_mount->mnt_stat.f_iosize)
+		panic("cluster_wbuild: size %d != filesize %d\n",
+			size, vp->v_mount->mnt_stat.f_iosize);
+#endif
+redo:
+	while ((!incore(vp, start_lbn) || start_lbn == lbn) && len) {
+		++start_lbn;
+		--len;
+	}
+
+	/* Get more memory for current buffer */
+	if (len <= 1) {
+		if (last_bp) {
+			bawrite(last_bp);
+		} else if (len) {
+			bp = getblk(vp, start_lbn, size, 0, 0);
+			bawrite(bp);
+		}
+		return;
+	}
+
+	bp = getblk(vp, start_lbn, size, 0, 0);
+	if (!(bp->b_flags & B_DELWRI)) {
+		++start_lbn;
+		--len;
+		brelse(bp);
+		goto redo;
+	}
+
+	/*
+	 * Extra memory in the buffer, punt on this buffer.
+	 * XXX we could handle this in most cases, but we would have to
+	 * push the extra memory down to after our max possible cluster
+	 * size and then potentially pull it back up if the cluster was
+	 * terminated prematurely--too much hassle.
+	 */
+	if (bp->b_bcount != bp->b_bufsize) {
+		++start_lbn;
+		--len;
+		bawrite(bp);
+		goto redo;
+	}
+
+	--len;
+	b_save = malloc(sizeof(struct buf *) * len + sizeof(struct cluster_save),
+	    M_SEGMENT, M_WAITOK);
+	b_save->bs_bcount = bp->b_bcount;
+	b_save->bs_bufsize = bp->b_bufsize;
+	b_save->bs_nchildren = 0;
+	b_save->bs_children = (struct buf **)(b_save + 1);
+	b_save->bs_saveaddr = bp->b_saveaddr;
+	bp->b_saveaddr = (caddr_t) b_save;
+
+	bp->b_flags |= B_CALL;
+	bp->b_iodone = cluster_callback;
+	cp = (char *)bp->b_data + size;
+	for (++start_lbn, i = 0; i < len; ++i, ++start_lbn) {
+		/*
+		 * Block is not in core or the non-sequential block
+		 * ending our cluster was part of the cluster (in which
+		 * case we don't want to write it twice).
+		 */
+		if (!incore(vp, start_lbn) ||
+		    last_bp == NULL && start_lbn == lbn)
+			break;
+
+		/*
+		 * Get the desired block buffer (unless it is the final
+		 * sequential block whose buffer was passed in explictly
+		 * as last_bp).
+		 */
+		if (last_bp == NULL || start_lbn != lbn) {
+			tbp = getblk(vp, start_lbn, size, 0, 0);
+			if (!(tbp->b_flags & B_DELWRI)) {
+				brelse(tbp);
+				break;
+			}
+		} else
+			tbp = last_bp;
+
+		++b_save->bs_nchildren;
+
+		/* Move memory from children to parent */
+		if (tbp->b_blkno != (bp->b_blkno + btodb(bp->b_bufsize))) {
+			printf("Clustered Block: %d addr %x bufsize: %d\n",
+			    bp->b_lblkno, bp->b_blkno, bp->b_bufsize);
+			printf("Child Block: %d addr: %x\n", tbp->b_lblkno,
+			    tbp->b_blkno);
+			panic("Clustered write to wrong blocks");
+		}
+
+		pagemove(tbp->b_data, cp, size);
+		bp->b_bcount += size;
+		bp->b_bufsize += size;
+
+		tbp->b_bufsize -= size;
+		tbp->b_flags &= ~(B_READ | B_DONE | B_ERROR | B_DELWRI);
+		tbp->b_flags |= (B_ASYNC | B_AGE);
+		s = splbio();
+		reassignbuf(tbp, tbp->b_vp);		/* put on clean list */
+		++tbp->b_vp->v_numoutput;
+		splx(s);
+		b_save->bs_children[i] = tbp;
+
+		cp += size;
+	}
+
+	if (i == 0) {
+		/* None to cluster */
+		bp->b_saveaddr = b_save->bs_saveaddr;
+		bp->b_flags &= ~B_CALL;
+		bp->b_iodone = NULL;
+		free(b_save, M_SEGMENT);
+	}
+	bawrite(bp);
+	if (i < len) {
+		len -= i + 1;
+		start_lbn += 1;
+		goto redo;
+	}
+}
+
+/*
+ * Collect together all the buffers in a cluster.
+ * Plus add one additional buffer.
+ */
+struct cluster_save *
+cluster_collectbufs(vp, last_bp)
+	struct vnode *vp;
+	struct buf *last_bp;
+{
+	struct cluster_save *buflist;
+	daddr_t	lbn;
+	int i, len;
+
+	len = vp->v_lastw - vp->v_cstart + 1;
+	buflist = malloc(sizeof(struct buf *) * (len + 1) + sizeof(*buflist),
+	    M_SEGMENT, M_WAITOK);
+	buflist->bs_nchildren = 0;
+	buflist->bs_children = (struct buf **)(buflist + 1);
+	for (lbn = vp->v_cstart, i = 0; i < len; lbn++, i++)
+		    (void)bread(vp, lbn, last_bp->b_bcount, NOCRED,
+			&buflist->bs_children[i]);
+	buflist->bs_children[i] = last_bp;
+	buflist->bs_nchildren = i + 1;
+	return (buflist);
+}

--- a/src-uland/fs-server/vfs_conf.c
+++ b/src-uland/fs-server/vfs_conf.c
@@ -1,0 +1,249 @@
+/* Copied from sys/kern/vfs_conf.c */
+/*
+ * Copyright (c) 1989, 1993, 1995
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vfs_conf.c	8.11 (Berkeley) 5/10/95
+ */
+
+#include <sys/param.h>
+#include <sys/mount.h>
+#include <sys/vnode.h>
+
+/*
+ * These define the root filesystem, device, and root filesystem type.
+ */
+struct mount *rootfs;
+struct vnode *rootvnode;
+int (*mountroot)() = NULL;
+
+/*
+ * Set up the initial array of known filesystem types.
+ */
+extern	struct vfsops ufs_vfsops;
+extern	int ffs_mountroot();
+extern	struct vfsops lfs_vfsops;
+extern	int lfs_mountroot();
+extern	struct vfsops mfs_vfsops;
+extern	int mfs_mountroot();
+extern	struct vfsops cd9660_vfsops;
+extern	int cd9660_mountroot();
+extern	struct vfsops msdos_vfsops;
+extern	struct vfsops adosfs_vfsops;
+extern	struct vfsops nfs_vfsops;
+extern	int nfs_mountroot();
+extern	struct vfsops afs_vfsops;
+extern	struct vfsops procfs_vfsops;
+extern	struct vfsops null_vfsops;
+extern	struct vfsops union_vfsops;
+extern	struct vfsops umap_vfsops;
+extern	struct vfsops portal_vfsops;
+extern	struct vfsops fdesc_vfsops;
+extern	struct vfsops kernfs_vfsops;
+
+/*
+ * Set up the filesystem operations for vnodes.
+ */
+static struct vfsconf vfsconflist[] = {
+
+	/* Fast Filesystem */
+#ifdef FFS
+	{ &ufs_vfsops, "ufs", 1, 0, MNT_LOCAL, ffs_mountroot, NULL },
+#endif
+
+	/* Log-based Filesystem */
+#ifdef LFS
+	{ &lfs_vfsops, "lfs", 5, 0, MNT_LOCAL, lfs_mountroot, NULL },
+#endif
+
+	/* Memory-based Filesystem */
+#ifdef MFS
+	{ &mfs_vfsops, "mfs", 3, 0, MNT_LOCAL, mfs_mountroot, NULL },
+#endif
+
+	/* ISO9660 (aka CDROM) Filesystem */
+#ifdef CD9660
+	{ &cd9660_vfsops, "cd9660", 14, 0, MNT_LOCAL, cd9660_mountroot, NULL },
+#endif
+
+	/* MSDOS Filesystem */
+#ifdef MSDOS
+	{ &msdos_vfsops, "msdos", 4, 0, MNT_LOCAL, NULL, NULL },
+#endif
+
+	/* AmigaDOS Filesystem */
+#ifdef ADOSFS
+	{ &adosfs_vfsops, "adosfs", 16, 0, MNT_LOCAL, NULL, NULL },
+#endif
+
+	/* Sun-compatible Network Filesystem */
+#ifdef NFS
+	{ &nfs_vfsops, "nfs", 2, 0, 0, nfs_mountroot, NULL },
+#endif
+
+	/* Andrew Filesystem */
+#ifdef AFS
+	{ &afs_vfsops, "andrewfs", 13, 0, 0, afs_mountroot, NULL },
+#endif
+
+	/* /proc Filesystem */
+#ifdef PROCFS
+	{ &procfs_vfsops, "procfs", 12, 0, 0, NULL, NULL },
+#endif
+
+	/* Loopback (Minimal) Filesystem Layer */
+#ifdef NULLFS
+	{ &null_vfsops, "loopback", 9, 0, 0, NULL, NULL },
+#endif
+
+	/* Union (translucent) Filesystem */
+#ifdef UNION
+	{ &union_vfsops, "union", 15, 0, 0, NULL, NULL },
+#endif
+
+	/* User/Group Identifer Remapping Filesystem */
+#ifdef UMAPFS
+	{ &umap_vfsops, "umap", 10, 0, 0, NULL, NULL },
+#endif
+
+	/* Portal Filesystem */
+#ifdef PORTAL
+	{ &portal_vfsops, "portal", 8, 0, 0, NULL, NULL },
+#endif
+
+	/* File Descriptor Filesystem */
+#ifdef FDESC
+	{ &fdesc_vfsops, "fdesc", 7, 0, 0, NULL, NULL },
+#endif
+
+	/* Kernel Information Filesystem */
+#ifdef KERNFS
+	{ &kernfs_vfsops, "kernfs", 11, 0, 0, NULL, NULL },
+#endif
+
+};
+
+/*
+ * Initially the size of the list, vfs_init will set maxvfsconf
+ * to the highest defined type number.
+ */
+int maxvfsconf = sizeof(vfsconflist) / sizeof (struct vfsconf);
+struct vfsconf *vfsconf = vfsconflist;
+
+/*
+ *
+ * vfs_opv_descs enumerates the list of vnode classes, each with it's own
+ * vnode operation vector.  It is consulted at system boot to build operation
+ * vectors.  It is NULL terminated.
+ *
+ */
+extern struct vnodeopv_desc ffs_vnodeop_opv_desc;
+extern struct vnodeopv_desc ffs_specop_opv_desc;
+extern struct vnodeopv_desc ffs_fifoop_opv_desc;
+extern struct vnodeopv_desc lfs_vnodeop_opv_desc;
+extern struct vnodeopv_desc lfs_specop_opv_desc;
+extern struct vnodeopv_desc lfs_fifoop_opv_desc;
+extern struct vnodeopv_desc mfs_vnodeop_opv_desc;
+extern struct vnodeopv_desc dead_vnodeop_opv_desc;
+extern struct vnodeopv_desc fifo_vnodeop_opv_desc;
+extern struct vnodeopv_desc spec_vnodeop_opv_desc;
+extern struct vnodeopv_desc nfsv2_vnodeop_opv_desc;
+extern struct vnodeopv_desc spec_nfsv2nodeop_opv_desc;
+extern struct vnodeopv_desc fifo_nfsv2nodeop_opv_desc;
+extern struct vnodeopv_desc fdesc_vnodeop_opv_desc;
+extern struct vnodeopv_desc portal_vnodeop_opv_desc;
+extern struct vnodeopv_desc null_vnodeop_opv_desc;
+extern struct vnodeopv_desc umap_vnodeop_opv_desc;
+extern struct vnodeopv_desc kernfs_vnodeop_opv_desc;
+extern struct vnodeopv_desc procfs_vnodeop_opv_desc;
+extern struct vnodeopv_desc cd9660_vnodeop_opv_desc;
+extern struct vnodeopv_desc cd9660_specop_opv_desc;
+extern struct vnodeopv_desc cd9660_fifoop_opv_desc;
+extern struct vnodeopv_desc union_vnodeop_opv_desc;
+
+struct vnodeopv_desc *vfs_opv_descs[] = {
+	&ffs_vnodeop_opv_desc,
+	&ffs_specop_opv_desc,
+#ifdef FIFO
+	&ffs_fifoop_opv_desc,
+#endif
+	&dead_vnodeop_opv_desc,
+#ifdef FIFO
+	&fifo_vnodeop_opv_desc,
+#endif
+	&spec_vnodeop_opv_desc,
+#ifdef LFS
+	&lfs_vnodeop_opv_desc,
+	&lfs_specop_opv_desc,
+#ifdef FIFO
+	&lfs_fifoop_opv_desc,
+#endif
+#endif
+#ifdef MFS
+	&mfs_vnodeop_opv_desc,
+#endif
+#ifdef NFS
+	&nfsv2_vnodeop_opv_desc,
+	&spec_nfsv2nodeop_opv_desc,
+#ifdef FIFO
+	&fifo_nfsv2nodeop_opv_desc,
+#endif
+#endif
+#ifdef FDESC
+	&fdesc_vnodeop_opv_desc,
+#endif
+#ifdef PORTAL
+	&portal_vnodeop_opv_desc,
+#endif
+#ifdef NULLFS
+	&null_vnodeop_opv_desc,
+#endif
+#ifdef UMAPFS
+	&umap_vnodeop_opv_desc,
+#endif
+#ifdef KERNFS
+	&kernfs_vnodeop_opv_desc,
+#endif
+#ifdef PROCFS
+	&procfs_vnodeop_opv_desc,
+#endif
+#ifdef CD9660
+	&cd9660_vnodeop_opv_desc,
+	&cd9660_specop_opv_desc,
+#ifdef FIFO
+	&cd9660_fifoop_opv_desc,
+#endif
+#endif
+#ifdef UNION
+	&union_vnodeop_opv_desc,
+#endif
+	NULL
+};

--- a/src-uland/fs-server/vfs_init.c
+++ b/src-uland/fs-server/vfs_init.c
@@ -1,0 +1,252 @@
+/* Copied from sys/kern/vfs_init.c */
+/*
+ * Copyright (c) 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed
+ * to Berkeley by John Heidemann of the UCLA Ficus project.
+ *
+ * Source: * @(#)i405_init.c 2.10 92/04/27 UCLA Ficus project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vfs_init.c	8.5 (Berkeley) 5/11/95
+ */
+
+
+#include <sys/param.h>
+#include <sys/mount.h>
+#include <sys/time.h>
+#include <sys/vnode.h>
+#include <sys/stat.h>
+#include <sys/namei.h>
+#include <sys/ucred.h>
+#include <sys/buf.h>
+#include <sys/errno.h>
+#include <sys/malloc.h>
+
+/*
+ * Sigh, such primitive tools are these...
+ */
+#if 0
+#define DODEBUG(A) A
+#else
+#define DODEBUG(A)
+#endif
+
+extern struct vnodeopv_desc *vfs_opv_descs[];
+				/* a list of lists of vnodeops defns */
+extern struct vnodeop_desc *vfs_op_descs[];
+				/* and the operations they perform */
+/*
+ * This code doesn't work if the defn is **vnodop_defns with cc.
+ * The problem is because of the compiler sometimes putting in an
+ * extra level of indirection for arrays.  It's an interesting
+ * "feature" of C.
+ */
+int vfs_opv_numops;
+
+typedef (*PFI)();   /* the standard Pointer to a Function returning an Int */
+
+/*
+ * A miscellaneous routine.
+ * A generic "default" routine that just returns an error.
+ */
+int
+vn_default_error()
+{
+
+	return (EOPNOTSUPP);
+}
+
+/*
+ * vfs_init.c
+ *
+ * Allocate and fill in operations vectors.
+ *
+ * An undocumented feature of this approach to defining operations is that
+ * there can be multiple entries in vfs_opv_descs for the same operations
+ * vector. This allows third parties to extend the set of operations
+ * supported by another layer in a binary compatibile way. For example,
+ * assume that NFS needed to be modified to support Ficus. NFS has an entry
+ * (probably nfs_vnopdeop_decls) declaring all the operations NFS supports by
+ * default. Ficus could add another entry (ficus_nfs_vnodeop_decl_entensions)
+ * listing those new operations Ficus adds to NFS, all without modifying the
+ * NFS code. (Of couse, the OTW NFS protocol still needs to be munged, but
+ * that is a(whole)nother story.) This is a feature.
+ */
+void
+vfs_opv_init()
+{
+	int i, j, k;
+	int (***opv_desc_vector_p)();
+	int (**opv_desc_vector)();
+	struct vnodeopv_entry_desc *opve_descp;
+
+	/*
+	 * Allocate the dynamic vectors and fill them in.
+	 */
+	for (i=0; vfs_opv_descs[i]; i++) {
+		opv_desc_vector_p = vfs_opv_descs[i]->opv_desc_vector_p;
+		/*
+		 * Allocate and init the vector, if it needs it.
+		 * Also handle backwards compatibility.
+		 */
+		if (*opv_desc_vector_p == NULL) {
+			/* XXX - shouldn't be M_VNODE */
+			MALLOC(*opv_desc_vector_p, PFI*,
+			       vfs_opv_numops*sizeof(PFI), M_VNODE, M_WAITOK);
+			bzero (*opv_desc_vector_p, vfs_opv_numops*sizeof(PFI));
+			DODEBUG(printf("vector at %x allocated\n",
+			    opv_desc_vector_p));
+		}
+		opv_desc_vector = *opv_desc_vector_p;
+		for (j=0; vfs_opv_descs[i]->opv_desc_ops[j].opve_op; j++) {
+			opve_descp = &(vfs_opv_descs[i]->opv_desc_ops[j]);
+
+			/*
+			 * Sanity check:  is this operation listed
+			 * in the list of operations?  We check this
+			 * by seeing if its offest is zero.  Since
+			 * the default routine should always be listed
+			 * first, it should be the only one with a zero
+			 * offset.  Any other operation with a zero
+			 * offset is probably not listed in
+			 * vfs_op_descs, and so is probably an error.
+			 *
+			 * A panic here means the layer programmer
+			 * has committed the all-too common bug
+			 * of adding a new operation to the layer's
+			 * list of vnode operations but
+			 * not adding the operation to the system-wide
+			 * list of supported operations.
+			 */
+			if (opve_descp->opve_op->vdesc_offset == 0 &&
+				    opve_descp->opve_op->vdesc_offset !=
+				    	VOFFSET(vop_default)) {
+				printf("operation %s not listed in %s.\n",
+				    opve_descp->opve_op->vdesc_name,
+				    "vfs_op_descs");
+				panic ("vfs_opv_init: bad operation");
+			}
+			/*
+			 * Fill in this entry.
+			 */
+			opv_desc_vector[opve_descp->opve_op->vdesc_offset] =
+					opve_descp->opve_impl;
+		}
+	}
+	/*
+	 * Finally, go back and replace unfilled routines
+	 * with their default.  (Sigh, an O(n^3) algorithm.  I
+	 * could make it better, but that'd be work, and n is small.)
+	 */
+	for (i = 0; vfs_opv_descs[i]; i++) {
+		opv_desc_vector = *(vfs_opv_descs[i]->opv_desc_vector_p);
+		/*
+		 * Force every operations vector to have a default routine.
+		 */
+		if (opv_desc_vector[VOFFSET(vop_default)]==NULL) {
+			panic("vfs_opv_init: operation vector without default routine.");
+		}
+		for (k = 0; k<vfs_opv_numops; k++)
+			if (opv_desc_vector[k] == NULL)
+				opv_desc_vector[k] = 
+					opv_desc_vector[VOFFSET(vop_default)];
+	}
+}
+
+/*
+ * Initialize known vnode operations vectors.
+ */
+void
+vfs_op_init()
+{
+	int i;
+
+	DODEBUG(printf("Vnode_interface_init.\n"));
+	/*
+	 * Set all vnode vectors to a well known value.
+	 */
+	for (i = 0; vfs_opv_descs[i]; i++)
+		*(vfs_opv_descs[i]->opv_desc_vector_p) = NULL;
+	/*
+	 * Figure out how many ops there are by counting the table,
+	 * and assign each its offset.
+	 */
+	for (vfs_opv_numops = 0, i = 0; vfs_op_descs[i]; i++) {
+		vfs_op_descs[i]->vdesc_offset = vfs_opv_numops;
+		vfs_opv_numops++;
+	}
+	DODEBUG(printf ("vfs_opv_numops=%d\n", vfs_opv_numops));
+}
+
+/*
+ * Routines having to do with the management of the vnode table.
+ */
+extern struct vnodeops dead_vnodeops;
+extern struct vnodeops spec_vnodeops;
+struct vattr va_null;
+
+/*
+ * Initialize the vnode structures and initialize each file system type.
+ */
+vfsinit()
+{
+	struct vfsconf *vfsp;
+	int i, maxtypenum;
+
+	/*
+	 * Initialize the vnode table
+	 */
+	vntblinit();
+	/*
+	 * Initialize the vnode name cache
+	 */
+	nchinit();
+	/*
+	 * Build vnode operation vectors.
+	 */
+	vfs_op_init();
+	vfs_opv_init();   /* finish the job */
+	/*
+	 * Initialize each file system type.
+	 */
+	vattr_null(&va_null);
+	maxtypenum = 0;
+	for (vfsp = vfsconf, i = 1; i <= maxvfsconf; i++, vfsp++) {
+		if (i < maxvfsconf)
+			vfsp->vfc_next = vfsp + 1;
+		if (maxtypenum <= vfsp->vfc_typenum)
+			maxtypenum = vfsp->vfc_typenum + 1;
+		(*vfsp->vfc_vfsops->vfs_init)(vfsp);
+	}
+	/* next vfc_typenum to be used */
+	maxvfsconf = maxtypenum;
+}

--- a/src-uland/fs-server/vfs_lookup.c
+++ b/src-uland/fs-server/vfs_lookup.c
@@ -1,0 +1,646 @@
+/* Copied from sys/kern/vfs_lookup.c */
+/*
+ * Copyright (c) 1982, 1986, 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vfs_lookup.c	8.10 (Berkeley) 5/27/95
+ */
+
+#include <sys/param.h>
+#include <sys/syslimits.h>
+#include <sys/time.h>
+#include <sys/namei.h>
+#include <sys/vnode.h>
+#include <sys/mount.h>
+#include <sys/errno.h>
+#include <sys/malloc.h>
+#include <sys/filedesc.h>
+#include <sys/proc.h>
+
+#ifdef KTRACE
+#include <sys/ktrace.h>
+#endif
+
+/*
+ * Convert a pathname into a pointer to a locked inode.
+ *
+ * The FOLLOW flag is set when symbolic links are to be followed
+ * when they occur at the end of the name translation process.
+ * Symbolic links are always followed for all other pathname
+ * components other than the last.
+ *
+ * The segflg defines whether the name is to be copied from user
+ * space or kernel space.
+ *
+ * Overall outline of namei:
+ *
+ *	copy in name
+ *	get starting directory
+ *	while (!done && !error) {
+ *		call lookup to search path.
+ *		if symbolic link, massage name in buffer and continue
+ *	}
+ */
+int
+namei(ndp)
+	register struct nameidata *ndp;
+{
+	register struct filedesc *fdp;	/* pointer to file descriptor state */
+	register char *cp;		/* pointer into pathname argument */
+	register struct vnode *dp;	/* the directory we are searching */
+	struct iovec aiov;		/* uio for reading symbolic links */
+	struct uio auio;
+	int error, linklen;
+	struct componentname *cnp = &ndp->ni_cnd;
+	struct proc *p = cnp->cn_proc;
+
+	ndp->ni_cnd.cn_cred = ndp->ni_cnd.cn_proc->p_ucred;
+#ifdef DIAGNOSTIC
+	if (!cnp->cn_cred || !cnp->cn_proc)
+		panic ("namei: bad cred/proc");
+	if (cnp->cn_nameiop & (~OPMASK))
+		panic ("namei: nameiop contaminated with flags");
+	if (cnp->cn_flags & OPMASK)
+		panic ("namei: flags contaminated with nameiops");
+#endif
+	fdp = cnp->cn_proc->p_fd;
+
+	/*
+	 * Get a buffer for the name to be translated, and copy the
+	 * name into the buffer.
+	 */
+	if ((cnp->cn_flags & HASBUF) == 0)
+		MALLOC(cnp->cn_pnbuf, caddr_t, MAXPATHLEN, M_NAMEI, M_WAITOK);
+	if (ndp->ni_segflg == UIO_SYSSPACE)
+		error = copystr(ndp->ni_dirp, cnp->cn_pnbuf,
+			    MAXPATHLEN, &ndp->ni_pathlen);
+	else
+		error = copyinstr(ndp->ni_dirp, cnp->cn_pnbuf,
+			    MAXPATHLEN, &ndp->ni_pathlen);
+	if (error) {
+		free(cnp->cn_pnbuf, M_NAMEI);
+		ndp->ni_vp = NULL;
+		return (error);
+	}
+	ndp->ni_loopcnt = 0;
+#ifdef KTRACE
+	if (KTRPOINT(cnp->cn_proc, KTR_NAMEI))
+		ktrnamei(cnp->cn_proc->p_tracep, cnp->cn_pnbuf);
+#endif
+
+	/*
+	 * Get starting point for the translation.
+	 */
+	if ((ndp->ni_rootdir = fdp->fd_rdir) == NULL)
+		ndp->ni_rootdir = rootvnode;
+	dp = fdp->fd_cdir;
+	VREF(dp);
+	for (;;) {
+		/*
+		 * Check if root directory should replace current directory.
+		 * Done at start of translation and after symbolic link.
+		 */
+		cnp->cn_nameptr = cnp->cn_pnbuf;
+		if (*(cnp->cn_nameptr) == '/') {
+			vrele(dp);
+			while (*(cnp->cn_nameptr) == '/') {
+				cnp->cn_nameptr++;
+				ndp->ni_pathlen--;
+			}
+			dp = ndp->ni_rootdir;
+			VREF(dp);
+		}
+		ndp->ni_startdir = dp;
+		if (error = lookup(ndp)) {
+			FREE(cnp->cn_pnbuf, M_NAMEI);
+			return (error);
+		}
+		/*
+		 * Check for symbolic link
+		 */
+		if ((cnp->cn_flags & ISSYMLINK) == 0) {
+			if ((cnp->cn_flags & (SAVENAME | SAVESTART)) == 0)
+				FREE(cnp->cn_pnbuf, M_NAMEI);
+			else
+				cnp->cn_flags |= HASBUF;
+			return (0);
+		}
+		if ((cnp->cn_flags & LOCKPARENT) && ndp->ni_pathlen == 1)
+			VOP_UNLOCK(ndp->ni_dvp, 0, p);
+		if (ndp->ni_loopcnt++ >= MAXSYMLINKS) {
+			error = ELOOP;
+			break;
+		}
+		if (ndp->ni_pathlen > 1)
+			MALLOC(cp, char *, MAXPATHLEN, M_NAMEI, M_WAITOK);
+		else
+			cp = cnp->cn_pnbuf;
+		aiov.iov_base = cp;
+		aiov.iov_len = MAXPATHLEN;
+		auio.uio_iov = &aiov;
+		auio.uio_iovcnt = 1;
+		auio.uio_offset = 0;
+		auio.uio_rw = UIO_READ;
+		auio.uio_segflg = UIO_SYSSPACE;
+		auio.uio_procp = (struct proc *)0;
+		auio.uio_resid = MAXPATHLEN;
+		if (error = VOP_READLINK(ndp->ni_vp, &auio, cnp->cn_cred)) {
+			if (ndp->ni_pathlen > 1)
+				free(cp, M_NAMEI);
+			break;
+		}
+		linklen = MAXPATHLEN - auio.uio_resid;
+		if (linklen + ndp->ni_pathlen >= MAXPATHLEN) {
+			if (ndp->ni_pathlen > 1)
+				free(cp, M_NAMEI);
+			error = ENAMETOOLONG;
+			break;
+		}
+		if (ndp->ni_pathlen > 1) {
+			bcopy(ndp->ni_next, cp + linklen, ndp->ni_pathlen);
+			FREE(cnp->cn_pnbuf, M_NAMEI);
+			cnp->cn_pnbuf = cp;
+		} else
+			cnp->cn_pnbuf[linklen] = '\0';
+		ndp->ni_pathlen += linklen;
+		vput(ndp->ni_vp);
+		dp = ndp->ni_dvp;
+	}
+	FREE(cnp->cn_pnbuf, M_NAMEI);
+	vrele(ndp->ni_dvp);
+	vput(ndp->ni_vp);
+	ndp->ni_vp = NULL;
+	return (error);
+}
+
+/*
+ * Search a pathname.
+ * This is a very central and rather complicated routine.
+ *
+ * The pathname is pointed to by ni_ptr and is of length ni_pathlen.
+ * The starting directory is taken from ni_startdir. The pathname is
+ * descended until done, or a symbolic link is encountered. The variable
+ * ni_more is clear if the path is completed; it is set to one if a
+ * symbolic link needing interpretation is encountered.
+ *
+ * The flag argument is LOOKUP, CREATE, RENAME, or DELETE depending on
+ * whether the name is to be looked up, created, renamed, or deleted.
+ * When CREATE, RENAME, or DELETE is specified, information usable in
+ * creating, renaming, or deleting a directory entry may be calculated.
+ * If flag has LOCKPARENT or'ed into it, the parent directory is returned
+ * locked. If flag has WANTPARENT or'ed into it, the parent directory is
+ * returned unlocked. Otherwise the parent directory is not returned. If
+ * the target of the pathname exists and LOCKLEAF is or'ed into the flag
+ * the target is returned locked, otherwise it is returned unlocked.
+ * When creating or renaming and LOCKPARENT is specified, the target may not
+ * be ".".  When deleting and LOCKPARENT is specified, the target may be ".".
+ * 
+ * Overall outline of lookup:
+ *
+ * dirloop:
+ *	identify next component of name at ndp->ni_ptr
+ *	handle degenerate case where name is null string
+ *	if .. and crossing mount points and on mounted filesys, find parent
+ *	call VOP_LOOKUP routine for next component name
+ *	    directory vnode returned in ni_dvp, unlocked unless LOCKPARENT set
+ *	    component vnode returned in ni_vp (if it exists), locked.
+ *	if result vnode is mounted on and crossing mount points,
+ *	    find mounted on vnode
+ *	if more components of name, do next level at dirloop
+ *	return the answer in ni_vp, locked if LOCKLEAF set
+ *	    if LOCKPARENT set, return locked parent in ni_dvp
+ *	    if WANTPARENT set, return unlocked parent in ni_dvp
+ */
+int
+lookup(ndp)
+	register struct nameidata *ndp;
+{
+	register char *cp;		/* pointer into pathname argument */
+	register struct vnode *dp = 0;	/* the directory we are searching */
+	struct vnode *tdp;		/* saved dp */
+	struct mount *mp;		/* mount table entry */
+	int docache;			/* == 0 do not cache last component */
+	int wantparent;			/* 1 => wantparent or lockparent flag */
+	int rdonly;			/* lookup read-only flag bit */
+	int error = 0;
+	struct componentname *cnp = &ndp->ni_cnd;
+	struct proc *p = cnp->cn_proc;
+
+	/*
+	 * Setup: break out flag bits into variables.
+	 */
+	wantparent = cnp->cn_flags & (LOCKPARENT | WANTPARENT);
+	docache = (cnp->cn_flags & NOCACHE) ^ NOCACHE;
+	if (cnp->cn_nameiop == DELETE ||
+	    (wantparent && cnp->cn_nameiop != CREATE))
+		docache = 0;
+	rdonly = cnp->cn_flags & RDONLY;
+	ndp->ni_dvp = NULL;
+	cnp->cn_flags &= ~ISSYMLINK;
+	dp = ndp->ni_startdir;
+	ndp->ni_startdir = NULLVP;
+	vn_lock(dp, LK_EXCLUSIVE | LK_RETRY, p);
+
+dirloop:
+	/*
+	 * Search a new directory.
+	 *
+	 * The cn_hash value is for use by vfs_cache.
+	 * The last component of the filename is left accessible via
+	 * cnp->cn_nameptr for callers that need the name. Callers needing
+	 * the name set the SAVENAME flag. When done, they assume
+	 * responsibility for freeing the pathname buffer.
+	 */
+	cnp->cn_consume = 0;
+	cnp->cn_hash = 0;
+	for (cp = cnp->cn_nameptr; *cp != 0 && *cp != '/'; cp++)
+		cnp->cn_hash += (unsigned char)*cp;
+	cnp->cn_namelen = cp - cnp->cn_nameptr;
+	if (cnp->cn_namelen > NAME_MAX) {
+		error = ENAMETOOLONG;
+		goto bad;
+	}
+#ifdef NAMEI_DIAGNOSTIC
+	{ char c = *cp;
+	*cp = '\0';
+	printf("{%s}: ", cnp->cn_nameptr);
+	*cp = c; }
+#endif
+	ndp->ni_pathlen -= cnp->cn_namelen;
+	ndp->ni_next = cp;
+	cnp->cn_flags |= MAKEENTRY;
+	if (*cp == '\0' && docache == 0)
+		cnp->cn_flags &= ~MAKEENTRY;
+	if (cnp->cn_namelen == 2 &&
+	    cnp->cn_nameptr[1] == '.' && cnp->cn_nameptr[0] == '.')
+		cnp->cn_flags |= ISDOTDOT;
+	else
+		cnp->cn_flags &= ~ISDOTDOT;
+	if (*ndp->ni_next == 0)
+		cnp->cn_flags |= ISLASTCN;
+	else
+		cnp->cn_flags &= ~ISLASTCN;
+
+
+	/*
+	 * Check for degenerate name (e.g. / or "")
+	 * which is a way of talking about a directory,
+	 * e.g. like "/." or ".".
+	 */
+	if (cnp->cn_nameptr[0] == '\0') {
+		if (dp->v_type != VDIR) {
+			error = ENOTDIR;
+			goto bad;
+		}
+		if (cnp->cn_nameiop != LOOKUP) {
+			error = EISDIR;
+			goto bad;
+		}
+		if (wantparent) {
+			ndp->ni_dvp = dp;
+			VREF(dp);
+		}
+		ndp->ni_vp = dp;
+		if (!(cnp->cn_flags & (LOCKPARENT | LOCKLEAF)))
+			VOP_UNLOCK(dp, 0, p);
+		if (cnp->cn_flags & SAVESTART)
+			panic("lookup: SAVESTART");
+		return (0);
+	}
+
+	/*
+	 * Handle "..": two special cases.
+	 * 1. If at root directory (e.g. after chroot)
+	 *    or at absolute root directory
+	 *    then ignore it so can't get out.
+	 * 2. If this vnode is the root of a mounted
+	 *    filesystem, then replace it with the
+	 *    vnode which was mounted on so we take the
+	 *    .. in the other file system.
+	 */
+	if (cnp->cn_flags & ISDOTDOT) {
+		for (;;) {
+			if (dp == ndp->ni_rootdir || dp == rootvnode) {
+				ndp->ni_dvp = dp;
+				ndp->ni_vp = dp;
+				VREF(dp);
+				goto nextname;
+			}
+			if ((dp->v_flag & VROOT) == 0 ||
+			    (cnp->cn_flags & NOCROSSMOUNT))
+				break;
+			tdp = dp;
+			dp = dp->v_mount->mnt_vnodecovered;
+			vput(tdp);
+			VREF(dp);
+			vn_lock(dp, LK_EXCLUSIVE | LK_RETRY, p);
+		}
+	}
+
+	/*
+	 * We now have a segment name to search for, and a directory to search.
+	 */
+unionlookup:
+	ndp->ni_dvp = dp;
+	ndp->ni_vp = NULL;
+	if (error = VOP_LOOKUP(dp, &ndp->ni_vp, cnp)) {
+#ifdef DIAGNOSTIC
+		if (ndp->ni_vp != NULL)
+			panic("leaf should be empty");
+#endif
+#ifdef NAMEI_DIAGNOSTIC
+		printf("not found\n");
+#endif
+		if ((error == ENOENT) &&
+		    (dp->v_flag & VROOT) &&
+		    (dp->v_mount->mnt_flag & MNT_UNION)) {
+			tdp = dp;
+			dp = dp->v_mount->mnt_vnodecovered;
+			vput(tdp);
+			VREF(dp);
+			vn_lock(dp, LK_EXCLUSIVE | LK_RETRY, p);
+			goto unionlookup;
+		}
+
+		if (error != EJUSTRETURN)
+			goto bad;
+		/*
+		 * If creating and at end of pathname, then can consider
+		 * allowing file to be created.
+		 */
+		if (rdonly) {
+			error = EROFS;
+			goto bad;
+		}
+		/*
+		 * We return with ni_vp NULL to indicate that the entry
+		 * doesn't currently exist, leaving a pointer to the
+		 * (possibly locked) directory inode in ndp->ni_dvp.
+		 */
+		if (cnp->cn_flags & SAVESTART) {
+			ndp->ni_startdir = ndp->ni_dvp;
+			VREF(ndp->ni_startdir);
+		}
+		return (0);
+	}
+#ifdef NAMEI_DIAGNOSTIC
+	printf("found\n");
+#endif
+
+	/*
+	 * Take into account any additional components consumed by
+	 * the underlying filesystem.
+	 */
+	if (cnp->cn_consume > 0) {
+		cnp->cn_nameptr += cnp->cn_consume;
+		ndp->ni_next += cnp->cn_consume;
+		ndp->ni_pathlen -= cnp->cn_consume;
+		cnp->cn_consume = 0;
+	}
+
+	dp = ndp->ni_vp;
+	/*
+	 * Check to see if the vnode has been mounted on;
+	 * if so find the root of the mounted file system.
+	 */
+	while (dp->v_type == VDIR && (mp = dp->v_mountedhere) &&
+	       (cnp->cn_flags & NOCROSSMOUNT) == 0) {
+		if (vfs_busy(mp, 0, 0, p))
+			continue;
+		error = VFS_ROOT(mp, &tdp);
+		vfs_unbusy(mp, p);
+		if (error)
+			goto bad2;
+		vput(dp);
+		ndp->ni_vp = dp = tdp;
+	}
+
+	/*
+	 * Check for symbolic link
+	 */
+	if ((dp->v_type == VLNK) &&
+	    ((cnp->cn_flags & FOLLOW) || *ndp->ni_next == '/')) {
+		cnp->cn_flags |= ISSYMLINK;
+		return (0);
+	}
+
+nextname:
+	/*
+	 * Not a symbolic link.  If more pathname,
+	 * continue at next component, else return.
+	 */
+	if (*ndp->ni_next == '/') {
+		cnp->cn_nameptr = ndp->ni_next;
+		while (*cnp->cn_nameptr == '/') {
+			cnp->cn_nameptr++;
+			ndp->ni_pathlen--;
+		}
+		vrele(ndp->ni_dvp);
+		goto dirloop;
+	}
+	/*
+	 * Disallow directory write attempts on read-only file systems.
+	 */
+	if (rdonly &&
+	    (cnp->cn_nameiop == DELETE || cnp->cn_nameiop == RENAME)) {
+		error = EROFS;
+		goto bad2;
+	}
+	if (cnp->cn_flags & SAVESTART) {
+		ndp->ni_startdir = ndp->ni_dvp;
+		VREF(ndp->ni_startdir);
+	}
+	if (!wantparent)
+		vrele(ndp->ni_dvp);
+	if ((cnp->cn_flags & LOCKLEAF) == 0)
+		VOP_UNLOCK(dp, 0, p);
+	return (0);
+
+bad2:
+	if ((cnp->cn_flags & LOCKPARENT) && *ndp->ni_next == '\0')
+		VOP_UNLOCK(ndp->ni_dvp, 0, p);
+	vrele(ndp->ni_dvp);
+bad:
+	vput(dp);
+	ndp->ni_vp = NULL;
+	return (error);
+}
+
+/*
+ * relookup - lookup a path name component
+ *    Used by lookup to re-aquire things.
+ */
+int
+relookup(dvp, vpp, cnp)
+	struct vnode *dvp, **vpp;
+	struct componentname *cnp;
+{
+	struct proc *p = cnp->cn_proc;
+	struct vnode *dp = 0;		/* the directory we are searching */
+	int docache;			/* == 0 do not cache last component */
+	int wantparent;			/* 1 => wantparent or lockparent flag */
+	int rdonly;			/* lookup read-only flag bit */
+	int error = 0;
+#ifdef NAMEI_DIAGNOSTIC
+	int newhash;			/* DEBUG: check name hash */
+	char *cp;			/* DEBUG: check name ptr/len */
+#endif
+
+	/*
+	 * Setup: break out flag bits into variables.
+	 */
+	wantparent = cnp->cn_flags & (LOCKPARENT|WANTPARENT);
+	docache = (cnp->cn_flags & NOCACHE) ^ NOCACHE;
+	if (cnp->cn_nameiop == DELETE ||
+	    (wantparent && cnp->cn_nameiop != CREATE))
+		docache = 0;
+	rdonly = cnp->cn_flags & RDONLY;
+	cnp->cn_flags &= ~ISSYMLINK;
+	dp = dvp;
+	vn_lock(dp, LK_EXCLUSIVE | LK_RETRY, p);
+
+/* dirloop: */
+	/*
+	 * Search a new directory.
+	 *
+	 * The cn_hash value is for use by vfs_cache.
+	 * The last component of the filename is left accessible via
+	 * cnp->cn_nameptr for callers that need the name. Callers needing
+	 * the name set the SAVENAME flag. When done, they assume
+	 * responsibility for freeing the pathname buffer.
+	 */
+#ifdef NAMEI_DIAGNOSTIC
+	for (newhash = 0, cp = cnp->cn_nameptr; *cp != 0 && *cp != '/'; cp++)
+		newhash += (unsigned char)*cp;
+	if (newhash != cnp->cn_hash)
+		panic("relookup: bad hash");
+	if (cnp->cn_namelen != cp - cnp->cn_nameptr)
+		panic ("relookup: bad len");
+	if (*cp != 0)
+		panic("relookup: not last component");
+	printf("{%s}: ", cnp->cn_nameptr);
+#endif
+
+	/*
+	 * Check for degenerate name (e.g. / or "")
+	 * which is a way of talking about a directory,
+	 * e.g. like "/." or ".".
+	 */
+	if (cnp->cn_nameptr[0] == '\0') {
+		if (cnp->cn_nameiop != LOOKUP || wantparent) {
+			error = EISDIR;
+			goto bad;
+		}
+		if (dp->v_type != VDIR) {
+			error = ENOTDIR;
+			goto bad;
+		}
+		if (!(cnp->cn_flags & LOCKLEAF))
+			VOP_UNLOCK(dp, 0, p);
+		*vpp = dp;
+		if (cnp->cn_flags & SAVESTART)
+			panic("lookup: SAVESTART");
+		return (0);
+	}
+
+	if (cnp->cn_flags & ISDOTDOT)
+		panic ("relookup: lookup on dot-dot");
+
+	/*
+	 * We now have a segment name to search for, and a directory to search.
+	 */
+	if (error = VOP_LOOKUP(dp, vpp, cnp)) {
+#ifdef DIAGNOSTIC
+		if (*vpp != NULL)
+			panic("leaf should be empty");
+#endif
+		if (error != EJUSTRETURN)
+			goto bad;
+		/*
+		 * If creating and at end of pathname, then can consider
+		 * allowing file to be created.
+		 */
+		if (rdonly) {
+			error = EROFS;
+			goto bad;
+		}
+		/* ASSERT(dvp == ndp->ni_startdir) */
+		if (cnp->cn_flags & SAVESTART)
+			VREF(dvp);
+		/*
+		 * We return with ni_vp NULL to indicate that the entry
+		 * doesn't currently exist, leaving a pointer to the
+		 * (possibly locked) directory inode in ndp->ni_dvp.
+		 */
+		return (0);
+	}
+	dp = *vpp;
+
+#ifdef DIAGNOSTIC
+	/*
+	 * Check for symbolic link
+	 */
+	if (dp->v_type == VLNK && (cnp->cn_flags & FOLLOW))
+		panic ("relookup: symlink found.\n");
+#endif
+
+	/*
+	 * Disallow directory write attempts on read-only file systems.
+	 */
+	if (rdonly &&
+	    (cnp->cn_nameiop == DELETE || cnp->cn_nameiop == RENAME)) {
+		error = EROFS;
+		goto bad2;
+	}
+	/* ASSERT(dvp == ndp->ni_startdir) */
+	if (cnp->cn_flags & SAVESTART)
+		VREF(dvp);
+	
+	if (!wantparent)
+		vrele(dvp);
+	if ((cnp->cn_flags & LOCKLEAF) == 0)
+		VOP_UNLOCK(dp, 0, p);
+	return (0);
+
+bad2:
+	if ((cnp->cn_flags & LOCKPARENT) && (cnp->cn_flags & ISLASTCN))
+		VOP_UNLOCK(dvp, 0, p);
+	vrele(dvp);
+bad:
+	vput(dp);
+	*vpp = NULL;
+	return (error);
+}

--- a/src-uland/fs-server/vfs_subr.c
+++ b/src-uland/fs-server/vfs_subr.c
@@ -1,0 +1,1783 @@
+/* Copied from sys/kern/vfs_subr.c */
+/*
+ * Copyright (c) 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vfs_subr.c	8.31 (Berkeley) 5/26/95
+ */
+
+/*
+ * External virtual filesystem routines
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/mount.h>
+#include <sys/time.h>
+#include <sys/vnode.h>
+#include <sys/stat.h>
+#include <sys/namei.h>
+#include <sys/ucred.h>
+#include <sys/buf.h>
+#include <sys/errno.h>
+#include <sys/malloc.h>
+#include <sys/domain.h>
+#include <sys/mbuf.h>
+
+#include <vm/vm.h>
+#include <sys/sysctl.h>
+
+#include <miscfs/specfs/specdev.h>
+
+enum vtype iftovt_tab[16] = {
+	VNON, VFIFO, VCHR, VNON, VDIR, VNON, VBLK, VNON,
+	VREG, VNON, VLNK, VNON, VSOCK, VNON, VNON, VBAD,
+};
+int	vttoif_tab[9] = {
+	0, S_IFREG, S_IFDIR, S_IFBLK, S_IFCHR, S_IFLNK,
+	S_IFSOCK, S_IFIFO, S_IFMT,
+};
+
+/*
+ * Insq/Remq for the vnode usage lists.
+ */
+#define	bufinsvn(bp, dp)	LIST_INSERT_HEAD(dp, bp, b_vnbufs)
+#define	bufremvn(bp) {							\
+	LIST_REMOVE(bp, b_vnbufs);					\
+	(bp)->b_vnbufs.le_next = NOLIST;				\
+}
+TAILQ_HEAD(freelst, vnode) vnode_free_list;	/* vnode free list */
+struct mntlist mountlist;			/* mounted filesystem list */
+struct simplelock mountlist_slock;
+static struct simplelock mntid_slock;
+struct simplelock mntvnode_slock;
+struct simplelock vnode_free_list_slock;
+static struct simplelock spechash_slock;
+
+/*
+ * Initialize the vnode management data structures.
+ */
+void
+vntblinit()
+{
+
+	simple_lock_init(&mntvnode_slock);
+	simple_lock_init(&mntid_slock);
+	simple_lock_init(&spechash_slock);
+	TAILQ_INIT(&vnode_free_list);
+	simple_lock_init(&vnode_free_list_slock);
+	CIRCLEQ_INIT(&mountlist);
+}
+
+/*
+ * Mark a mount point as busy. Used to synchronize access and to delay
+ * unmounting. Interlock is not released on failure.
+ */
+int
+vfs_busy(mp, flags, interlkp, p)
+	struct mount *mp;
+	int flags;
+	struct simplelock *interlkp;
+	struct proc *p;
+{
+	int lkflags;
+
+	if (mp->mnt_flag & MNT_UNMOUNT) {
+		if (flags & LK_NOWAIT)
+			return (ENOENT);
+		mp->mnt_flag |= MNT_MWAIT;
+		if (interlkp)
+			simple_unlock(interlkp);
+		/*
+		 * Since all busy locks are shared except the exclusive
+		 * lock granted when unmounting, the only place that a
+		 * wakeup needs to be done is at the release of the
+		 * exclusive lock at the end of dounmount.
+		 */
+		sleep((caddr_t)mp, PVFS);
+		if (interlkp)
+			simple_lock(interlkp);
+		return (ENOENT);
+	}
+	lkflags = LK_SHARED;
+	if (interlkp)
+		lkflags |= LK_INTERLOCK;
+	if (lockmgr(&mp->mnt_lock, lkflags, interlkp, p))
+		panic("vfs_busy: unexpected lock failure");
+	return (0);
+}
+
+/*
+ * Free a busy filesystem.
+ */
+void
+vfs_unbusy(mp, p)
+	struct mount *mp;
+	struct proc *p;
+{
+
+	lockmgr(&mp->mnt_lock, LK_RELEASE, NULL, p);
+}
+
+/*
+ * Lookup a filesystem type, and if found allocate and initialize
+ * a mount structure for it.
+ *
+ * Devname is usually updated by mount(8) after booting.
+ */
+int
+vfs_rootmountalloc(fstypename, devname, mpp)
+	char *fstypename;
+	char *devname;
+	struct mount **mpp;
+{
+	struct proc *p = curproc;	/* XXX */
+	struct vfsconf *vfsp;
+	struct mount *mp;
+
+	for (vfsp = vfsconf; vfsp; vfsp = vfsp->vfc_next)
+		if (!strcmp(vfsp->vfc_name, fstypename))
+			break;
+	if (vfsp == NULL)
+		return (ENODEV);
+	mp = malloc((u_long)sizeof(struct mount), M_MOUNT, M_WAITOK);
+	bzero((char *)mp, (u_long)sizeof(struct mount));
+	lockinit(&mp->mnt_lock, PVFS, "vfslock", 0, 0);
+	(void)vfs_busy(mp, LK_NOWAIT, 0, p);
+	LIST_INIT(&mp->mnt_vnodelist);
+	mp->mnt_vfc = vfsp;
+	mp->mnt_op = vfsp->vfc_vfsops;
+	mp->mnt_flag = MNT_RDONLY;
+	mp->mnt_vnodecovered = NULLVP;
+	vfsp->vfc_refcount++;
+	mp->mnt_stat.f_type = vfsp->vfc_typenum;
+	mp->mnt_flag |= vfsp->vfc_flags & MNT_VISFLAGMASK;
+	strncpy(mp->mnt_stat.f_fstypename, vfsp->vfc_name, MFSNAMELEN);
+	mp->mnt_stat.f_mntonname[0] = '/';
+	(void) copystr(devname, mp->mnt_stat.f_mntfromname, MNAMELEN - 1, 0);
+	*mpp = mp;
+	return (0);
+}
+
+/*
+ * Find an appropriate filesystem to use for the root. If a filesystem
+ * has not been preselected, walk through the list of known filesystems
+ * trying those that have mountroot routines, and try them until one
+ * works or we have tried them all.
+ */
+int
+vfs_mountroot()
+{
+	struct vfsconf *vfsp;
+	extern int (*mountroot)(void);
+	int error;
+
+	if (mountroot != NULL)
+		return ((*mountroot)());
+	for (vfsp = vfsconf; vfsp; vfsp = vfsp->vfc_next) {
+		if (vfsp->vfc_mountroot == NULL)
+			continue;
+		if ((error = (*vfsp->vfc_mountroot)()) == 0)
+			return (0);
+		printf("%s_mountroot failed: %d\n", vfsp->vfc_name, error);
+	}
+	return (ENODEV);
+}
+
+/*
+ * Lookup a mount point by filesystem identifier.
+ */
+struct mount *
+vfs_getvfs(fsid)
+	fsid_t *fsid;
+{
+	register struct mount *mp;
+
+	simple_lock(&mountlist_slock);
+	for (mp = mountlist.cqh_first; mp != (void *)&mountlist;
+	     mp = mp->mnt_list.cqe_next) {
+		if (mp->mnt_stat.f_fsid.val[0] == fsid->val[0] &&
+		    mp->mnt_stat.f_fsid.val[1] == fsid->val[1]) {
+			simple_unlock(&mountlist_slock);
+			return (mp);
+		}
+	}
+	simple_unlock(&mountlist_slock);
+	return ((struct mount *)0);
+}
+
+/*
+ * Get a new unique fsid
+ */
+void
+vfs_getnewfsid(mp)
+	struct mount *mp;
+{
+static u_short xxxfs_mntid;
+
+	fsid_t tfsid;
+	int mtype;
+
+	simple_lock(&mntid_slock);
+	mtype = mp->mnt_vfc->vfc_typenum;
+	mp->mnt_stat.f_fsid.val[0] = makedev(nblkdev + mtype, 0);
+	mp->mnt_stat.f_fsid.val[1] = mtype;
+	if (xxxfs_mntid == 0)
+		++xxxfs_mntid;
+	tfsid.val[0] = makedev(nblkdev + mtype, xxxfs_mntid);
+	tfsid.val[1] = mtype;
+	if (mountlist.cqh_first != (void *)&mountlist) {
+		while (vfs_getvfs(&tfsid)) {
+			tfsid.val[0]++;
+			xxxfs_mntid++;
+		}
+	}
+	mp->mnt_stat.f_fsid.val[0] = tfsid.val[0];
+	simple_unlock(&mntid_slock);
+}
+
+/*
+ * Set vnode attributes to VNOVAL
+ */
+void
+vattr_null(vap)
+	register struct vattr *vap;
+{
+
+	vap->va_type = VNON;
+	vap->va_size = vap->va_bytes = VNOVAL;
+	vap->va_mode = vap->va_nlink = vap->va_uid = vap->va_gid =
+		vap->va_fsid = vap->va_fileid =
+		vap->va_blocksize = vap->va_rdev =
+		vap->va_atime.ts_sec = vap->va_atime.ts_nsec =
+		vap->va_mtime.ts_sec = vap->va_mtime.ts_nsec =
+		vap->va_ctime.ts_sec = vap->va_ctime.ts_nsec =
+		vap->va_flags = vap->va_gen = VNOVAL;
+	vap->va_vaflags = 0;
+}
+
+/*
+ * Routines having to do with the management of the vnode table.
+ */
+extern int (**dead_vnodeop_p)();
+static void vclean __P((struct vnode *vp, int flag, struct proc *p));
+extern void vgonel __P((struct vnode *vp, struct proc *p));
+long numvnodes;
+extern struct vattr va_null;
+
+/*
+ * Return the next vnode from the free list.
+ */
+int
+getnewvnode(tag, mp, vops, vpp)
+	enum vtagtype tag;
+	struct mount *mp;
+	int (**vops)();
+	struct vnode **vpp;
+{
+	struct proc *p = curproc;	/* XXX */
+	struct vnode *vp;
+	int s;
+	int cnt;
+
+top:
+	simple_lock(&vnode_free_list_slock);
+	if ((vnode_free_list.tqh_first == NULL &&
+	     numvnodes < 2 * desiredvnodes) ||
+	    numvnodes < desiredvnodes) {
+		simple_unlock(&vnode_free_list_slock);
+		vp = (struct vnode *)malloc((u_long)sizeof *vp,
+		    M_VNODE, M_WAITOK);
+		bzero((char *)vp, sizeof *vp);
+		numvnodes++;
+	} else {
+		for (vp = vnode_free_list.tqh_first;
+				vp != NULLVP; vp = vp->v_freelist.tqe_next) {
+			if (simple_lock_try(&vp->v_interlock))
+				break;
+		}
+		/*
+		 * Unless this is a bad time of the month, at most
+		 * the first NCPUS items on the free list are
+		 * locked, so this is close enough to being empty.
+		 */
+		if (vp == NULLVP) {
+			simple_unlock(&vnode_free_list_slock);
+			tablefull("vnode");
+			*vpp = 0;
+			return (ENFILE);
+		}
+		if (vp->v_usecount)
+			panic("free vnode isn't");
+		TAILQ_REMOVE(&vnode_free_list, vp, v_freelist);
+		/* see comment on why 0xdeadb is set at end of vgone (below) */
+		vp->v_freelist.tqe_prev = (struct vnode **)0xdeadb;
+		simple_unlock(&vnode_free_list_slock);
+		vp->v_lease = NULL;
+		if (vp->v_type != VBAD)
+			vgonel(vp, p);
+		else
+			simple_unlock(&vp->v_interlock);
+#ifdef DIAGNOSTIC
+		if (vp->v_data)
+			panic("cleaned vnode isn't");
+		s = splbio();
+		if (vp->v_numoutput)
+			panic("Clean vnode has pending I/O's");
+		splx(s);
+#endif
+		vp->v_flag = 0;
+		vp->v_lastr = 0;
+		vp->v_ralen = 0;
+		vp->v_maxra = 0;
+		vp->v_lastw = 0;
+		vp->v_lasta = 0;
+		vp->v_cstart = 0;
+		vp->v_clen = 0;
+		vp->v_socket = 0;
+	}
+	vp->v_type = VNON;
+	cache_purge(vp);
+	vp->v_tag = tag;
+	vp->v_op = vops;
+	insmntque(vp, mp);
+	*vpp = vp;
+	vp->v_usecount = 1;
+	vp->v_data = 0;
+	return (0);
+}
+
+/*
+ * Move a vnode from one mount queue to another.
+ */
+void
+insmntque(vp, mp)
+	struct vnode *vp;
+	struct mount *mp;
+{
+
+	simple_lock(&mntvnode_slock);
+	/*
+	 * Delete from old mount point vnode list, if on one.
+	 */
+	if (vp->v_mount != NULL)
+		LIST_REMOVE(vp, v_mntvnodes);
+	/*
+	 * Insert into list of vnodes for the new mount point, if available.
+	 */
+	if ((vp->v_mount = mp) != NULL)
+		LIST_INSERT_HEAD(&mp->mnt_vnodelist, vp, v_mntvnodes);
+	simple_unlock(&mntvnode_slock);
+}
+
+/*
+ * Update outstanding I/O count and do wakeup if requested.
+ */
+void
+vwakeup(bp)
+	register struct buf *bp;
+{
+	register struct vnode *vp;
+
+	bp->b_flags &= ~B_WRITEINPROG;
+	if (vp = bp->b_vp) {
+		if (--vp->v_numoutput < 0)
+			panic("vwakeup: neg numoutput");
+		if ((vp->v_flag & VBWAIT) && vp->v_numoutput <= 0) {
+			if (vp->v_numoutput < 0)
+				panic("vwakeup: neg numoutput 2");
+			vp->v_flag &= ~VBWAIT;
+			wakeup((caddr_t)&vp->v_numoutput);
+		}
+	}
+}
+
+/*
+ * Flush out and invalidate all buffers associated with a vnode.
+ * Called with the underlying object locked.
+ */
+int
+vinvalbuf(vp, flags, cred, p, slpflag, slptimeo)
+	register struct vnode *vp;
+	int flags;
+	struct ucred *cred;
+	struct proc *p;
+	int slpflag, slptimeo;
+{
+	register struct buf *bp;
+	struct buf *nbp, *blist;
+	int s, error;
+
+	if (flags & V_SAVE) {
+		if (error = VOP_FSYNC(vp, cred, MNT_WAIT, p))
+			return (error);
+		if (vp->v_dirtyblkhd.lh_first != NULL)
+			panic("vinvalbuf: dirty bufs");
+	}
+	for (;;) {
+		if ((blist = vp->v_cleanblkhd.lh_first) && flags & V_SAVEMETA)
+			while (blist && blist->b_lblkno < 0)
+				blist = blist->b_vnbufs.le_next;
+		if (!blist && (blist = vp->v_dirtyblkhd.lh_first) &&
+		    (flags & V_SAVEMETA))
+			while (blist && blist->b_lblkno < 0)
+				blist = blist->b_vnbufs.le_next;
+		if (!blist)
+			break;
+
+		for (bp = blist; bp; bp = nbp) {
+			nbp = bp->b_vnbufs.le_next;
+			if (flags & V_SAVEMETA && bp->b_lblkno < 0)
+				continue;
+			s = splbio();
+			if (bp->b_flags & B_BUSY) {
+				bp->b_flags |= B_WANTED;
+				error = tsleep((caddr_t)bp,
+					slpflag | (PRIBIO + 1), "vinvalbuf",
+					slptimeo);
+				splx(s);
+				if (error)
+					return (error);
+				break;
+			}
+			bremfree(bp);
+			bp->b_flags |= B_BUSY;
+			splx(s);
+			/*
+			 * XXX Since there are no node locks for NFS, I believe
+			 * there is a slight chance that a delayed write will
+			 * occur while sleeping just above, so check for it.
+			 */
+			if ((bp->b_flags & B_DELWRI) && (flags & V_SAVE)) {
+				(void) VOP_BWRITE(bp);
+				break;
+			}
+			bp->b_flags |= B_INVAL;
+			brelse(bp);
+		}
+	}
+	if (!(flags & V_SAVEMETA) &&
+	    (vp->v_dirtyblkhd.lh_first || vp->v_cleanblkhd.lh_first))
+		panic("vinvalbuf: flush failed");
+	return (0);
+}
+
+/*
+ * Associate a buffer with a vnode.
+ */
+void
+bgetvp(vp, bp)
+	register struct vnode *vp;
+	register struct buf *bp;
+{
+
+	if (bp->b_vp)
+		panic("bgetvp: not free");
+	VHOLD(vp);
+	bp->b_vp = vp;
+	if (vp->v_type == VBLK || vp->v_type == VCHR)
+		bp->b_dev = vp->v_rdev;
+	else
+		bp->b_dev = NODEV;
+	/*
+	 * Insert onto list for new vnode.
+	 */
+	bufinsvn(bp, &vp->v_cleanblkhd);
+}
+
+/*
+ * Disassociate a buffer from a vnode.
+ */
+void
+brelvp(bp)
+	register struct buf *bp;
+{
+	struct vnode *vp;
+
+	if (bp->b_vp == (struct vnode *) 0)
+		panic("brelvp: NULL");
+	/*
+	 * Delete from old vnode list, if on one.
+	 */
+	if (bp->b_vnbufs.le_next != NOLIST)
+		bufremvn(bp);
+	vp = bp->b_vp;
+	bp->b_vp = (struct vnode *) 0;
+	HOLDRELE(vp);
+}
+
+/*
+ * Reassign a buffer from one vnode to another.
+ * Used to assign file specific control information
+ * (indirect blocks) to the vnode to which they belong.
+ */
+void
+reassignbuf(bp, newvp)
+	register struct buf *bp;
+	register struct vnode *newvp;
+{
+	register struct buflists *listheadp;
+
+	if (newvp == NULL) {
+		printf("reassignbuf: NULL");
+		return;
+	}
+	/*
+	 * Delete from old vnode list, if on one.
+	 */
+	if (bp->b_vnbufs.le_next != NOLIST)
+		bufremvn(bp);
+	/*
+	 * If dirty, put on list of dirty buffers;
+	 * otherwise insert onto list of clean buffers.
+	 */
+	if (bp->b_flags & B_DELWRI)
+		listheadp = &newvp->v_dirtyblkhd;
+	else
+		listheadp = &newvp->v_cleanblkhd;
+	bufinsvn(bp, listheadp);
+}
+
+/*
+ * Create a vnode for a block device.
+ * Used for root filesystem, argdev, and swap areas.
+ * Also used for memory file system special devices.
+ */
+int
+bdevvp(dev, vpp)
+	dev_t dev;
+	struct vnode **vpp;
+{
+	register struct vnode *vp;
+	struct vnode *nvp;
+	int error;
+
+	if (dev == NODEV) {
+		*vpp = NULLVP;
+		return (ENODEV);
+	}
+	error = getnewvnode(VT_NON, (struct mount *)0, spec_vnodeop_p, &nvp);
+	if (error) {
+		*vpp = NULLVP;
+		return (error);
+	}
+	vp = nvp;
+	vp->v_type = VBLK;
+	if (nvp = checkalias(vp, dev, (struct mount *)0)) {
+		vput(vp);
+		vp = nvp;
+	}
+	*vpp = vp;
+	return (0);
+}
+
+/*
+ * Check to see if the new vnode represents a special device
+ * for which we already have a vnode (either because of
+ * bdevvp() or because of a different vnode representing
+ * the same block device). If such an alias exists, deallocate
+ * the existing contents and return the aliased vnode. The
+ * caller is responsible for filling it with its new contents.
+ */
+struct vnode *
+checkalias(nvp, nvp_rdev, mp)
+	register struct vnode *nvp;
+	dev_t nvp_rdev;
+	struct mount *mp;
+{
+	struct proc *p = curproc;	/* XXX */
+	struct vnode *vp;
+	struct vnode **vpp;
+
+	if (nvp->v_type != VBLK && nvp->v_type != VCHR)
+		return (NULLVP);
+
+	vpp = &speclisth[SPECHASH(nvp_rdev)];
+loop:
+	simple_lock(&spechash_slock);
+	for (vp = *vpp; vp; vp = vp->v_specnext) {
+		if (nvp_rdev != vp->v_rdev || nvp->v_type != vp->v_type)
+			continue;
+		/*
+		 * Alias, but not in use, so flush it out.
+		 */
+		simple_lock(&vp->v_interlock);
+		if (vp->v_usecount == 0) {
+			simple_unlock(&spechash_slock);
+			vgonel(vp, p);
+			goto loop;
+		}
+		if (vget(vp, LK_EXCLUSIVE | LK_INTERLOCK, p)) {
+			simple_unlock(&spechash_slock);
+			goto loop;
+		}
+		break;
+	}
+	if (vp == NULL || vp->v_tag != VT_NON) {
+		MALLOC(nvp->v_specinfo, struct specinfo *,
+			sizeof(struct specinfo), M_VNODE, M_WAITOK);
+		nvp->v_rdev = nvp_rdev;
+		nvp->v_hashchain = vpp;
+		nvp->v_specnext = *vpp;
+		nvp->v_specflags = 0;
+		simple_unlock(&spechash_slock);
+		*vpp = nvp;
+		if (vp != NULLVP) {
+			nvp->v_flag |= VALIASED;
+			vp->v_flag |= VALIASED;
+			vput(vp);
+		}
+		return (NULLVP);
+	}
+	simple_unlock(&spechash_slock);
+	VOP_UNLOCK(vp, 0, p);
+	simple_lock(&vp->v_interlock);
+	vclean(vp, 0, p);
+	vp->v_op = nvp->v_op;
+	vp->v_tag = nvp->v_tag;
+	nvp->v_type = VNON;
+	insmntque(vp, mp);
+	return (vp);
+}
+
+/*
+ * Grab a particular vnode from the free list, increment its
+ * reference count and lock it. The vnode lock bit is set the
+ * vnode is being eliminated in vgone. The process is awakened
+ * when the transition is completed, and an error returned to
+ * indicate that the vnode is no longer usable (possibly having
+ * been changed to a new file system type).
+ */
+int
+vget(vp, flags, p)
+	struct vnode *vp;
+	int flags;
+	struct proc *p;
+{
+	int error;
+
+	/*
+	 * If the vnode is in the process of being cleaned out for
+	 * another use, we wait for the cleaning to finish and then
+	 * return failure. Cleaning is determined by checking that
+	 * the VXLOCK flag is set.
+	 */
+	if ((flags & LK_INTERLOCK) == 0)
+		simple_lock(&vp->v_interlock);
+	if (vp->v_flag & VXLOCK) {
+		vp->v_flag |= VXWANT;
+		simple_unlock(&vp->v_interlock);
+		tsleep((caddr_t)vp, PINOD, "vget", 0);
+		return (ENOENT);
+	}
+	if (vp->v_usecount == 0) {
+		simple_lock(&vnode_free_list_slock);
+		TAILQ_REMOVE(&vnode_free_list, vp, v_freelist);
+		simple_unlock(&vnode_free_list_slock);
+	}
+	vp->v_usecount++;
+	if (flags & LK_TYPE_MASK) {
+		if (error = vn_lock(vp, flags | LK_INTERLOCK, p))
+			vrele(vp);
+		return (error);
+	}
+	simple_unlock(&vp->v_interlock);
+	return (0);
+}
+
+/*
+ * Stubs to use when there is no locking to be done on the underlying object.
+ * A minimal shared lock is necessary to ensure that the underlying object
+ * is not revoked while an operation is in progress. So, an active shared
+ * count is maintained in an auxillary vnode lock structure.
+ */
+int
+vop_nolock(ap)
+	struct vop_lock_args /* {
+		struct vnode *a_vp;
+		int a_flags;
+		struct proc *a_p;
+	} */ *ap;
+{
+#ifdef notyet
+	/*
+	 * This code cannot be used until all the non-locking filesystems
+	 * (notably NFS) are converted to properly lock and release nodes.
+	 * Also, certain vnode operations change the locking state within
+	 * the operation (create, mknod, remove, link, rename, mkdir, rmdir,
+	 * and symlink). Ideally these operations should not change the
+	 * lock state, but should be changed to let the caller of the
+	 * function unlock them. Otherwise all intermediate vnode layers
+	 * (such as union, umapfs, etc) must catch these functions to do
+	 * the necessary locking at their layer. Note that the inactive
+	 * and lookup operations also change their lock state, but this 
+	 * cannot be avoided, so these two operations will always need
+	 * to be handled in intermediate layers.
+	 */
+	struct vnode *vp = ap->a_vp;
+	int vnflags, flags = ap->a_flags;
+
+	if (vp->v_vnlock == NULL) {
+		if ((flags & LK_TYPE_MASK) == LK_DRAIN)
+			return (0);
+		MALLOC(vp->v_vnlock, struct lock *, sizeof(struct lock),
+		    M_VNODE, M_WAITOK);
+		lockinit(vp->v_vnlock, PVFS, "vnlock", 0, 0);
+	}
+	switch (flags & LK_TYPE_MASK) {
+	case LK_DRAIN:
+		vnflags = LK_DRAIN;
+		break;
+	case LK_EXCLUSIVE:
+	case LK_SHARED:
+		vnflags = LK_SHARED;
+		break;
+	case LK_UPGRADE:
+	case LK_EXCLUPGRADE:
+	case LK_DOWNGRADE:
+		return (0);
+	case LK_RELEASE:
+	default:
+		panic("vop_nolock: bad operation %d", flags & LK_TYPE_MASK);
+	}
+	if (flags & LK_INTERLOCK)
+		vnflags |= LK_INTERLOCK;
+	return(lockmgr(vp->v_vnlock, vnflags, &vp->v_interlock, ap->a_p));
+#else /* for now */
+	/*
+	 * Since we are not using the lock manager, we must clear
+	 * the interlock here.
+	 */
+	if (ap->a_flags & LK_INTERLOCK)
+		simple_unlock(&ap->a_vp->v_interlock);
+	return (0);
+#endif
+}
+
+/*
+ * Decrement the active use count.
+ */
+int
+vop_nounlock(ap)
+	struct vop_unlock_args /* {
+		struct vnode *a_vp;
+		int a_flags;
+		struct proc *a_p;
+	} */ *ap;
+{
+	struct vnode *vp = ap->a_vp;
+
+	if (vp->v_vnlock == NULL)
+		return (0);
+	return (lockmgr(vp->v_vnlock, LK_RELEASE, NULL, ap->a_p));
+}
+
+/*
+ * Return whether or not the node is in use.
+ */
+int
+vop_noislocked(ap)
+	struct vop_islocked_args /* {
+		struct vnode *a_vp;
+	} */ *ap;
+{
+	struct vnode *vp = ap->a_vp;
+
+	if (vp->v_vnlock == NULL)
+		return (0);
+	return (lockstatus(vp->v_vnlock));
+}
+
+/*
+ * Vnode reference.
+ */
+void
+vref(vp)
+	struct vnode *vp;
+{
+
+	simple_lock(&vp->v_interlock);
+	if (vp->v_usecount <= 0)
+		panic("vref used where vget required");
+	vp->v_usecount++;
+	simple_unlock(&vp->v_interlock);
+}
+
+/*
+ * vput(), just unlock and vrele()
+ */
+void
+vput(vp)
+	struct vnode *vp;
+{
+	struct proc *p = curproc;	/* XXX */
+
+#ifdef DIGANOSTIC
+	if (vp == NULL)
+		panic("vput: null vp");
+#endif
+	simple_lock(&vp->v_interlock);
+	vp->v_usecount--;
+	if (vp->v_usecount > 0) {
+		simple_unlock(&vp->v_interlock);
+		VOP_UNLOCK(vp, 0, p);
+		return;
+	}
+#ifdef DIAGNOSTIC
+	if (vp->v_usecount < 0 || vp->v_writecount != 0) {
+		vprint("vput: bad ref count", vp);
+		panic("vput: ref cnt");
+	}
+#endif
+	/*
+	 * insert at tail of LRU list
+	 */
+	simple_lock(&vnode_free_list_slock);
+	TAILQ_INSERT_TAIL(&vnode_free_list, vp, v_freelist);
+	simple_unlock(&vnode_free_list_slock);
+	simple_unlock(&vp->v_interlock);
+	VOP_INACTIVE(vp, p);
+}
+
+/*
+ * Vnode release.
+ * If count drops to zero, call inactive routine and return to freelist.
+ */
+void
+vrele(vp)
+	struct vnode *vp;
+{
+	struct proc *p = curproc;	/* XXX */
+
+#ifdef DIAGNOSTIC
+	if (vp == NULL)
+		panic("vrele: null vp");
+#endif
+	simple_lock(&vp->v_interlock);
+	vp->v_usecount--;
+	if (vp->v_usecount > 0) {
+		simple_unlock(&vp->v_interlock);
+		return;
+	}
+#ifdef DIAGNOSTIC
+	if (vp->v_usecount < 0 || vp->v_writecount != 0) {
+		vprint("vrele: bad ref count", vp);
+		panic("vrele: ref cnt");
+	}
+#endif
+	/*
+	 * insert at tail of LRU list
+	 */
+	simple_lock(&vnode_free_list_slock);
+	TAILQ_INSERT_TAIL(&vnode_free_list, vp, v_freelist);
+	simple_unlock(&vnode_free_list_slock);
+	if (vn_lock(vp, LK_EXCLUSIVE | LK_INTERLOCK, p) == 0)
+		VOP_INACTIVE(vp, p);
+}
+
+#ifdef DIAGNOSTIC
+/*
+ * Page or buffer structure gets a reference.
+ */
+void
+vhold(vp)
+	register struct vnode *vp;
+{
+
+	simple_lock(&vp->v_interlock);
+	vp->v_holdcnt++;
+	simple_unlock(&vp->v_interlock);
+}
+
+/*
+ * Page or buffer structure frees a reference.
+ */
+void
+holdrele(vp)
+	register struct vnode *vp;
+{
+
+	simple_lock(&vp->v_interlock);
+	if (vp->v_holdcnt <= 0)
+		panic("holdrele: holdcnt");
+	vp->v_holdcnt--;
+	simple_unlock(&vp->v_interlock);
+}
+#endif /* DIAGNOSTIC */
+
+/*
+ * Remove any vnodes in the vnode table belonging to mount point mp.
+ *
+ * If MNT_NOFORCE is specified, there should not be any active ones,
+ * return error if any are found (nb: this is a user error, not a
+ * system error). If MNT_FORCE is specified, detach any active vnodes
+ * that are found.
+ */
+#ifdef DIAGNOSTIC
+int busyprt = 0;	/* print out busy vnodes */
+struct ctldebug debug1 = { "busyprt", &busyprt };
+#endif
+
+int
+vflush(mp, skipvp, flags)
+	struct mount *mp;
+	struct vnode *skipvp;
+	int flags;
+{
+	struct proc *p = curproc;	/* XXX */
+	struct vnode *vp, *nvp;
+	int busy = 0;
+
+	simple_lock(&mntvnode_slock);
+loop:
+	for (vp = mp->mnt_vnodelist.lh_first; vp; vp = nvp) {
+		if (vp->v_mount != mp)
+			goto loop;
+		nvp = vp->v_mntvnodes.le_next;
+		/*
+		 * Skip over a selected vnode.
+		 */
+		if (vp == skipvp)
+			continue;
+
+		simple_lock(&vp->v_interlock);
+		/*
+		 * Skip over a vnodes marked VSYSTEM.
+		 */
+		if ((flags & SKIPSYSTEM) && (vp->v_flag & VSYSTEM)) {
+			simple_unlock(&vp->v_interlock);
+			continue;
+		}
+		/*
+		 * If WRITECLOSE is set, only flush out regular file
+		 * vnodes open for writing.
+		 */
+		if ((flags & WRITECLOSE) &&
+		    (vp->v_writecount == 0 || vp->v_type != VREG)) {
+			simple_unlock(&vp->v_interlock);
+			continue;
+		}
+		/*
+		 * With v_usecount == 0, all we need to do is clear
+		 * out the vnode data structures and we are done.
+		 */
+		if (vp->v_usecount == 0) {
+			simple_unlock(&mntvnode_slock);
+			vgonel(vp, p);
+			simple_lock(&mntvnode_slock);
+			continue;
+		}
+		/*
+		 * If FORCECLOSE is set, forcibly close the vnode.
+		 * For block or character devices, revert to an
+		 * anonymous device. For all other files, just kill them.
+		 */
+		if (flags & FORCECLOSE) {
+			simple_unlock(&mntvnode_slock);
+			if (vp->v_type != VBLK && vp->v_type != VCHR) {
+				vgonel(vp, p);
+			} else {
+				vclean(vp, 0, p);
+				vp->v_op = spec_vnodeop_p;
+				insmntque(vp, (struct mount *)0);
+			}
+			simple_lock(&mntvnode_slock);
+			continue;
+		}
+#ifdef DIAGNOSTIC
+		if (busyprt)
+			vprint("vflush: busy vnode", vp);
+#endif
+		simple_unlock(&vp->v_interlock);
+		busy++;
+	}
+	simple_unlock(&mntvnode_slock);
+	if (busy)
+		return (EBUSY);
+	return (0);
+}
+
+/*
+ * Disassociate the underlying file system from a vnode.
+ * The vnode interlock is held on entry.
+ */
+static void
+vclean(vp, flags, p)
+	struct vnode *vp;
+	int flags;
+	struct proc *p;
+{
+	int active;
+
+	/*
+	 * Check to see if the vnode is in use.
+	 * If so we have to reference it before we clean it out
+	 * so that its count cannot fall to zero and generate a
+	 * race against ourselves to recycle it.
+	 */
+	if (active = vp->v_usecount)
+		vp->v_usecount++;
+	/*
+	 * Prevent the vnode from being recycled or
+	 * brought into use while we clean it out.
+	 */
+	if (vp->v_flag & VXLOCK)
+		panic("vclean: deadlock");
+	vp->v_flag |= VXLOCK;
+	/*
+	 * Even if the count is zero, the VOP_INACTIVE routine may still
+	 * have the object locked while it cleans it out. The VOP_LOCK
+	 * ensures that the VOP_INACTIVE routine is done with its work.
+	 * For active vnodes, it ensures that no other activity can
+	 * occur while the underlying object is being cleaned out.
+	 */
+	VOP_LOCK(vp, LK_DRAIN | LK_INTERLOCK, p);
+	/*
+	 * Clean out any buffers associated with the vnode.
+	 */
+	if (flags & DOCLOSE)
+		vinvalbuf(vp, V_SAVE, NOCRED, p, 0, 0);
+	/*
+	 * If purging an active vnode, it must be closed and
+	 * deactivated before being reclaimed. Note that the
+	 * VOP_INACTIVE will unlock the vnode.
+	 */
+	if (active) {
+		if (flags & DOCLOSE)
+			VOP_CLOSE(vp, IO_NDELAY, NOCRED, p);
+		VOP_INACTIVE(vp, p);
+	} else {
+		/*
+		 * Any other processes trying to obtain this lock must first
+		 * wait for VXLOCK to clear, then call the new lock operation.
+		 */
+		VOP_UNLOCK(vp, 0, p);
+	}
+	/*
+	 * Reclaim the vnode.
+	 */
+	if (VOP_RECLAIM(vp, p))
+		panic("vclean: cannot reclaim");
+	if (active)
+		vrele(vp);
+	cache_purge(vp);
+	if (vp->v_vnlock) {
+		if ((vp->v_vnlock->lk_flags & LK_DRAINED) == 0)
+			vprint("vclean: lock not drained", vp);
+		FREE(vp->v_vnlock, M_VNODE);
+		vp->v_vnlock = NULL;
+	}
+
+	/*
+	 * Done with purge, notify sleepers of the grim news.
+	 */
+	vp->v_op = dead_vnodeop_p;
+	vp->v_tag = VT_NON;
+	vp->v_flag &= ~VXLOCK;
+	if (vp->v_flag & VXWANT) {
+		vp->v_flag &= ~VXWANT;
+		wakeup((caddr_t)vp);
+	}
+}
+
+/*
+ * Eliminate all activity associated with  the requested vnode
+ * and with all vnodes aliased to the requested vnode.
+ */
+int
+vop_revoke(ap)
+	struct vop_revoke_args /* {
+		struct vnode *a_vp;
+		int a_flags;
+	} */ *ap;
+{
+	struct vnode *vp, *vq;
+	struct proc *p = curproc;	/* XXX */
+
+#ifdef DIAGNOSTIC
+	if ((ap->a_flags & REVOKEALL) == 0)
+		panic("vop_revoke");
+#endif
+
+	vp = ap->a_vp;
+	simple_lock(&vp->v_interlock);
+
+	if (vp->v_flag & VALIASED) {
+		/*
+		 * If a vgone (or vclean) is already in progress,
+		 * wait until it is done and return.
+		 */
+		if (vp->v_flag & VXLOCK) {
+			vp->v_flag |= VXWANT;
+			simple_unlock(&vp->v_interlock);
+			tsleep((caddr_t)vp, PINOD, "vop_revokeall", 0);
+			return (0);
+		}
+		/*
+		 * Ensure that vp will not be vgone'd while we
+		 * are eliminating its aliases.
+		 */
+		vp->v_flag |= VXLOCK;
+		simple_unlock(&vp->v_interlock);
+		while (vp->v_flag & VALIASED) {
+			simple_lock(&spechash_slock);
+			for (vq = *vp->v_hashchain; vq; vq = vq->v_specnext) {
+				if (vq->v_rdev != vp->v_rdev ||
+				    vq->v_type != vp->v_type || vp == vq)
+					continue;
+				simple_unlock(&spechash_slock);
+				vgone(vq);
+				break;
+			}
+			if (vq == NULLVP)
+				simple_unlock(&spechash_slock);
+		}
+		/*
+		 * Remove the lock so that vgone below will
+		 * really eliminate the vnode after which time
+		 * vgone will awaken any sleepers.
+		 */
+		simple_lock(&vp->v_interlock);
+		vp->v_flag &= ~VXLOCK;
+	}
+	vgonel(vp, p);
+	return (0);
+}
+
+/*
+ * Recycle an unused vnode to the front of the free list.
+ * Release the passed interlock if the vnode will be recycled.
+ */
+int
+vrecycle(vp, inter_lkp, p)
+	struct vnode *vp;
+	struct simplelock *inter_lkp;
+	struct proc *p;
+{
+
+	simple_lock(&vp->v_interlock);
+	if (vp->v_usecount == 0) {
+		if (inter_lkp)
+			simple_unlock(inter_lkp);
+		vgonel(vp, p);
+		return (1);
+	}
+	simple_unlock(&vp->v_interlock);
+	return (0);
+}
+
+/*
+ * Eliminate all activity associated with a vnode
+ * in preparation for reuse.
+ */
+void
+vgone(vp)
+	struct vnode *vp;
+{
+	struct proc *p = curproc;	/* XXX */
+
+	simple_lock(&vp->v_interlock);
+	vgonel(vp, p);
+}
+
+/*
+ * vgone, with the vp interlock held.
+ */
+void
+vgonel(vp, p)
+	struct vnode *vp;
+	struct proc *p;
+{
+	struct vnode *vq;
+	struct vnode *vx;
+
+	/*
+	 * If a vgone (or vclean) is already in progress,
+	 * wait until it is done and return.
+	 */
+	if (vp->v_flag & VXLOCK) {
+		vp->v_flag |= VXWANT;
+		simple_unlock(&vp->v_interlock);
+		tsleep((caddr_t)vp, PINOD, "vgone", 0);
+		return;
+	}
+	/*
+	 * Clean out the filesystem specific data.
+	 */
+	vclean(vp, DOCLOSE, p);
+	/*
+	 * Delete from old mount point vnode list, if on one.
+	 */
+	if (vp->v_mount != NULL)
+		insmntque(vp, (struct mount *)0);
+	/*
+	 * If special device, remove it from special device alias list
+	 * if it is on one.
+	 */
+	if ((vp->v_type == VBLK || vp->v_type == VCHR) && vp->v_specinfo != 0) {
+		simple_lock(&spechash_slock);
+		if (*vp->v_hashchain == vp) {
+			*vp->v_hashchain = vp->v_specnext;
+		} else {
+			for (vq = *vp->v_hashchain; vq; vq = vq->v_specnext) {
+				if (vq->v_specnext != vp)
+					continue;
+				vq->v_specnext = vp->v_specnext;
+				break;
+			}
+			if (vq == NULL)
+				panic("missing bdev");
+		}
+		if (vp->v_flag & VALIASED) {
+			vx = NULL;
+			for (vq = *vp->v_hashchain; vq; vq = vq->v_specnext) {
+				if (vq->v_rdev != vp->v_rdev ||
+				    vq->v_type != vp->v_type)
+					continue;
+				if (vx)
+					break;
+				vx = vq;
+			}
+			if (vx == NULL)
+				panic("missing alias");
+			if (vq == NULL)
+				vx->v_flag &= ~VALIASED;
+			vp->v_flag &= ~VALIASED;
+		}
+		simple_unlock(&spechash_slock);
+		FREE(vp->v_specinfo, M_VNODE);
+		vp->v_specinfo = NULL;
+	}
+	/*
+	 * If it is on the freelist and not already at the head,
+	 * move it to the head of the list. The test of the back
+	 * pointer and the reference count of zero is because
+	 * it will be removed from the free list by getnewvnode,
+	 * but will not have its reference count incremented until
+	 * after calling vgone. If the reference count were
+	 * incremented first, vgone would (incorrectly) try to
+	 * close the previous instance of the underlying object.
+	 * So, the back pointer is explicitly set to `0xdeadb' in
+	 * getnewvnode after removing it from the freelist to ensure
+	 * that we do not try to move it here.
+	 */
+	if (vp->v_usecount == 0) {
+		simple_lock(&vnode_free_list_slock);
+		if ((vp->v_freelist.tqe_prev != (struct vnode **)0xdeadb) &&
+		    vnode_free_list.tqh_first != vp) {
+			TAILQ_REMOVE(&vnode_free_list, vp, v_freelist);
+			TAILQ_INSERT_HEAD(&vnode_free_list, vp, v_freelist);
+		}
+		simple_unlock(&vnode_free_list_slock);
+	}
+	vp->v_type = VBAD;
+}
+
+/*
+ * Lookup a vnode by device number.
+ */
+int
+vfinddev(dev, type, vpp)
+	dev_t dev;
+	enum vtype type;
+	struct vnode **vpp;
+{
+	struct vnode *vp;
+	int rc = 0;
+
+	simple_lock(&spechash_slock);
+	for (vp = speclisth[SPECHASH(dev)]; vp; vp = vp->v_specnext) {
+		if (dev != vp->v_rdev || type != vp->v_type)
+			continue;
+		*vpp = vp;
+		rc = 1;
+		break;
+	}
+	simple_unlock(&spechash_slock);
+	return (rc);
+}
+
+/*
+ * Calculate the total number of references to a special device.
+ */
+int
+vcount(vp)
+	struct vnode *vp;
+{
+	struct vnode *vq, *vnext;
+	int count;
+
+loop:
+	if ((vp->v_flag & VALIASED) == 0)
+		return (vp->v_usecount);
+	simple_lock(&spechash_slock);
+	for (count = 0, vq = *vp->v_hashchain; vq; vq = vnext) {
+		vnext = vq->v_specnext;
+		if (vq->v_rdev != vp->v_rdev || vq->v_type != vp->v_type)
+			continue;
+		/*
+		 * Alias, but not in use, so flush it out.
+		 */
+		if (vq->v_usecount == 0 && vq != vp) {
+			simple_unlock(&spechash_slock);
+			vgone(vq);
+			goto loop;
+		}
+		count += vq->v_usecount;
+	}
+	simple_unlock(&spechash_slock);
+	return (count);
+}
+
+/*
+ * Print out a description of a vnode.
+ */
+static char *typename[] =
+   { "VNON", "VREG", "VDIR", "VBLK", "VCHR", "VLNK", "VSOCK", "VFIFO", "VBAD" };
+
+void
+vprint(label, vp)
+	char *label;
+	register struct vnode *vp;
+{
+	char buf[64];
+
+	if (label != NULL)
+		printf("%s: ", label);
+	printf("type %s, usecount %d, writecount %d, refcount %d,",
+		typename[vp->v_type], vp->v_usecount, vp->v_writecount,
+		vp->v_holdcnt);
+	buf[0] = '\0';
+	if (vp->v_flag & VROOT)
+		strcat(buf, "|VROOT");
+	if (vp->v_flag & VTEXT)
+		strcat(buf, "|VTEXT");
+	if (vp->v_flag & VSYSTEM)
+		strcat(buf, "|VSYSTEM");
+	if (vp->v_flag & VXLOCK)
+		strcat(buf, "|VXLOCK");
+	if (vp->v_flag & VXWANT)
+		strcat(buf, "|VXWANT");
+	if (vp->v_flag & VBWAIT)
+		strcat(buf, "|VBWAIT");
+	if (vp->v_flag & VALIASED)
+		strcat(buf, "|VALIASED");
+	if (buf[0] != '\0')
+		printf(" flags (%s)", &buf[1]);
+	if (vp->v_data == NULL) {
+		printf("\n");
+	} else {
+		printf("\n\t");
+		VOP_PRINT(vp);
+	}
+}
+
+#ifdef DEBUG
+/*
+ * List all of the locked vnodes in the system.
+ * Called when debugging the kernel.
+ */
+void
+printlockedvnodes()
+{
+	struct proc *p = curproc;	/* XXX */
+	struct mount *mp, *nmp;
+	struct vnode *vp;
+
+	printf("Locked vnodes\n");
+	simple_lock(&mountlist_slock);
+	for (mp = mountlist.cqh_first; mp != (void *)&mountlist; mp = nmp) {
+		if (vfs_busy(mp, LK_NOWAIT, &mountlist_slock, p)) {
+			nmp = mp->mnt_list.cqe_next;
+			continue;
+		}
+		for (vp = mp->mnt_vnodelist.lh_first;
+		     vp != NULL;
+		     vp = vp->v_mntvnodes.le_next) {
+			if (VOP_ISLOCKED(vp))
+				vprint((char *)0, vp);
+		}
+		simple_lock(&mountlist_slock);
+		nmp = mp->mnt_list.cqe_next;
+		vfs_unbusy(mp, p);
+	}
+	simple_unlock(&mountlist_slock);
+}
+#endif
+
+/*
+ * Top level filesystem related information gathering.
+ */
+int
+vfs_sysctl(name, namelen, oldp, oldlenp, newp, newlen, p)
+	int *name;
+	u_int namelen;
+	void *oldp;
+	size_t *oldlenp;
+	void *newp;
+	size_t newlen;
+	struct proc *p;
+{
+	struct ctldebug *cdp;
+	struct vfsconf *vfsp;
+
+	/* all sysctl names at this level are at least name and field */
+	if (namelen < 2)
+		return (ENOTDIR);		/* overloaded */
+	if (name[0] != VFS_GENERIC) {
+		for (vfsp = vfsconf; vfsp; vfsp = vfsp->vfc_next)
+			if (vfsp->vfc_typenum == name[0])
+				break;
+		if (vfsp == NULL)
+			return (EOPNOTSUPP);
+		return ((*vfsp->vfc_vfsops->vfs_sysctl)(&name[1], namelen - 1,
+		    oldp, oldlenp, newp, newlen, p));
+	}
+	switch (name[1]) {
+	case VFS_MAXTYPENUM:
+		return (sysctl_rdint(oldp, oldlenp, newp, maxvfsconf));
+	case VFS_CONF:
+		if (namelen < 3)
+			return (ENOTDIR);	/* overloaded */
+		for (vfsp = vfsconf; vfsp; vfsp = vfsp->vfc_next)
+			if (vfsp->vfc_typenum == name[2])
+				break;
+		if (vfsp == NULL)
+			return (EOPNOTSUPP);
+		return (sysctl_rdstruct(oldp, oldlenp, newp, vfsp,
+		    sizeof(struct vfsconf)));
+	}
+	return (EOPNOTSUPP);
+}
+
+int kinfo_vdebug = 1;
+int kinfo_vgetfailed;
+#define KINFO_VNODESLOP	10
+/*
+ * Dump vnode list (via sysctl).
+ * Copyout address of vnode followed by vnode.
+ */
+/* ARGSUSED */
+int
+sysctl_vnode(where, sizep, p)
+	char *where;
+	size_t *sizep;
+	struct proc *p;
+{
+	struct mount *mp, *nmp;
+	struct vnode *nvp, *vp;
+	char *bp = where, *savebp;
+	char *ewhere;
+	int error;
+
+#define VPTRSZ	sizeof (struct vnode *)
+#define VNODESZ	sizeof (struct vnode)
+	if (where == NULL) {
+		*sizep = (numvnodes + KINFO_VNODESLOP) * (VPTRSZ + VNODESZ);
+		return (0);
+	}
+	ewhere = where + *sizep;
+		
+	simple_lock(&mountlist_slock);
+	for (mp = mountlist.cqh_first; mp != (void *)&mountlist; mp = nmp) {
+		if (vfs_busy(mp, LK_NOWAIT, &mountlist_slock, p)) {
+			nmp = mp->mnt_list.cqe_next;
+			continue;
+		}
+		savebp = bp;
+again:
+		simple_lock(&mntvnode_slock);
+		for (vp = mp->mnt_vnodelist.lh_first;
+		     vp != NULL;
+		     vp = nvp) {
+			/*
+			 * Check that the vp is still associated with
+			 * this filesystem.  RACE: could have been
+			 * recycled onto the same filesystem.
+			 */
+			if (vp->v_mount != mp) {
+				simple_unlock(&mntvnode_slock);
+				if (kinfo_vdebug)
+					printf("kinfo: vp changed\n");
+				bp = savebp;
+				goto again;
+			}
+			nvp = vp->v_mntvnodes.le_next;
+			if (bp + VPTRSZ + VNODESZ > ewhere) {
+				simple_unlock(&mntvnode_slock);
+				*sizep = bp - where;
+				return (ENOMEM);
+			}
+			simple_unlock(&mntvnode_slock);
+			if ((error = copyout((caddr_t)&vp, bp, VPTRSZ)) ||
+			   (error = copyout((caddr_t)vp, bp + VPTRSZ, VNODESZ)))
+				return (error);
+			bp += VPTRSZ + VNODESZ;
+			simple_lock(&mntvnode_slock);
+		}
+		simple_unlock(&mntvnode_slock);
+		simple_lock(&mountlist_slock);
+		nmp = mp->mnt_list.cqe_next;
+		vfs_unbusy(mp, p);
+	}
+	simple_unlock(&mountlist_slock);
+
+	*sizep = bp - where;
+	return (0);
+}
+
+/*
+ * Check to see if a filesystem is mounted on a block device.
+ */
+int
+vfs_mountedon(vp)
+	struct vnode *vp;
+{
+	struct vnode *vq;
+	int error = 0;
+
+	if (vp->v_specflags & SI_MOUNTEDON)
+		return (EBUSY);
+	if (vp->v_flag & VALIASED) {
+		simple_lock(&spechash_slock);
+		for (vq = *vp->v_hashchain; vq; vq = vq->v_specnext) {
+			if (vq->v_rdev != vp->v_rdev ||
+			    vq->v_type != vp->v_type)
+				continue;
+			if (vq->v_specflags & SI_MOUNTEDON) {
+				error = EBUSY;
+				break;
+			}
+		}
+		simple_unlock(&spechash_slock);
+	}
+	return (error);
+}
+
+/*
+ * Unmount all filesystems. The list is traversed in reverse order
+ * of mounting to avoid dependencies.
+ */
+void
+vfs_unmountall()
+{
+	struct mount *mp, *nmp;
+	struct proc *p = curproc;	/* XXX */
+
+	/*
+	 * Since this only runs when rebooting, it is not interlocked.
+	 */
+	for (mp = mountlist.cqh_last; mp != (void *)&mountlist; mp = nmp) {
+		nmp = mp->mnt_list.cqe_prev;
+		(void) dounmount(mp, MNT_FORCE, p);
+	}
+}
+
+/*
+ * Build hash lists of net addresses and hang them off the mount point.
+ * Called by ufs_mount() to set up the lists of export addresses.
+ */
+static int
+vfs_hang_addrlist(mp, nep, argp)
+	struct mount *mp;
+	struct netexport *nep;
+	struct export_args *argp;
+{
+	register struct netcred *np;
+	register struct radix_node_head *rnh;
+	register int i;
+	struct radix_node *rn;
+	struct sockaddr *saddr, *smask = 0;
+	struct domain *dom;
+	int error;
+
+	if (argp->ex_addrlen == 0) {
+		if (mp->mnt_flag & MNT_DEFEXPORTED)
+			return (EPERM);
+		np = &nep->ne_defexported;
+		np->netc_exflags = argp->ex_flags;
+		np->netc_anon = argp->ex_anon;
+		np->netc_anon.cr_ref = 1;
+		mp->mnt_flag |= MNT_DEFEXPORTED;
+		return (0);
+	}
+	i = sizeof(struct netcred) + argp->ex_addrlen + argp->ex_masklen;
+	np = (struct netcred *)malloc(i, M_NETADDR, M_WAITOK);
+	bzero((caddr_t)np, i);
+	saddr = (struct sockaddr *)(np + 1);
+	if (error = copyin(argp->ex_addr, (caddr_t)saddr, argp->ex_addrlen))
+		goto out;
+	if (saddr->sa_len > argp->ex_addrlen)
+		saddr->sa_len = argp->ex_addrlen;
+	if (argp->ex_masklen) {
+		smask = (struct sockaddr *)((caddr_t)saddr + argp->ex_addrlen);
+		error = copyin(argp->ex_addr, (caddr_t)smask, argp->ex_masklen);
+		if (error)
+			goto out;
+		if (smask->sa_len > argp->ex_masklen)
+			smask->sa_len = argp->ex_masklen;
+	}
+	i = saddr->sa_family;
+	if ((rnh = nep->ne_rtable[i]) == 0) {
+		/*
+		 * Seems silly to initialize every AF when most are not
+		 * used, do so on demand here
+		 */
+		for (dom = domains; dom; dom = dom->dom_next)
+			if (dom->dom_family == i && dom->dom_rtattach) {
+				dom->dom_rtattach((void **)&nep->ne_rtable[i],
+					dom->dom_rtoffset);
+				break;
+			}
+		if ((rnh = nep->ne_rtable[i]) == 0) {
+			error = ENOBUFS;
+			goto out;
+		}
+	}
+	rn = (*rnh->rnh_addaddr)((caddr_t)saddr, (caddr_t)smask, rnh,
+		np->netc_rnodes);
+	if (rn == 0) {
+		/*
+		 * One of the reasons that rnh_addaddr may fail is that
+		 * the entry already exists. To check for this case, we
+		 * look up the entry to see if it is there. If so, we
+		 * do not need to make a new entry but do return success.
+		 */
+		free(np, M_NETADDR);
+		rn = (*rnh->rnh_matchaddr)((caddr_t)saddr, rnh);
+		if (rn != 0 && (rn->rn_flags & RNF_ROOT) == 0 &&
+		    ((struct netcred *)rn)->netc_exflags == argp->ex_flags &&
+		    !bcmp((caddr_t)&((struct netcred *)rn)->netc_anon,
+			    (caddr_t)&argp->ex_anon, sizeof(struct ucred)))
+			return (0);
+		return (EPERM);
+	}
+	np->netc_exflags = argp->ex_flags;
+	np->netc_anon = argp->ex_anon;
+	np->netc_anon.cr_ref = 1;
+	return (0);
+out:
+	free(np, M_NETADDR);
+	return (error);
+}
+
+/* ARGSUSED */
+static int
+vfs_free_netcred(rn, w)
+	struct radix_node *rn;
+	caddr_t w;
+{
+	register struct radix_node_head *rnh = (struct radix_node_head *)w;
+
+	(*rnh->rnh_deladdr)(rn->rn_key, rn->rn_mask, rnh);
+	free((caddr_t)rn, M_NETADDR);
+	return (0);
+}
+
+/*
+ * Free the net address hash lists that are hanging off the mount points.
+ */
+static void
+vfs_free_addrlist(nep)
+	struct netexport *nep;
+{
+	register int i;
+	register struct radix_node_head *rnh;
+
+	for (i = 0; i <= AF_MAX; i++)
+		if (rnh = nep->ne_rtable[i]) {
+			(*rnh->rnh_walktree)(rnh, vfs_free_netcred,
+			    (caddr_t)rnh);
+			free((caddr_t)rnh, M_RTABLE);
+			nep->ne_rtable[i] = 0;
+		}
+}
+
+int
+vfs_export(mp, nep, argp)
+	struct mount *mp;
+	struct netexport *nep;
+	struct export_args *argp;
+{
+	int error;
+
+	if (argp->ex_flags & MNT_DELEXPORT) {
+		vfs_free_addrlist(nep);
+		mp->mnt_flag &= ~(MNT_EXPORTED | MNT_DEFEXPORTED);
+	}
+	if (argp->ex_flags & MNT_EXPORTED) {
+		if (error = vfs_hang_addrlist(mp, nep, argp))
+			return (error);
+		mp->mnt_flag |= MNT_EXPORTED;
+	}
+	return (0);
+}
+
+struct netcred *
+vfs_export_lookup(mp, nep, nam)
+	register struct mount *mp;
+	struct netexport *nep;
+	struct mbuf *nam;
+{
+	register struct netcred *np;
+	register struct radix_node_head *rnh;
+	struct sockaddr *saddr;
+
+	np = NULL;
+	if (mp->mnt_flag & MNT_EXPORTED) {
+		/*
+		 * Lookup in the export list first.
+		 */
+		if (nam != NULL) {
+			saddr = mtod(nam, struct sockaddr *);
+			rnh = nep->ne_rtable[saddr->sa_family];
+			if (rnh != NULL) {
+				np = (struct netcred *)
+					(*rnh->rnh_matchaddr)((caddr_t)saddr,
+							      rnh);
+				if (np && np->netc_rnodes->rn_flags & RNF_ROOT)
+					np = NULL;
+			}
+		}
+		/*
+		 * If no address match, use the default if it exists.
+		 */
+		if (np == NULL && mp->mnt_flag & MNT_DEFEXPORTED)
+			np = &nep->ne_defexported;
+	}
+	return (np);
+}

--- a/src-uland/fs-server/vfs_syscalls.c
+++ b/src-uland/fs-server/vfs_syscalls.c
@@ -1,0 +1,2418 @@
+/* Copied from sys/kern/vfs_syscalls.c */
+/*
+ * Copyright (c) 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vfs_syscalls.c	8.41 (Berkeley) 6/15/95
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/namei.h>
+#include <sys/filedesc.h>
+#include <sys/kernel.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/vnode.h>
+#include <sys/mount.h>
+#include <sys/proc.h>
+#include <sys/uio.h>
+#include <sys/malloc.h>
+#include <sys/dirent.h>
+
+#include <sys/syscallargs.h>
+
+#include <vm/vm.h>
+#include <sys/sysctl.h>
+
+static int change_dir __P((struct nameidata *ndp, struct proc *p));
+static void checkdirs __P((struct vnode *olddp));
+
+/*
+ * Virtual File System System Calls
+ */
+
+/*
+ * Mount a file system.
+ */
+/* ARGSUSED */
+int
+mount(p, uap, retval)
+	struct proc *p;
+	register struct mount_args /* {
+		syscallarg(char *) type;
+		syscallarg(char *) path;
+		syscallarg(int) flags;
+		syscallarg(caddr_t) data;
+	} */ *uap;
+	register_t *retval;
+{
+	struct vnode *vp;
+	struct mount *mp;
+	struct vfsconf *vfsp;
+	int error, flag;
+	struct vattr va;
+	u_long fstypenum;
+	struct nameidata nd;
+	char fstypename[MFSNAMELEN];
+
+	/*
+	 * Get vnode to be covered
+	 */
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	if (SCARG(uap, flags) & MNT_UPDATE) {
+		if ((vp->v_flag & VROOT) == 0) {
+			vput(vp);
+			return (EINVAL);
+		}
+		mp = vp->v_mount;
+		flag = mp->mnt_flag;
+		/*
+		 * We only allow the filesystem to be reloaded if it
+		 * is currently mounted read-only.
+		 */
+		if ((SCARG(uap, flags) & MNT_RELOAD) &&
+		    ((mp->mnt_flag & MNT_RDONLY) == 0)) {
+			vput(vp);
+			return (EOPNOTSUPP);	/* Needs translation */
+		}
+		mp->mnt_flag |=
+		    SCARG(uap, flags) & (MNT_RELOAD | MNT_FORCE | MNT_UPDATE);
+		/*
+		 * Only root, or the user that did the original mount is
+		 * permitted to update it.
+		 */
+		if (mp->mnt_stat.f_owner != p->p_ucred->cr_uid &&
+		    (error = suser(p->p_ucred, &p->p_acflag))) {
+			vput(vp);
+			return (error);
+		}
+		/*
+		 * Do not allow NFS export by non-root users. Silently
+		 * enforce MNT_NOSUID and MNT_NODEV for non-root users.
+		 */
+		if (p->p_ucred->cr_uid != 0) {
+			if (SCARG(uap, flags) & MNT_EXPORTED) {
+				vput(vp);
+				return (EPERM);
+			}
+			SCARG(uap, flags) |= MNT_NOSUID | MNT_NODEV;
+		}
+		if (vfs_busy(mp, LK_NOWAIT, 0, p)) {
+			vput(vp);
+			return (EBUSY);
+		}
+		VOP_UNLOCK(vp, 0, p);
+		goto update;
+	}
+	/*
+	 * If the user is not root, ensure that they own the directory
+	 * onto which we are attempting to mount.
+	 */
+	if ((error = VOP_GETATTR(vp, &va, p->p_ucred, p)) ||
+	    (va.va_uid != p->p_ucred->cr_uid &&
+	     (error = suser(p->p_ucred, &p->p_acflag)))) {
+		vput(vp);
+		return (error);
+	}
+	/*
+	 * Do not allow NFS export by non-root users. Silently
+	 * enforce MNT_NOSUID and MNT_NODEV for non-root users.
+	 */
+	if (p->p_ucred->cr_uid != 0) {
+		if (SCARG(uap, flags) & MNT_EXPORTED) {
+			vput(vp);
+			return (EPERM);
+		}
+		SCARG(uap, flags) |= MNT_NOSUID | MNT_NODEV;
+	}
+	if (error = vinvalbuf(vp, V_SAVE, p->p_ucred, p, 0, 0))
+		return (error);
+	if (vp->v_type != VDIR) {
+		vput(vp);
+		return (ENOTDIR);
+	}
+#ifdef COMPAT_43
+	/*
+	 * Historically filesystem types were identified by number. If we
+	 * get an integer for the filesystem type instead of a string, we
+	 * check to see if it matches one of the historic filesystem types.
+	 */
+	fstypenum = (u_long)SCARG(uap, type);
+	if (fstypenum < maxvfsconf) {
+		for (vfsp = vfsconf; vfsp; vfsp = vfsp->vfc_next)
+			if (vfsp->vfc_typenum == fstypenum)
+				break;
+		if (vfsp == NULL) {
+			vput(vp);
+			return (ENODEV);
+		}
+		strncpy(fstypename, vfsp->vfc_name, MFSNAMELEN);
+	} else
+#endif /* COMPAT_43 */
+	if (error = copyinstr(SCARG(uap, type), fstypename, MFSNAMELEN, NULL)) {
+		vput(vp);
+		return (error);
+	}
+	for (vfsp = vfsconf; vfsp; vfsp = vfsp->vfc_next)
+		if (!strcmp(vfsp->vfc_name, fstypename))
+			break;
+	if (vfsp == NULL) {
+		vput(vp);
+		return (ENODEV);
+	}
+	if (vp->v_mountedhere != NULL) {
+		vput(vp);
+		return (EBUSY);
+	}
+
+	/*
+	 * Allocate and initialize the filesystem.
+	 */
+	mp = (struct mount *)malloc((u_long)sizeof(struct mount),
+		M_MOUNT, M_WAITOK);
+	bzero((char *)mp, (u_long)sizeof(struct mount));
+	lockinit(&mp->mnt_lock, PVFS, "vfslock", 0, 0);
+	(void)vfs_busy(mp, LK_NOWAIT, 0, p);
+	mp->mnt_op = vfsp->vfc_vfsops;
+	mp->mnt_vfc = vfsp;
+	vfsp->vfc_refcount++;
+	mp->mnt_stat.f_type = vfsp->vfc_typenum;
+	mp->mnt_flag |= vfsp->vfc_flags & MNT_VISFLAGMASK;
+	strncpy(mp->mnt_stat.f_fstypename, vfsp->vfc_name, MFSNAMELEN);
+	vp->v_mountedhere = mp;
+	mp->mnt_vnodecovered = vp;
+	mp->mnt_stat.f_owner = p->p_ucred->cr_uid;
+update:
+	/*
+	 * Set the mount level flags.
+	 */
+	if (SCARG(uap, flags) & MNT_RDONLY)
+		mp->mnt_flag |= MNT_RDONLY;
+	else if (mp->mnt_flag & MNT_RDONLY)
+		mp->mnt_flag |= MNT_WANTRDWR;
+	mp->mnt_flag &=~ (MNT_NOSUID | MNT_NOEXEC | MNT_NODEV |
+	    MNT_SYNCHRONOUS | MNT_UNION | MNT_ASYNC);
+	mp->mnt_flag |= SCARG(uap, flags) & (MNT_NOSUID | MNT_NOEXEC |
+	    MNT_NODEV | MNT_SYNCHRONOUS | MNT_UNION | MNT_ASYNC);
+	/*
+	 * Mount the filesystem.
+	 */
+	error = VFS_MOUNT(mp, SCARG(uap, path), SCARG(uap, data), &nd, p);
+	if (mp->mnt_flag & MNT_UPDATE) {
+		vrele(vp);
+		if (mp->mnt_flag & MNT_WANTRDWR)
+			mp->mnt_flag &= ~MNT_RDONLY;
+		mp->mnt_flag &=~
+		    (MNT_UPDATE | MNT_RELOAD | MNT_FORCE | MNT_WANTRDWR);
+		if (error)
+			mp->mnt_flag = flag;
+		vfs_unbusy(mp, p);
+		return (error);
+	}
+	/*
+	 * Put the new filesystem on the mount list after root.
+	 */
+	cache_purge(vp);
+	if (!error) {
+		simple_lock(&mountlist_slock);
+		CIRCLEQ_INSERT_TAIL(&mountlist, mp, mnt_list);
+		simple_unlock(&mountlist_slock);
+		checkdirs(vp);
+		VOP_UNLOCK(vp, 0, p);
+		vfs_unbusy(mp, p);
+		if (error = VFS_START(mp, 0, p))
+			vrele(vp);
+	} else {
+		mp->mnt_vnodecovered->v_mountedhere = (struct mount *)0;
+		mp->mnt_vfc->vfc_refcount--;
+		vfs_unbusy(mp, p);
+		free((caddr_t)mp, M_MOUNT);
+		vput(vp);
+	}
+	return (error);
+}
+
+/*
+ * Scan all active processes to see if any of them have a current
+ * or root directory onto which the new filesystem has just been
+ * mounted. If so, replace them with the new mount point.
+ */
+static void
+checkdirs(olddp)
+	struct vnode *olddp;
+{
+	struct filedesc *fdp;
+	struct vnode *newdp;
+	struct proc *p;
+
+	if (olddp->v_usecount == 1)
+		return;
+	if (VFS_ROOT(olddp->v_mountedhere, &newdp))
+		panic("mount: lost mount");
+	for (p = allproc.lh_first; p != 0; p = p->p_list.le_next) {
+		fdp = p->p_fd;
+		if (fdp->fd_cdir == olddp) {
+			vrele(fdp->fd_cdir);
+			VREF(newdp);
+			fdp->fd_cdir = newdp;
+		}
+		if (fdp->fd_rdir == olddp) {
+			vrele(fdp->fd_rdir);
+			VREF(newdp);
+			fdp->fd_rdir = newdp;
+		}
+	}
+	if (rootvnode == olddp) {
+		vrele(rootvnode);
+		VREF(newdp);
+		rootvnode = newdp;
+	}
+	vput(newdp);
+}
+
+/*
+ * Unmount a file system.
+ *
+ * Note: unmount takes a path to the vnode mounted on as argument,
+ * not special file (as before).
+ */
+/* ARGSUSED */
+int
+unmount(p, uap, retval)
+	struct proc *p;
+	register struct unmount_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) flags;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct mount *mp;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	mp = vp->v_mount;
+
+	/*
+	 * Only root, or the user that did the original mount is
+	 * permitted to unmount this filesystem.
+	 */
+	if ((mp->mnt_stat.f_owner != p->p_ucred->cr_uid) &&
+	    (error = suser(p->p_ucred, &p->p_acflag))) {
+		vput(vp);
+		return (error);
+	}
+
+	/*
+	 * Don't allow unmounting the root file system.
+	 */
+	if (mp->mnt_flag & MNT_ROOTFS) {
+		vput(vp);
+		return (EINVAL);
+	}
+
+	/*
+	 * Must be the root of the filesystem
+	 */
+	if ((vp->v_flag & VROOT) == 0) {
+		vput(vp);
+		return (EINVAL);
+	}
+	vput(vp);
+	return (dounmount(mp, SCARG(uap, flags), p));
+}
+
+/*
+ * Do the actual file system unmount.
+ */
+int
+dounmount(mp, flags, p)
+	register struct mount *mp;
+	int flags;
+	struct proc *p;
+{
+	struct vnode *coveredvp;
+	int error;
+
+	simple_lock(&mountlist_slock);
+	mp->mnt_flag |= MNT_UNMOUNT;
+	lockmgr(&mp->mnt_lock, LK_DRAIN | LK_INTERLOCK, &mountlist_slock, p);
+	mp->mnt_flag &=~ MNT_ASYNC;
+	vnode_pager_umount(mp);	/* release cached vnodes */
+	cache_purgevfs(mp);	/* remove cache entries for this file sys */
+	if (((mp->mnt_flag & MNT_RDONLY) ||
+	     (error = VFS_SYNC(mp, MNT_WAIT, p->p_ucred, p)) == 0) ||
+	    (flags & MNT_FORCE))
+		error = VFS_UNMOUNT(mp, flags, p);
+	simple_lock(&mountlist_slock);
+	if (error) {
+		mp->mnt_flag &= ~MNT_UNMOUNT;
+		lockmgr(&mp->mnt_lock, LK_RELEASE | LK_INTERLOCK | LK_REENABLE,
+		    &mountlist_slock, p);
+		return (error);
+	}
+	CIRCLEQ_REMOVE(&mountlist, mp, mnt_list);
+	if ((coveredvp = mp->mnt_vnodecovered) != NULLVP) {
+		coveredvp->v_mountedhere = (struct mount *)0;
+		vrele(coveredvp);
+	}
+	mp->mnt_vfc->vfc_refcount--;
+	if (mp->mnt_vnodelist.lh_first != NULL)
+		panic("unmount: dangling vnode");
+	lockmgr(&mp->mnt_lock, LK_RELEASE | LK_INTERLOCK, &mountlist_slock, p);
+	if (mp->mnt_flag & MNT_MWAIT)
+		wakeup((caddr_t)mp);
+	free((caddr_t)mp, M_MOUNT);
+	return (0);
+}
+
+/*
+ * Sync each mounted filesystem.
+ */
+#ifdef DEBUG
+int syncprt = 0;
+struct ctldebug debug0 = { "syncprt", &syncprt };
+#endif
+
+/* ARGSUSED */
+int
+sync(p, uap, retval)
+	struct proc *p;
+	void *uap;
+	register_t *retval;
+{
+	register struct mount *mp, *nmp;
+	int asyncflag;
+
+	simple_lock(&mountlist_slock);
+	for (mp = mountlist.cqh_first; mp != (void *)&mountlist; mp = nmp) {
+		if (vfs_busy(mp, LK_NOWAIT, &mountlist_slock, p)) {
+			nmp = mp->mnt_list.cqe_next;
+			continue;
+		}
+		if ((mp->mnt_flag & MNT_RDONLY) == 0) {
+			asyncflag = mp->mnt_flag & MNT_ASYNC;
+			mp->mnt_flag &= ~MNT_ASYNC;
+			VFS_SYNC(mp, MNT_NOWAIT, p->p_ucred, p);
+			if (asyncflag)
+				mp->mnt_flag |= MNT_ASYNC;
+		}
+		simple_lock(&mountlist_slock);
+		nmp = mp->mnt_list.cqe_next;
+		vfs_unbusy(mp, p);
+	}
+	simple_unlock(&mountlist_slock);
+#ifdef DIAGNOSTIC
+	if (syncprt)
+		vfs_bufstats();
+#endif /* DIAGNOSTIC */
+	return (0);
+}
+
+/*
+ * Change filesystem quotas.
+ */
+/* ARGSUSED */
+int
+quotactl(p, uap, retval)
+	struct proc *p;
+	register struct quotactl_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) cmd;
+		syscallarg(int) uid;
+		syscallarg(caddr_t) arg;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct mount *mp;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	mp = nd.ni_vp->v_mount;
+	vrele(nd.ni_vp);
+	return (VFS_QUOTACTL(mp, SCARG(uap, cmd), SCARG(uap, uid),
+	    SCARG(uap, arg), p));
+}
+
+/*
+ * Get filesystem statistics.
+ */
+/* ARGSUSED */
+int
+statfs(p, uap, retval)
+	struct proc *p;
+	register struct statfs_args /* {
+		syscallarg(char *) path;
+		syscallarg(struct statfs *) buf;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct mount *mp;
+	register struct statfs *sp;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	mp = nd.ni_vp->v_mount;
+	sp = &mp->mnt_stat;
+	vrele(nd.ni_vp);
+	if (error = VFS_STATFS(mp, sp, p))
+		return (error);
+	sp->f_flags = mp->mnt_flag & MNT_VISFLAGMASK;
+	return (copyout((caddr_t)sp, (caddr_t)SCARG(uap, buf), sizeof(*sp)));
+}
+
+/*
+ * Get filesystem statistics.
+ */
+/* ARGSUSED */
+int
+fstatfs(p, uap, retval)
+	struct proc *p;
+	register struct fstatfs_args /* {
+		syscallarg(int) fd;
+		syscallarg(struct statfs *) buf;
+	} */ *uap;
+	register_t *retval;
+{
+	struct file *fp;
+	struct mount *mp;
+	register struct statfs *sp;
+	int error;
+
+	if (error = getvnode(p->p_fd, SCARG(uap, fd), &fp))
+		return (error);
+	mp = ((struct vnode *)fp->f_data)->v_mount;
+	sp = &mp->mnt_stat;
+	if (error = VFS_STATFS(mp, sp, p))
+		return (error);
+	sp->f_flags = mp->mnt_flag & MNT_VISFLAGMASK;
+	return (copyout((caddr_t)sp, (caddr_t)SCARG(uap, buf), sizeof(*sp)));
+}
+
+/*
+ * Get statistics on all filesystems.
+ */
+int
+getfsstat(p, uap, retval)
+	struct proc *p;
+	register struct getfsstat_args /* {
+		syscallarg(struct statfs *) buf;
+		syscallarg(long) bufsize;
+		syscallarg(int) flags;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct mount *mp, *nmp;
+	register struct statfs *sp;
+	caddr_t sfsp;
+	long count, maxcount, error;
+
+	maxcount = SCARG(uap, bufsize) / sizeof(struct statfs);
+	sfsp = (caddr_t)SCARG(uap, buf);
+	count = 0;
+	simple_lock(&mountlist_slock);
+	for (mp = mountlist.cqh_first; mp != (void *)&mountlist; mp = nmp) {
+		if (vfs_busy(mp, LK_NOWAIT, &mountlist_slock, p)) {
+			nmp = mp->mnt_list.cqe_next;
+			continue;
+		}
+		if (sfsp && count < maxcount) {
+			sp = &mp->mnt_stat;
+			/*
+			 * If MNT_NOWAIT is specified, do not refresh the
+			 * fsstat cache. MNT_WAIT overrides MNT_NOWAIT.
+			 */
+			if (((SCARG(uap, flags) & MNT_NOWAIT) == 0 ||
+			    (SCARG(uap, flags) & MNT_WAIT)) &&
+			    (error = VFS_STATFS(mp, sp, p))) {
+				simple_lock(&mountlist_slock);
+				nmp = mp->mnt_list.cqe_next;
+				vfs_unbusy(mp, p);
+				continue;
+			}
+			sp->f_flags = mp->mnt_flag & MNT_VISFLAGMASK;
+			if (error = copyout((caddr_t)sp, sfsp, sizeof(*sp)))
+				return (error);
+			sfsp += sizeof(*sp);
+		}
+		count++;
+		simple_lock(&mountlist_slock);
+		nmp = mp->mnt_list.cqe_next;
+		vfs_unbusy(mp, p);
+	}
+	simple_unlock(&mountlist_slock);
+	if (sfsp && count > maxcount)
+		*retval = maxcount;
+	else
+		*retval = count;
+	return (0);
+}
+
+/*
+ * Change current working directory to a given file descriptor.
+ */
+/* ARGSUSED */
+int
+fchdir(p, uap, retval)
+	struct proc *p;
+	struct fchdir_args /* {
+		syscallarg(int) fd;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct filedesc *fdp = p->p_fd;
+	struct vnode *vp, *tdp;
+	struct mount *mp;
+	struct file *fp;
+	int error;
+
+	if (error = getvnode(fdp, SCARG(uap, fd), &fp))
+		return (error);
+	vp = (struct vnode *)fp->f_data;
+	VREF(vp);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	if (vp->v_type != VDIR)
+		error = ENOTDIR;
+	else
+		error = VOP_ACCESS(vp, VEXEC, p->p_ucred, p);
+	while (!error && (mp = vp->v_mountedhere) != NULL) {
+		if (vfs_busy(mp, 0, 0, p))
+			continue;
+		error = VFS_ROOT(mp, &tdp);
+		vfs_unbusy(mp, p);
+		if (error)
+			break;
+		vput(vp);
+		vp = tdp;
+	}
+	if (error) {
+		vput(vp);
+		return (error);
+	}
+	VOP_UNLOCK(vp, 0, p);
+	vrele(fdp->fd_cdir);
+	fdp->fd_cdir = vp;
+	return (0);
+}
+
+/*
+ * Change current working directory (``.'').
+ */
+/* ARGSUSED */
+int
+chdir(p, uap, retval)
+	struct proc *p;
+	struct chdir_args /* {
+		syscallarg(char *) path;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct filedesc *fdp = p->p_fd;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = change_dir(&nd, p))
+		return (error);
+	vrele(fdp->fd_cdir);
+	fdp->fd_cdir = nd.ni_vp;
+	return (0);
+}
+
+/*
+ * Change notion of root (``/'') directory.
+ */
+/* ARGSUSED */
+int
+chroot(p, uap, retval)
+	struct proc *p;
+	struct chroot_args /* {
+		syscallarg(char *) path;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct filedesc *fdp = p->p_fd;
+	int error;
+	struct nameidata nd;
+
+	if (error = suser(p->p_ucred, &p->p_acflag))
+		return (error);
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = change_dir(&nd, p))
+		return (error);
+	if (fdp->fd_rdir != NULL)
+		vrele(fdp->fd_rdir);
+	fdp->fd_rdir = nd.ni_vp;
+	return (0);
+}
+
+/*
+ * Common routine for chroot and chdir.
+ */
+static int
+change_dir(ndp, p)
+	register struct nameidata *ndp;
+	struct proc *p;
+{
+	struct vnode *vp;
+	int error;
+
+	if (error = namei(ndp))
+		return (error);
+	vp = ndp->ni_vp;
+	if (vp->v_type != VDIR)
+		error = ENOTDIR;
+	else
+		error = VOP_ACCESS(vp, VEXEC, p->p_ucred, p);
+	if (error)
+		vput(vp);
+	else
+		VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+/*
+ * Check permissions, allocate an open file structure,
+ * and call the device open routine if any.
+ */
+int
+open(p, uap, retval)
+	struct proc *p;
+	register struct open_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) flags;
+		syscallarg(int) mode;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct filedesc *fdp = p->p_fd;
+	register struct file *fp;
+	register struct vnode *vp;
+	int flags, cmode;
+	struct file *nfp;
+	int type, indx, error;
+	struct flock lf;
+	struct nameidata nd;
+	extern struct fileops vnops;
+
+	if (error = falloc(p, &nfp, &indx))
+		return (error);
+	fp = nfp;
+	flags = FFLAGS(SCARG(uap, flags));
+	cmode = ((SCARG(uap, mode) &~ fdp->fd_cmask) & ALLPERMS) &~ S_ISTXT;
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	p->p_dupfd = -indx - 1;			/* XXX check for fdopen */
+	if (error = vn_open(&nd, flags, cmode)) {
+		ffree(fp);
+		if ((error == ENODEV || error == ENXIO) &&
+		    p->p_dupfd >= 0 &&			/* XXX from fdopen */
+		    (error =
+			dupfdopen(fdp, indx, p->p_dupfd, flags, error)) == 0) {
+			*retval = indx;
+			return (0);
+		}
+		if (error == ERESTART)
+			error = EINTR;
+		fdp->fd_ofiles[indx] = NULL;
+		return (error);
+	}
+	p->p_dupfd = 0;
+	vp = nd.ni_vp;
+	fp->f_flag = flags & FMASK;
+	fp->f_type = DTYPE_VNODE;
+	fp->f_ops = &vnops;
+	fp->f_data = (caddr_t)vp;
+	if (flags & (O_EXLOCK | O_SHLOCK)) {
+		lf.l_whence = SEEK_SET;
+		lf.l_start = 0;
+		lf.l_len = 0;
+		if (flags & O_EXLOCK)
+			lf.l_type = F_WRLCK;
+		else
+			lf.l_type = F_RDLCK;
+		type = F_FLOCK;
+		if ((flags & FNONBLOCK) == 0)
+			type |= F_WAIT;
+		VOP_UNLOCK(vp, 0, p);
+		if (error = VOP_ADVLOCK(vp, (caddr_t)fp, F_SETLK, &lf, type)) {
+			(void) vn_close(vp, fp->f_flag, fp->f_cred, p);
+			ffree(fp);
+			fdp->fd_ofiles[indx] = NULL;
+			return (error);
+		}
+		vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+		fp->f_flag |= FHASLOCK;
+	}
+	VOP_UNLOCK(vp, 0, p);
+	*retval = indx;
+	return (0);
+}
+
+#ifdef COMPAT_43
+/*
+ * Create a file.
+ */
+int
+compat_43_creat(p, uap, retval)
+	struct proc *p;
+	register struct compat_43_creat_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) mode;
+	} */ *uap;
+	register_t *retval;
+{
+	struct open_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) flags;
+		syscallarg(int) mode;
+	} */ nuap;
+
+	SCARG(&nuap, path) = SCARG(uap, path);
+	SCARG(&nuap, mode) = SCARG(uap, mode);
+	SCARG(&nuap, flags) = O_WRONLY | O_CREAT | O_TRUNC;
+	return (open(p, &nuap, retval));
+}
+#endif /* COMPAT_43 */
+
+/*
+ * Create a special file.
+ */
+/* ARGSUSED */
+int
+mknod(p, uap, retval)
+	struct proc *p;
+	register struct mknod_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) mode;
+		syscallarg(int) dev;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct vattr vattr;
+	int error;
+	int whiteout;
+	struct nameidata nd;
+
+	if (error = suser(p->p_ucred, &p->p_acflag))
+		return (error);
+	NDINIT(&nd, CREATE, LOCKPARENT, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	if (vp != NULL)
+		error = EEXIST;
+	else {
+		VATTR_NULL(&vattr);
+		vattr.va_mode = (SCARG(uap, mode) & ALLPERMS) &~ p->p_fd->fd_cmask;
+		vattr.va_rdev = SCARG(uap, dev);
+		whiteout = 0;
+
+		switch (SCARG(uap, mode) & S_IFMT) {
+		case S_IFMT:	/* used by badsect to flag bad sectors */
+			vattr.va_type = VBAD;
+			break;
+		case S_IFCHR:
+			vattr.va_type = VCHR;
+			break;
+		case S_IFBLK:
+			vattr.va_type = VBLK;
+			break;
+		case S_IFWHT:
+			whiteout = 1;
+			break;
+		default:
+			error = EINVAL;
+			break;
+		}
+	}
+	if (!error) {
+		VOP_LEASE(nd.ni_dvp, p, p->p_ucred, LEASE_WRITE);
+		if (whiteout) {
+			error = VOP_WHITEOUT(nd.ni_dvp, &nd.ni_cnd, CREATE);
+			if (error)
+				VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+			vput(nd.ni_dvp);
+		} else {
+			error = VOP_MKNOD(nd.ni_dvp, &nd.ni_vp,
+						&nd.ni_cnd, &vattr);
+		}
+	} else {
+		VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+		if (nd.ni_dvp == vp)
+			vrele(nd.ni_dvp);
+		else
+			vput(nd.ni_dvp);
+		if (vp)
+			vrele(vp);
+	}
+	return (error);
+}
+
+/*
+ * Create a named pipe.
+ */
+/* ARGSUSED */
+int
+mkfifo(p, uap, retval)
+	struct proc *p;
+	register struct mkfifo_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) mode;
+	} */ *uap;
+	register_t *retval;
+{
+	struct vattr vattr;
+	int error;
+	struct nameidata nd;
+
+#ifndef FIFO
+	return (EOPNOTSUPP);
+#else
+	NDINIT(&nd, CREATE, LOCKPARENT, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	if (nd.ni_vp != NULL) {
+		VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+		if (nd.ni_dvp == nd.ni_vp)
+			vrele(nd.ni_dvp);
+		else
+			vput(nd.ni_dvp);
+		vrele(nd.ni_vp);
+		return (EEXIST);
+	}
+	VATTR_NULL(&vattr);
+	vattr.va_type = VFIFO;
+	vattr.va_mode = (SCARG(uap, mode) & ALLPERMS) &~ p->p_fd->fd_cmask;
+	VOP_LEASE(nd.ni_dvp, p, p->p_ucred, LEASE_WRITE);
+	return (VOP_MKNOD(nd.ni_dvp, &nd.ni_vp, &nd.ni_cnd, &vattr));
+#endif /* FIFO */
+}
+
+/*
+ * Make a hard file link.
+ */
+/* ARGSUSED */
+int
+link(p, uap, retval)
+	struct proc *p;
+	register struct link_args /* {
+		syscallarg(char *) path;
+		syscallarg(char *) link;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct nameidata nd;
+	int error;
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	if (vp->v_type != VDIR ||
+	    (error = suser(p->p_ucred, &p->p_acflag)) == 0) {
+		nd.ni_cnd.cn_nameiop = CREATE;
+		nd.ni_cnd.cn_flags = LOCKPARENT;
+		nd.ni_dirp = SCARG(uap, link);
+		if ((error = namei(&nd)) == 0) {
+			if (nd.ni_vp != NULL)
+				error = EEXIST;
+			if (!error) {
+				VOP_LEASE(nd.ni_dvp, p, p->p_ucred,
+				    LEASE_WRITE);
+				VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+				error = VOP_LINK(vp, nd.ni_dvp, &nd.ni_cnd);
+			} else {
+				VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+				if (nd.ni_dvp == nd.ni_vp)
+					vrele(nd.ni_dvp);
+				else
+					vput(nd.ni_dvp);
+				if (nd.ni_vp)
+					vrele(nd.ni_vp);
+			}
+		}
+	}
+	vrele(vp);
+	return (error);
+}
+
+/*
+ * Make a symbolic link.
+ */
+/* ARGSUSED */
+int
+symlink(p, uap, retval)
+	struct proc *p;
+	register struct symlink_args /* {
+		syscallarg(char *) path;
+		syscallarg(char *) link;
+	} */ *uap;
+	register_t *retval;
+{
+	struct vattr vattr;
+	char *path;
+	int error;
+	struct nameidata nd;
+
+	MALLOC(path, char *, MAXPATHLEN, M_NAMEI, M_WAITOK);
+	if (error = copyinstr(SCARG(uap, path), path, MAXPATHLEN, NULL))
+		goto out;
+	NDINIT(&nd, CREATE, LOCKPARENT, UIO_USERSPACE, SCARG(uap, link), p);
+	if (error = namei(&nd))
+		goto out;
+	if (nd.ni_vp) {
+		VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+		if (nd.ni_dvp == nd.ni_vp)
+			vrele(nd.ni_dvp);
+		else
+			vput(nd.ni_dvp);
+		vrele(nd.ni_vp);
+		error = EEXIST;
+		goto out;
+	}
+	VATTR_NULL(&vattr);
+	vattr.va_mode = ACCESSPERMS &~ p->p_fd->fd_cmask;
+	VOP_LEASE(nd.ni_dvp, p, p->p_ucred, LEASE_WRITE);
+	error = VOP_SYMLINK(nd.ni_dvp, &nd.ni_vp, &nd.ni_cnd, &vattr, path);
+out:
+	FREE(path, M_NAMEI);
+	return (error);
+}
+
+/*
+ * Delete a whiteout from the filesystem.
+ */
+/* ARGSUSED */
+int
+undelete(p, uap, retval)
+	struct proc *p;
+	register struct undelete_args /* {
+		syscallarg(char *) path;
+	} */ *uap;
+	register_t *retval;
+{
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, DELETE, LOCKPARENT|DOWHITEOUT, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	error = namei(&nd);
+	if (error)
+		return (error);
+
+	if (nd.ni_vp != NULLVP || !(nd.ni_cnd.cn_flags & ISWHITEOUT)) {
+		VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+		if (nd.ni_dvp == nd.ni_vp)
+			vrele(nd.ni_dvp);
+		else
+			vput(nd.ni_dvp);
+		if (nd.ni_vp)
+			vrele(nd.ni_vp);
+		return (EEXIST);
+	}
+
+	VOP_LEASE(nd.ni_dvp, p, p->p_ucred, LEASE_WRITE);
+	if (error = VOP_WHITEOUT(nd.ni_dvp, &nd.ni_cnd, DELETE))
+		VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+	vput(nd.ni_dvp);
+	return (error);
+}
+
+/*
+ * Delete a name from the filesystem.
+ */
+/* ARGSUSED */
+int
+unlink(p, uap, retval)
+	struct proc *p;
+	struct unlink_args /* {
+		syscallarg(char *) path;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, DELETE, LOCKPARENT, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+
+	if (vp->v_type != VDIR ||
+	    (error = suser(p->p_ucred, &p->p_acflag)) == 0) {
+		/*
+		 * The root of a mounted filesystem cannot be deleted.
+		 */
+		if (vp->v_flag & VROOT)
+			error = EBUSY;
+		else
+			(void)vnode_pager_uncache(vp);
+	}
+
+	if (!error) {
+		VOP_LEASE(nd.ni_dvp, p, p->p_ucred, LEASE_WRITE);
+		error = VOP_REMOVE(nd.ni_dvp, nd.ni_vp, &nd.ni_cnd);
+	} else {
+		VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+		if (nd.ni_dvp == vp)
+			vrele(nd.ni_dvp);
+		else
+			vput(nd.ni_dvp);
+		if (vp != NULLVP)
+			vput(vp);
+	}
+	return (error);
+}
+
+/*
+ * Reposition read/write file offset.
+ */
+int
+lseek(p, uap, retval)
+	struct proc *p;
+	register struct lseek_args /* {
+		syscallarg(int) fd;
+		syscallarg(int) pad;
+		syscallarg(off_t) offset;
+		syscallarg(int) whence;
+	} */ *uap;
+	register_t *retval;
+{
+	struct ucred *cred = p->p_ucred;
+	register struct filedesc *fdp = p->p_fd;
+	register struct file *fp;
+	struct vattr vattr;
+	int error;
+
+	if ((u_int)SCARG(uap, fd) >= fdp->fd_nfiles ||
+	    (fp = fdp->fd_ofiles[SCARG(uap, fd)]) == NULL)
+		return (EBADF);
+	if (fp->f_type != DTYPE_VNODE)
+		return (ESPIPE);
+	switch (SCARG(uap, whence)) {
+	case L_INCR:
+		fp->f_offset += SCARG(uap, offset);
+		break;
+	case L_XTND:
+		if (error =
+		    VOP_GETATTR((struct vnode *)fp->f_data, &vattr, cred, p))
+			return (error);
+		fp->f_offset = SCARG(uap, offset) + vattr.va_size;
+		break;
+	case L_SET:
+		fp->f_offset = SCARG(uap, offset);
+		break;
+	default:
+		return (EINVAL);
+	}
+	*(off_t *)retval = fp->f_offset;
+	return (0);
+}
+
+#if defined(COMPAT_43) || defined(COMPAT_SUNOS)
+/*
+ * Reposition read/write file offset.
+ */
+int
+compat_43_lseek(p, uap, retval)
+	struct proc *p;
+	register struct compat_43_lseek_args /* {
+		syscallarg(int) fd;
+		syscallarg(long) offset;
+		syscallarg(int) whence;
+	} */ *uap;
+	register_t *retval;
+{
+	struct lseek_args /* {
+		syscallarg(int) fd;
+		syscallarg(int) pad;
+		syscallarg(off_t) offset;
+		syscallarg(int) whence;
+	} */ nuap;
+	off_t qret;
+	int error;
+
+	SCARG(&nuap, fd) = SCARG(uap, fd);
+	SCARG(&nuap, offset) = SCARG(uap, offset);
+	SCARG(&nuap, whence) = SCARG(uap, whence);
+	error = lseek(p, &nuap, &qret);
+	*(long *)retval = qret;
+	return (error);
+}
+#endif /* COMPAT_43 */
+
+/*
+ * Check access permissions.
+ */
+int
+access(p, uap, retval)
+	struct proc *p;
+	register struct access_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) flags;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct ucred *cred = p->p_ucred;
+	register struct vnode *vp;
+	int error, flags, t_gid, t_uid;
+	struct nameidata nd;
+
+	t_uid = cred->cr_uid;
+	t_gid = cred->cr_groups[0];
+	cred->cr_uid = p->p_cred->p_ruid;
+	cred->cr_groups[0] = p->p_cred->p_rgid;
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		goto out1;
+	vp = nd.ni_vp;
+
+	/* Flags == 0 means only check for existence. */
+	if (SCARG(uap, flags)) {
+		flags = 0;
+		if (SCARG(uap, flags) & R_OK)
+			flags |= VREAD;
+		if (SCARG(uap, flags) & W_OK)
+			flags |= VWRITE;
+		if (SCARG(uap, flags) & X_OK)
+			flags |= VEXEC;
+		if ((flags & VWRITE) == 0 || (error = vn_writechk(vp)) == 0)
+			error = VOP_ACCESS(vp, flags, cred, p);
+	}
+	vput(vp);
+out1:
+	cred->cr_uid = t_uid;
+	cred->cr_groups[0] = t_gid;
+	return (error);
+}
+
+#if defined(COMPAT_43) || defined(COMPAT_SUNOS)
+/*
+ * Get file status; this version follows links.
+ */
+/* ARGSUSED */
+int
+compat_43_stat(p, uap, retval)
+	struct proc *p;
+	register struct compat_43_stat_args /* {
+		syscallarg(char *) path;
+		syscallarg(struct ostat *) ub;
+	} */ *uap;
+	register_t *retval;
+{
+	struct stat sb;
+	struct ostat osb;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	error = vn_stat(nd.ni_vp, &sb, p);
+	vput(nd.ni_vp);
+	if (error)
+		return (error);
+	cvtstat(&sb, &osb);
+	error = copyout((caddr_t)&osb, (caddr_t)SCARG(uap, ub), sizeof (osb));
+	return (error);
+}
+
+/*
+ * Get file status; this version does not follow links.
+ */
+/* ARGSUSED */
+int
+compat_43_lstat(p, uap, retval)
+	struct proc *p;
+	register struct compat_43_lstat_args /* {
+		syscallarg(char *) path;
+		syscallarg(struct ostat *) ub;
+	} */ *uap;
+	register_t *retval;
+{
+	struct vnode *vp, *dvp;
+	struct stat sb, sb1;
+	struct ostat osb;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, NOFOLLOW | LOCKLEAF | LOCKPARENT, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	/*
+	 * For symbolic links, always return the attributes of its
+	 * containing directory, except for mode, size, and links.
+	 */
+	vp = nd.ni_vp;
+	dvp = nd.ni_dvp;
+	if (vp->v_type != VLNK) {
+		if (dvp == vp)
+			vrele(dvp);
+		else
+			vput(dvp);
+		error = vn_stat(vp, &sb, p);
+		vput(vp);
+		if (error)
+			return (error);
+	} else {
+		error = vn_stat(dvp, &sb, p);
+		vput(dvp);
+		if (error) {
+			vput(vp);
+			return (error);
+		}
+		error = vn_stat(vp, &sb1, p);
+		vput(vp);
+		if (error)
+			return (error);
+		sb.st_mode &= ~S_IFDIR;
+		sb.st_mode |= S_IFLNK;
+		sb.st_nlink = sb1.st_nlink;
+		sb.st_size = sb1.st_size;
+		sb.st_blocks = sb1.st_blocks;
+	}
+	cvtstat(&sb, &osb);
+	error = copyout((caddr_t)&osb, (caddr_t)SCARG(uap, ub), sizeof (osb));
+	return (error);
+}
+
+/*
+ * Convert from an old to a new stat structure.
+ */
+void
+cvtstat(st, ost)
+	struct stat *st;
+	struct ostat *ost;
+{
+
+	ost->st_dev = st->st_dev;
+	ost->st_ino = st->st_ino;
+	ost->st_mode = st->st_mode;
+	ost->st_nlink = st->st_nlink;
+	ost->st_uid = st->st_uid;
+	ost->st_gid = st->st_gid;
+	ost->st_rdev = st->st_rdev;
+	if (st->st_size < (quad_t)1 << 32)
+		ost->st_size = st->st_size;
+	else
+		ost->st_size = -2;
+	ost->st_atime = st->st_atime;
+	ost->st_mtime = st->st_mtime;
+	ost->st_ctime = st->st_ctime;
+	ost->st_blksize = st->st_blksize;
+	ost->st_blocks = st->st_blocks;
+	ost->st_flags = st->st_flags;
+	ost->st_gen = st->st_gen;
+}
+#endif /* COMPAT_43 || COMPAT_SUNOS */
+
+/*
+ * Get file status; this version follows links.
+ */
+/* ARGSUSED */
+int
+stat(p, uap, retval)
+	struct proc *p;
+	register struct stat_args /* {
+		syscallarg(char *) path;
+		syscallarg(struct stat *) ub;
+	} */ *uap;
+	register_t *retval;
+{
+	struct stat sb;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	error = vn_stat(nd.ni_vp, &sb, p);
+	vput(nd.ni_vp);
+	if (error)
+		return (error);
+	error = copyout((caddr_t)&sb, (caddr_t)SCARG(uap, ub), sizeof (sb));
+	return (error);
+}
+
+/*
+ * Get file status; this version does not follow links.
+ */
+/* ARGSUSED */
+int
+lstat(p, uap, retval)
+	struct proc *p;
+	register struct lstat_args /* {
+		syscallarg(char *) path;
+		syscallarg(struct stat *) ub;
+	} */ *uap;
+	register_t *retval;
+{
+	int error;
+	struct vnode *vp, *dvp;
+	struct stat sb, sb1;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, NOFOLLOW | LOCKLEAF | LOCKPARENT, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	/*
+	 * For symbolic links, always return the attributes of its containing
+	 * directory, except for mode, size, inode number, and links.
+	 */
+	vp = nd.ni_vp;
+	dvp = nd.ni_dvp;
+	if (vp->v_type != VLNK) {
+		if (dvp == vp)
+			vrele(dvp);
+		else
+			vput(dvp);
+		error = vn_stat(vp, &sb, p);
+		vput(vp);
+		if (error)
+			return (error);
+	} else {
+		error = vn_stat(dvp, &sb, p);
+		vput(dvp);
+		if (error) {
+			vput(vp);
+			return (error);
+		}
+		error = vn_stat(vp, &sb1, p);
+		vput(vp);
+		if (error)
+			return (error);
+		sb.st_mode &= ~S_IFDIR;
+		sb.st_mode |= S_IFLNK;
+		sb.st_nlink = sb1.st_nlink;
+		sb.st_size = sb1.st_size;
+		sb.st_blocks = sb1.st_blocks;
+		sb.st_ino = sb1.st_ino;
+	}
+	error = copyout((caddr_t)&sb, (caddr_t)SCARG(uap, ub), sizeof (sb));
+	return (error);
+}
+
+/*
+ * Get configurable pathname variables.
+ */
+/* ARGSUSED */
+int
+pathconf(p, uap, retval)
+	struct proc *p;
+	register struct pathconf_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) name;
+	} */ *uap;
+	register_t *retval;
+{
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	error = VOP_PATHCONF(nd.ni_vp, SCARG(uap, name), retval);
+	vput(nd.ni_vp);
+	return (error);
+}
+
+/*
+ * Return target name of a symbolic link.
+ */
+/* ARGSUSED */
+int
+readlink(p, uap, retval)
+	struct proc *p;
+	register struct readlink_args /* {
+		syscallarg(char *) path;
+		syscallarg(char *) buf;
+		syscallarg(int) count;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct iovec aiov;
+	struct uio auio;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, NOFOLLOW | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	if (vp->v_type != VLNK)
+		error = EINVAL;
+	else {
+		aiov.iov_base = SCARG(uap, buf);
+		aiov.iov_len = SCARG(uap, count);
+		auio.uio_iov = &aiov;
+		auio.uio_iovcnt = 1;
+		auio.uio_offset = 0;
+		auio.uio_rw = UIO_READ;
+		auio.uio_segflg = UIO_USERSPACE;
+		auio.uio_procp = p;
+		auio.uio_resid = SCARG(uap, count);
+		error = VOP_READLINK(vp, &auio, p->p_ucred);
+	}
+	vput(vp);
+	*retval = SCARG(uap, count) - auio.uio_resid;
+	return (error);
+}
+
+/*
+ * Change flags of a file given a path name.
+ */
+/* ARGSUSED */
+int
+chflags(p, uap, retval)
+	struct proc *p;
+	register struct chflags_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) flags;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct vattr vattr;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	VATTR_NULL(&vattr);
+	vattr.va_flags = SCARG(uap, flags);
+	error = VOP_SETATTR(vp, &vattr, p->p_ucred, p);
+	vput(vp);
+	return (error);
+}
+
+/*
+ * Change flags of a file given a file descriptor.
+ */
+/* ARGSUSED */
+int
+fchflags(p, uap, retval)
+	struct proc *p;
+	register struct fchflags_args /* {
+		syscallarg(int) fd;
+		syscallarg(int) flags;
+	} */ *uap;
+	register_t *retval;
+{
+	struct vattr vattr;
+	struct vnode *vp;
+	struct file *fp;
+	int error;
+
+	if (error = getvnode(p->p_fd, SCARG(uap, fd), &fp))
+		return (error);
+	vp = (struct vnode *)fp->f_data;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	VATTR_NULL(&vattr);
+	vattr.va_flags = SCARG(uap, flags);
+	error = VOP_SETATTR(vp, &vattr, p->p_ucred, p);
+	VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+/*
+ * Change mode of a file given path name.
+ */
+/* ARGSUSED */
+int
+chmod(p, uap, retval)
+	struct proc *p;
+	register struct chmod_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) mode;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct vattr vattr;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	VATTR_NULL(&vattr);
+	vattr.va_mode = SCARG(uap, mode) & ALLPERMS;
+	error = VOP_SETATTR(vp, &vattr, p->p_ucred, p);
+	vput(vp);
+	return (error);
+}
+
+/*
+ * Change mode of a file given a file descriptor.
+ */
+/* ARGSUSED */
+int
+fchmod(p, uap, retval)
+	struct proc *p;
+	register struct fchmod_args /* {
+		syscallarg(int) fd;
+		syscallarg(int) mode;
+	} */ *uap;
+	register_t *retval;
+{
+	struct vattr vattr;
+	struct vnode *vp;
+	struct file *fp;
+	int error;
+
+	if (error = getvnode(p->p_fd, SCARG(uap, fd), &fp))
+		return (error);
+	vp = (struct vnode *)fp->f_data;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	VATTR_NULL(&vattr);
+	vattr.va_mode = SCARG(uap, mode) & ALLPERMS;
+	error = VOP_SETATTR(vp, &vattr, p->p_ucred, p);
+	VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+/*
+ * Set ownership given a path name.
+ */
+/* ARGSUSED */
+int
+chown(p, uap, retval)
+	struct proc *p;
+	register struct chown_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) uid;
+		syscallarg(int) gid;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct vattr vattr;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	VATTR_NULL(&vattr);
+	vattr.va_uid = SCARG(uap, uid);
+	vattr.va_gid = SCARG(uap, gid);
+	error = VOP_SETATTR(vp, &vattr, p->p_ucred, p);
+	vput(vp);
+	return (error);
+}
+
+/*
+ * Set ownership given a file descriptor.
+ */
+/* ARGSUSED */
+int
+fchown(p, uap, retval)
+	struct proc *p;
+	register struct fchown_args /* {
+		syscallarg(int) fd;
+		syscallarg(int) uid;
+		syscallarg(int) gid;
+	} */ *uap;
+	register_t *retval;
+{
+	struct vattr vattr;
+	struct vnode *vp;
+	struct file *fp;
+	int error;
+
+	if (error = getvnode(p->p_fd, SCARG(uap, fd), &fp))
+		return (error);
+	vp = (struct vnode *)fp->f_data;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	VATTR_NULL(&vattr);
+	vattr.va_uid = SCARG(uap, uid);
+	vattr.va_gid = SCARG(uap, gid);
+	error = VOP_SETATTR(vp, &vattr, p->p_ucred, p);
+	VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+/*
+ * Set the access and modification times of a file.
+ */
+/* ARGSUSED */
+int
+utimes(p, uap, retval)
+	struct proc *p;
+	register struct utimes_args /* {
+		syscallarg(char *) path;
+		syscallarg(struct timeval *) tptr;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct timeval tv[2];
+	struct vattr vattr;
+	int error;
+	struct nameidata nd;
+
+	VATTR_NULL(&vattr);
+	if (SCARG(uap, tptr) == NULL) {
+		microtime(&tv[0]);
+		tv[1] = tv[0];
+		vattr.va_vaflags |= VA_UTIMES_NULL;
+	} else if (error = copyin((caddr_t)SCARG(uap, tptr), (caddr_t)tv,
+	    sizeof (tv)))
+  		return (error);
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	vattr.va_atime.ts_sec = tv[0].tv_sec;
+	vattr.va_atime.ts_nsec = tv[0].tv_usec * 1000;
+	vattr.va_mtime.ts_sec = tv[1].tv_sec;
+	vattr.va_mtime.ts_nsec = tv[1].tv_usec * 1000;
+	error = VOP_SETATTR(vp, &vattr, p->p_ucred, p);
+	vput(vp);
+	return (error);
+}
+
+/*
+ * Truncate a file given its path name.
+ */
+/* ARGSUSED */
+int
+truncate(p, uap, retval)
+	struct proc *p;
+	register struct truncate_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) pad;
+		syscallarg(off_t) length;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct vattr vattr;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	if (vp->v_type == VDIR)
+		error = EISDIR;
+	else if ((error = vn_writechk(vp)) == 0 &&
+	    (error = VOP_ACCESS(vp, VWRITE, p->p_ucred, p)) == 0) {
+		VATTR_NULL(&vattr);
+		vattr.va_size = SCARG(uap, length);
+		error = VOP_SETATTR(vp, &vattr, p->p_ucred, p);
+	}
+	vput(vp);
+	return (error);
+}
+
+/*
+ * Truncate a file given a file descriptor.
+ */
+/* ARGSUSED */
+int
+ftruncate(p, uap, retval)
+	struct proc *p;
+	register struct ftruncate_args /* {
+		syscallarg(int) fd;
+		syscallarg(int) pad;
+		syscallarg(off_t) length;
+	} */ *uap;
+	register_t *retval;
+{
+	struct vattr vattr;
+	struct vnode *vp;
+	struct file *fp;
+	int error;
+
+	if (error = getvnode(p->p_fd, SCARG(uap, fd), &fp))
+		return (error);
+	if ((fp->f_flag & FWRITE) == 0)
+		return (EINVAL);
+	vp = (struct vnode *)fp->f_data;
+	VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	if (vp->v_type == VDIR)
+		error = EISDIR;
+	else if ((error = vn_writechk(vp)) == 0) {
+		VATTR_NULL(&vattr);
+		vattr.va_size = SCARG(uap, length);
+		error = VOP_SETATTR(vp, &vattr, fp->f_cred, p);
+	}
+	VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+#if defined(COMPAT_43) || defined(COMPAT_SUNOS)
+/*
+ * Truncate a file given its path name.
+ */
+/* ARGSUSED */
+int
+compat_43_truncate(p, uap, retval)
+	struct proc *p;
+	register struct compat_43_truncate_args /* {
+		syscallarg(char *) path;
+		syscallarg(long) length;
+	} */ *uap;
+	register_t *retval;
+{
+	struct truncate_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) pad;
+		syscallarg(off_t) length;
+	} */ nuap;
+
+	SCARG(&nuap, path) = SCARG(uap, path);
+	SCARG(&nuap, length) = SCARG(uap, length);
+	return (truncate(p, &nuap, retval));
+}
+
+/*
+ * Truncate a file given a file descriptor.
+ */
+/* ARGSUSED */
+int
+compat_43_ftruncate(p, uap, retval)
+	struct proc *p;
+	register struct compat_43_ftruncate_args /* {
+		syscallarg(int) fd;
+		syscallarg(long) length;
+	} */ *uap;
+	register_t *retval;
+{
+	struct ftruncate_args /* {
+		syscallarg(int) fd;
+		syscallarg(int) pad;
+		syscallarg(off_t) length;
+	} */ nuap;
+
+	SCARG(&nuap, fd) = SCARG(uap, fd);
+	SCARG(&nuap, length) = SCARG(uap, length);
+	return (ftruncate(p, &nuap, retval));
+}
+#endif /* COMPAT_43 || COMPAT_SUNOS */
+
+/*
+ * Sync an open file.
+ */
+/* ARGSUSED */
+int
+fsync(p, uap, retval)
+	struct proc *p;
+	struct fsync_args /* {
+		syscallarg(int) fd;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct file *fp;
+	int error;
+
+	if (error = getvnode(p->p_fd, SCARG(uap, fd), &fp))
+		return (error);
+	vp = (struct vnode *)fp->f_data;
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	error = VOP_FSYNC(vp, fp->f_cred, MNT_WAIT, p);
+	VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+/*
+ * Rename files.  Source and destination must either both be directories,
+ * or both not be directories.  If target is a directory, it must be empty.
+ */
+/* ARGSUSED */
+int
+rename(p, uap, retval)
+	struct proc *p;
+	register struct rename_args /* {
+		syscallarg(char *) from;
+		syscallarg(char *) to;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *tvp, *fvp, *tdvp;
+	struct nameidata fromnd, tond;
+	int error;
+
+	NDINIT(&fromnd, DELETE, WANTPARENT | SAVESTART, UIO_USERSPACE,
+	    SCARG(uap, from), p);
+	if (error = namei(&fromnd))
+		return (error);
+	fvp = fromnd.ni_vp;
+	NDINIT(&tond, RENAME, LOCKPARENT | LOCKLEAF | NOCACHE | SAVESTART,
+	    UIO_USERSPACE, SCARG(uap, to), p);
+	if (error = namei(&tond)) {
+		VOP_ABORTOP(fromnd.ni_dvp, &fromnd.ni_cnd);
+		vrele(fromnd.ni_dvp);
+		vrele(fvp);
+		goto out1;
+	}
+	tdvp = tond.ni_dvp;
+	tvp = tond.ni_vp;
+	if (tvp != NULL) {
+		if (fvp->v_type == VDIR && tvp->v_type != VDIR) {
+			error = ENOTDIR;
+			goto out;
+		} else if (fvp->v_type != VDIR && tvp->v_type == VDIR) {
+			error = EISDIR;
+			goto out;
+		}
+	}
+	if (fvp == tdvp)
+		error = EINVAL;
+	/*
+	 * If source is the same as the destination (that is the
+	 * same inode number with the same name in the same directory),
+	 * then there is nothing to do.
+	 */
+	if (fvp == tvp && fromnd.ni_dvp == tdvp &&
+	    fromnd.ni_cnd.cn_namelen == tond.ni_cnd.cn_namelen &&
+	    !bcmp(fromnd.ni_cnd.cn_nameptr, tond.ni_cnd.cn_nameptr,
+	      fromnd.ni_cnd.cn_namelen))
+		error = -1;
+out:
+	if (!error) {
+		VOP_LEASE(tdvp, p, p->p_ucred, LEASE_WRITE);
+		if (fromnd.ni_dvp != tdvp)
+			VOP_LEASE(fromnd.ni_dvp, p, p->p_ucred, LEASE_WRITE);
+		if (tvp)
+			VOP_LEASE(tvp, p, p->p_ucred, LEASE_WRITE);
+		error = VOP_RENAME(fromnd.ni_dvp, fromnd.ni_vp, &fromnd.ni_cnd,
+				   tond.ni_dvp, tond.ni_vp, &tond.ni_cnd);
+	} else {
+		VOP_ABORTOP(tond.ni_dvp, &tond.ni_cnd);
+		if (tdvp == tvp)
+			vrele(tdvp);
+		else
+			vput(tdvp);
+		if (tvp)
+			vput(tvp);
+		VOP_ABORTOP(fromnd.ni_dvp, &fromnd.ni_cnd);
+		vrele(fromnd.ni_dvp);
+		vrele(fvp);
+	}
+	vrele(tond.ni_startdir);
+	FREE(tond.ni_cnd.cn_pnbuf, M_NAMEI);
+out1:
+	if (fromnd.ni_startdir)
+		vrele(fromnd.ni_startdir);
+	FREE(fromnd.ni_cnd.cn_pnbuf, M_NAMEI);
+	if (error == -1)
+		return (0);
+	return (error);
+}
+
+/*
+ * Make a directory file.
+ */
+/* ARGSUSED */
+int
+mkdir(p, uap, retval)
+	struct proc *p;
+	register struct mkdir_args /* {
+		syscallarg(char *) path;
+		syscallarg(int) mode;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct vattr vattr;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, CREATE, LOCKPARENT, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	if (vp != NULL) {
+		VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+		if (nd.ni_dvp == vp)
+			vrele(nd.ni_dvp);
+		else
+			vput(nd.ni_dvp);
+		vrele(vp);
+		return (EEXIST);
+	}
+	VATTR_NULL(&vattr);
+	vattr.va_type = VDIR;
+	vattr.va_mode = (SCARG(uap, mode) & ACCESSPERMS) &~ p->p_fd->fd_cmask;
+	VOP_LEASE(nd.ni_dvp, p, p->p_ucred, LEASE_WRITE);
+	error = VOP_MKDIR(nd.ni_dvp, &nd.ni_vp, &nd.ni_cnd, &vattr);
+	if (!error)
+		vput(nd.ni_vp);
+	return (error);
+}
+
+/*
+ * Remove a directory file.
+ */
+/* ARGSUSED */
+int
+rmdir(p, uap, retval)
+	struct proc *p;
+	struct rmdir_args /* {
+		syscallarg(char *) path;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, DELETE, LOCKPARENT | LOCKLEAF, UIO_USERSPACE,
+	    SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	if (vp->v_type != VDIR) {
+		error = ENOTDIR;
+		goto out;
+	}
+	/*
+	 * No rmdir "." please.
+	 */
+	if (nd.ni_dvp == vp) {
+		error = EINVAL;
+		goto out;
+	}
+	/*
+	 * The root of a mounted filesystem cannot be deleted.
+	 */
+	if (vp->v_flag & VROOT)
+		error = EBUSY;
+out:
+	if (!error) {
+		VOP_LEASE(nd.ni_dvp, p, p->p_ucred, LEASE_WRITE);
+		VOP_LEASE(vp, p, p->p_ucred, LEASE_WRITE);
+		error = VOP_RMDIR(nd.ni_dvp, nd.ni_vp, &nd.ni_cnd);
+	} else {
+		VOP_ABORTOP(nd.ni_dvp, &nd.ni_cnd);
+		if (nd.ni_dvp == vp)
+			vrele(nd.ni_dvp);
+		else
+			vput(nd.ni_dvp);
+		vput(vp);
+	}
+	return (error);
+}
+
+#ifdef COMPAT_43
+/*
+ * Read a block of directory entries in a file system independent format.
+ */
+int
+compat_43_getdirentries(p, uap, retval)
+	struct proc *p;
+	register struct compat_43_getdirentries_args /* {
+		syscallarg(int) fd;
+		syscallarg(char *) buf;
+		syscallarg(u_int) count;
+		syscallarg(long *) basep;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct file *fp;
+	struct uio auio, kuio;
+	struct iovec aiov, kiov;
+	struct dirent *dp, *edp;
+	caddr_t dirbuf;
+	int error, eofflag, readcnt;
+	long loff;
+
+	if (error = getvnode(p->p_fd, SCARG(uap, fd), &fp))
+		return (error);
+	if ((fp->f_flag & FREAD) == 0)
+		return (EBADF);
+	vp = (struct vnode *)fp->f_data;
+unionread:
+	if (vp->v_type != VDIR)
+		return (EINVAL);
+	aiov.iov_base = SCARG(uap, buf);
+	aiov.iov_len = SCARG(uap, count);
+	auio.uio_iov = &aiov;
+	auio.uio_iovcnt = 1;
+	auio.uio_rw = UIO_READ;
+	auio.uio_segflg = UIO_USERSPACE;
+	auio.uio_procp = p;
+	auio.uio_resid = SCARG(uap, count);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	loff = auio.uio_offset = fp->f_offset;
+#	if (BYTE_ORDER != LITTLE_ENDIAN)
+		if (vp->v_mount->mnt_maxsymlinklen <= 0) {
+			error = VOP_READDIR(vp, &auio, fp->f_cred, &eofflag,
+			    (int *)0, (u_long *)0);
+			fp->f_offset = auio.uio_offset;
+		} else
+#	endif
+	{
+		kuio = auio;
+		kuio.uio_iov = &kiov;
+		kuio.uio_segflg = UIO_SYSSPACE;
+		kiov.iov_len = SCARG(uap, count);
+		MALLOC(dirbuf, caddr_t, SCARG(uap, count), M_TEMP, M_WAITOK);
+		kiov.iov_base = dirbuf;
+		error = VOP_READDIR(vp, &kuio, fp->f_cred, &eofflag,
+			    (int *)0, (u_long *)0);
+		fp->f_offset = kuio.uio_offset;
+		if (error == 0) {
+			readcnt = SCARG(uap, count) - kuio.uio_resid;
+			edp = (struct dirent *)&dirbuf[readcnt];
+			for (dp = (struct dirent *)dirbuf; dp < edp; ) {
+#				if (BYTE_ORDER == LITTLE_ENDIAN)
+					/*
+					 * The expected low byte of
+					 * dp->d_namlen is our dp->d_type.
+					 * The high MBZ byte of dp->d_namlen
+					 * is our dp->d_namlen.
+					 */
+					dp->d_type = dp->d_namlen;
+					dp->d_namlen = 0;
+#				else
+					/*
+					 * The dp->d_type is the high byte
+					 * of the expected dp->d_namlen,
+					 * so must be zero'ed.
+					 */
+					dp->d_type = 0;
+#				endif
+				if (dp->d_reclen > 0) {
+					dp = (struct dirent *)
+					    ((char *)dp + dp->d_reclen);
+				} else {
+					error = EIO;
+					break;
+				}
+			}
+			if (dp >= edp)
+				error = uiomove(dirbuf, readcnt, &auio);
+		}
+		FREE(dirbuf, M_TEMP);
+	}
+	VOP_UNLOCK(vp, 0, p);
+	if (error)
+		return (error);
+
+#ifdef UNION
+{
+	extern int (**union_vnodeop_p)();
+	extern struct vnode *union_dircache __P((struct vnode*, struct proc*));
+
+	if ((SCARG(uap, count) == auio.uio_resid) &&
+	    (vp->v_op == union_vnodeop_p)) {
+		struct vnode *lvp;
+
+		lvp = union_dircache(vp, p);
+		if (lvp != NULLVP) {
+			struct vattr va;
+
+			/*
+			 * If the directory is opaque,
+			 * then don't show lower entries
+			 */
+			error = VOP_GETATTR(vp, &va, fp->f_cred, p);
+			if (va.va_flags & OPAQUE) {
+				vput(lvp);
+				lvp = NULL;
+			}
+		}
+		
+		if (lvp != NULLVP) {
+			error = VOP_OPEN(lvp, FREAD, fp->f_cred, p);
+			if (error) {
+				vput(lvp);
+				return (error);
+			}
+			VOP_UNLOCK(lvp, 0, p);
+			fp->f_data = (caddr_t) lvp;
+			fp->f_offset = 0;
+			error = vn_close(vp, FREAD, fp->f_cred, p);
+			if (error)
+				return (error);
+			vp = lvp;
+			goto unionread;
+		}
+	}
+}
+#endif /* UNION */
+
+	if ((SCARG(uap, count) == auio.uio_resid) &&
+	    (vp->v_flag & VROOT) &&
+	    (vp->v_mount->mnt_flag & MNT_UNION)) {
+		struct vnode *tvp = vp;
+		vp = vp->v_mount->mnt_vnodecovered;
+		VREF(vp);
+		fp->f_data = (caddr_t) vp;
+		fp->f_offset = 0;
+		vrele(tvp);
+		goto unionread;
+	}
+	error = copyout((caddr_t)&loff, (caddr_t)SCARG(uap, basep),
+	    sizeof(long));
+	*retval = SCARG(uap, count) - auio.uio_resid;
+	return (error);
+}
+#endif /* COMPAT_43 */
+
+/*
+ * Read a block of directory entries in a file system independent format.
+ */
+int
+getdirentries(p, uap, retval)
+	struct proc *p;
+	register struct getdirentries_args /* {
+		syscallarg(int) fd;
+		syscallarg(char *) buf;
+		syscallarg(u_int) count;
+		syscallarg(long *) basep;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct file *fp;
+	struct uio auio;
+	struct iovec aiov;
+	long loff;
+	int error, eofflag;
+
+	if (error = getvnode(p->p_fd, SCARG(uap, fd), &fp))
+		return (error);
+	if ((fp->f_flag & FREAD) == 0)
+		return (EBADF);
+	vp = (struct vnode *)fp->f_data;
+unionread:
+	if (vp->v_type != VDIR)
+		return (EINVAL);
+	aiov.iov_base = SCARG(uap, buf);
+	aiov.iov_len = SCARG(uap, count);
+	auio.uio_iov = &aiov;
+	auio.uio_iovcnt = 1;
+	auio.uio_rw = UIO_READ;
+	auio.uio_segflg = UIO_USERSPACE;
+	auio.uio_procp = p;
+	auio.uio_resid = SCARG(uap, count);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	loff = auio.uio_offset = fp->f_offset;
+	error = VOP_READDIR(vp, &auio, fp->f_cred, &eofflag,
+			    (int *)0, (u_long *)0);
+	fp->f_offset = auio.uio_offset;
+	VOP_UNLOCK(vp, 0, p);
+	if (error)
+		return (error);
+
+#ifdef UNION
+{
+	extern int (**union_vnodeop_p)();
+	extern struct vnode *union_dircache __P((struct vnode*, struct proc*));
+
+	if ((SCARG(uap, count) == auio.uio_resid) &&
+	    (vp->v_op == union_vnodeop_p)) {
+		struct vnode *lvp;
+
+		lvp = union_dircache(vp, p);
+		if (lvp != NULLVP) {
+			struct vattr va;
+
+			/*
+			 * If the directory is opaque,
+			 * then don't show lower entries
+			 */
+			error = VOP_GETATTR(vp, &va, fp->f_cred, p);
+			if (va.va_flags & OPAQUE) {
+				vput(lvp);
+				lvp = NULL;
+			}
+		}
+
+		if (lvp != NULLVP) {
+			error = VOP_OPEN(lvp, FREAD, fp->f_cred, p);
+			if (error) {
+				vput(lvp);
+				return (error);
+			}
+			VOP_UNLOCK(lvp, 0, p);
+			fp->f_data = (caddr_t) lvp;
+			fp->f_offset = 0;
+			error = vn_close(vp, FREAD, fp->f_cred, p);
+			if (error)
+				return (error);
+			vp = lvp;
+			goto unionread;
+		}
+	}
+}
+#endif /* UNION */
+
+	if ((SCARG(uap, count) == auio.uio_resid) &&
+	    (vp->v_flag & VROOT) &&
+	    (vp->v_mount->mnt_flag & MNT_UNION)) {
+		struct vnode *tvp = vp;
+		vp = vp->v_mount->mnt_vnodecovered;
+		VREF(vp);
+		fp->f_data = (caddr_t) vp;
+		fp->f_offset = 0;
+		vrele(tvp);
+		goto unionread;
+	}
+	error = copyout((caddr_t)&loff, (caddr_t)SCARG(uap, basep),
+	    sizeof(long));
+	*retval = SCARG(uap, count) - auio.uio_resid;
+	return (error);
+}
+
+/*
+ * Set the mode mask for creation of filesystem nodes.
+ */
+int
+umask(p, uap, retval)
+	struct proc *p;
+	struct umask_args /* {
+		syscallarg(int) newmask;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct filedesc *fdp;
+
+	fdp = p->p_fd;
+	*retval = fdp->fd_cmask;
+	fdp->fd_cmask = SCARG(uap, newmask) & ALLPERMS;
+	return (0);
+}
+
+/*
+ * Void all references to file by ripping underlying filesystem
+ * away from vnode.
+ */
+/* ARGSUSED */
+int
+revoke(p, uap, retval)
+	struct proc *p;
+	register struct revoke_args /* {
+		syscallarg(char *) path;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct vnode *vp;
+	struct vattr vattr;
+	int error;
+	struct nameidata nd;
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, SCARG(uap, path), p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	if (error = VOP_GETATTR(vp, &vattr, p->p_ucred, p))
+		goto out;
+	if (p->p_ucred->cr_uid != vattr.va_uid &&
+	    (error = suser(p->p_ucred, &p->p_acflag)))
+		goto out;
+	if (vp->v_usecount > 1 || (vp->v_flag & VALIASED))
+		VOP_REVOKE(vp, REVOKEALL);
+out:
+	vrele(vp);
+	return (error);
+}
+
+/*
+ * Convert a user file descriptor to a kernel file entry.
+ */
+int
+getvnode(fdp, fd, fpp)
+	struct filedesc *fdp;
+	struct file **fpp;
+	int fd;
+{
+	struct file *fp;
+
+	if ((u_int)fd >= fdp->fd_nfiles ||
+	    (fp = fdp->fd_ofiles[fd]) == NULL)
+		return (EBADF);
+	if (fp->f_type != DTYPE_VNODE)
+		return (EINVAL);
+	*fpp = fp;
+	return (0);
+}

--- a/src-uland/fs-server/vfs_vnops.c
+++ b/src-uland/fs-server/vfs_vnops.c
@@ -1,0 +1,450 @@
+/* Copied from sys/kern/vfs_vnops.c */
+/*
+ * Copyright (c) 1982, 1986, 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vfs_vnops.c	8.14 (Berkeley) 6/15/95
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/buf.h>
+#include <sys/proc.h>
+#include <sys/mount.h>
+#include <sys/namei.h>
+#include <sys/vnode.h>
+#include <sys/ioctl.h>
+#include <sys/tty.h>
+
+#include <vm/vm.h>
+
+struct 	fileops vnops =
+	{ vn_read, vn_write, vn_ioctl, vn_select, vn_closefile };
+
+/*
+ * Common code for vnode open operations.
+ * Check permissions, and call the VOP_OPEN or VOP_CREATE routine.
+ */
+vn_open(ndp, fmode, cmode)
+	register struct nameidata *ndp;
+	int fmode, cmode;
+{
+	register struct vnode *vp;
+	register struct proc *p = ndp->ni_cnd.cn_proc;
+	register struct ucred *cred = p->p_ucred;
+	struct vattr vat;
+	struct vattr *vap = &vat;
+	int error;
+
+	if (fmode & O_CREAT) {
+		ndp->ni_cnd.cn_nameiop = CREATE;
+		ndp->ni_cnd.cn_flags = LOCKPARENT | LOCKLEAF;
+		if ((fmode & O_EXCL) == 0)
+			ndp->ni_cnd.cn_flags |= FOLLOW;
+		if (error = namei(ndp))
+			return (error);
+		if (ndp->ni_vp == NULL) {
+			VATTR_NULL(vap);
+			vap->va_type = VREG;
+			vap->va_mode = cmode;
+			if (fmode & O_EXCL)
+				vap->va_vaflags |= VA_EXCLUSIVE;
+			VOP_LEASE(ndp->ni_dvp, p, cred, LEASE_WRITE);
+			if (error = VOP_CREATE(ndp->ni_dvp, &ndp->ni_vp,
+			    &ndp->ni_cnd, vap))
+				return (error);
+			fmode &= ~O_TRUNC;
+			vp = ndp->ni_vp;
+		} else {
+			VOP_ABORTOP(ndp->ni_dvp, &ndp->ni_cnd);
+			if (ndp->ni_dvp == ndp->ni_vp)
+				vrele(ndp->ni_dvp);
+			else
+				vput(ndp->ni_dvp);
+			ndp->ni_dvp = NULL;
+			vp = ndp->ni_vp;
+			if (fmode & O_EXCL) {
+				error = EEXIST;
+				goto bad;
+			}
+			fmode &= ~O_CREAT;
+		}
+	} else {
+		ndp->ni_cnd.cn_nameiop = LOOKUP;
+		ndp->ni_cnd.cn_flags = FOLLOW | LOCKLEAF;
+		if (error = namei(ndp))
+			return (error);
+		vp = ndp->ni_vp;
+	}
+	if (vp->v_type == VSOCK) {
+		error = EOPNOTSUPP;
+		goto bad;
+	}
+	if ((fmode & O_CREAT) == 0) {
+		if (fmode & FREAD) {
+			if (error = VOP_ACCESS(vp, VREAD, cred, p))
+				goto bad;
+		}
+		if (fmode & (FWRITE | O_TRUNC)) {
+			if (vp->v_type == VDIR) {
+				error = EISDIR;
+				goto bad;
+			}
+			if ((error = vn_writechk(vp)) ||
+			    (error = VOP_ACCESS(vp, VWRITE, cred, p)))
+				goto bad;
+		}
+	}
+	if (fmode & O_TRUNC) {
+		VOP_UNLOCK(vp, 0, p);				/* XXX */
+		VOP_LEASE(vp, p, cred, LEASE_WRITE);
+		vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);	/* XXX */
+		VATTR_NULL(vap);
+		vap->va_size = 0;
+		if (error = VOP_SETATTR(vp, vap, cred, p))
+			goto bad;
+	}
+	if (error = VOP_OPEN(vp, fmode, cred, p))
+		goto bad;
+	if (fmode & FWRITE)
+		vp->v_writecount++;
+	return (0);
+bad:
+	vput(vp);
+	return (error);
+}
+
+/*
+ * Check for write permissions on the specified vnode.
+ * Prototype text segments cannot be written.
+ */
+vn_writechk(vp)
+	register struct vnode *vp;
+{
+
+	/*
+	 * If there's shared text associated with
+	 * the vnode, try to free it up once.  If
+	 * we fail, we can't allow writing.
+	 */
+	if ((vp->v_flag & VTEXT) && !vnode_pager_uncache(vp))
+		return (ETXTBSY);
+	return (0);
+}
+
+/*
+ * Vnode close call
+ */
+vn_close(vp, flags, cred, p)
+	register struct vnode *vp;
+	int flags;
+	struct ucred *cred;
+	struct proc *p;
+{
+	int error;
+
+	if (flags & FWRITE)
+		vp->v_writecount--;
+	error = VOP_CLOSE(vp, flags, cred, p);
+	vrele(vp);
+	return (error);
+}
+
+/*
+ * Package up an I/O request on a vnode into a uio and do it.
+ */
+vn_rdwr(rw, vp, base, len, offset, segflg, ioflg, cred, aresid, p)
+	enum uio_rw rw;
+	struct vnode *vp;
+	caddr_t base;
+	int len;
+	off_t offset;
+	enum uio_seg segflg;
+	int ioflg;
+	struct ucred *cred;
+	int *aresid;
+	struct proc *p;
+{
+	struct uio auio;
+	struct iovec aiov;
+	int error;
+
+	if ((ioflg & IO_NODELOCKED) == 0)
+		vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	auio.uio_iov = &aiov;
+	auio.uio_iovcnt = 1;
+	aiov.iov_base = base;
+	aiov.iov_len = len;
+	auio.uio_resid = len;
+	auio.uio_offset = offset;
+	auio.uio_segflg = segflg;
+	auio.uio_rw = rw;
+	auio.uio_procp = p;
+	if (rw == UIO_READ) {
+		error = VOP_READ(vp, &auio, ioflg, cred);
+	} else {
+		error = VOP_WRITE(vp, &auio, ioflg, cred);
+	}
+	if (aresid)
+		*aresid = auio.uio_resid;
+	else
+		if (auio.uio_resid && error == 0)
+			error = EIO;
+	if ((ioflg & IO_NODELOCKED) == 0)
+		VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+/*
+ * File table vnode read routine.
+ */
+vn_read(fp, uio, cred)
+	struct file *fp;
+	struct uio *uio;
+	struct ucred *cred;
+{
+	struct vnode *vp = (struct vnode *)fp->f_data;
+	struct proc *p = uio->uio_procp;
+	int count, error;
+
+	VOP_LEASE(vp, p, cred, LEASE_READ);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	uio->uio_offset = fp->f_offset;
+	count = uio->uio_resid;
+	error = VOP_READ(vp, uio, (fp->f_flag & FNONBLOCK) ? IO_NDELAY : 0,
+		cred);
+	fp->f_offset += count - uio->uio_resid;
+	VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+/*
+ * File table vnode write routine.
+ */
+vn_write(fp, uio, cred)
+	struct file *fp;
+	struct uio *uio;
+	struct ucred *cred;
+{
+	struct vnode *vp = (struct vnode *)fp->f_data;
+	struct proc *p = uio->uio_procp;
+	int count, error, ioflag = IO_UNIT;
+
+	if (vp->v_type == VREG && (fp->f_flag & O_APPEND))
+		ioflag |= IO_APPEND;
+	if (fp->f_flag & FNONBLOCK)
+		ioflag |= IO_NDELAY;
+	if ((fp->f_flag & O_FSYNC) ||
+	    (vp->v_mount && (vp->v_mount->mnt_flag & MNT_SYNCHRONOUS)))
+		ioflag |= IO_SYNC;
+	VOP_LEASE(vp, p, cred, LEASE_WRITE);
+	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	uio->uio_offset = fp->f_offset;
+	count = uio->uio_resid;
+	error = VOP_WRITE(vp, uio, ioflag, cred);
+	if (ioflag & IO_APPEND)
+		fp->f_offset = uio->uio_offset;
+	else
+		fp->f_offset += count - uio->uio_resid;
+	VOP_UNLOCK(vp, 0, p);
+	return (error);
+}
+
+/*
+ * File table vnode stat routine.
+ */
+vn_stat(vp, sb, p)
+	struct vnode *vp;
+	register struct stat *sb;
+	struct proc *p;
+{
+	struct vattr vattr;
+	register struct vattr *vap;
+	int error;
+	u_short mode;
+
+	vap = &vattr;
+	error = VOP_GETATTR(vp, vap, p->p_ucred, p);
+	if (error)
+		return (error);
+	/*
+	 * Copy from vattr table
+	 */
+	sb->st_dev = vap->va_fsid;
+	sb->st_ino = vap->va_fileid;
+	mode = vap->va_mode;
+	switch (vp->v_type) {
+	case VREG:
+		mode |= S_IFREG;
+		break;
+	case VDIR:
+		mode |= S_IFDIR;
+		break;
+	case VBLK:
+		mode |= S_IFBLK;
+		break;
+	case VCHR:
+		mode |= S_IFCHR;
+		break;
+	case VLNK:
+		mode |= S_IFLNK;
+		break;
+	case VSOCK:
+		mode |= S_IFSOCK;
+		break;
+	case VFIFO:
+		mode |= S_IFIFO;
+		break;
+	default:
+		return (EBADF);
+	};
+	sb->st_mode = mode;
+	sb->st_nlink = vap->va_nlink;
+	sb->st_uid = vap->va_uid;
+	sb->st_gid = vap->va_gid;
+	sb->st_rdev = vap->va_rdev;
+	sb->st_size = vap->va_size;
+	sb->st_atimespec = vap->va_atime;
+	sb->st_mtimespec = vap->va_mtime;
+	sb->st_ctimespec = vap->va_ctime;
+	sb->st_blksize = vap->va_blocksize;
+	sb->st_flags = vap->va_flags;
+	sb->st_gen = vap->va_gen;
+	sb->st_blocks = vap->va_bytes / S_BLKSIZE;
+	return (0);
+}
+
+/*
+ * File table vnode ioctl routine.
+ */
+vn_ioctl(fp, com, data, p)
+	struct file *fp;
+	u_long com;
+	caddr_t data;
+	struct proc *p;
+{
+	register struct vnode *vp = ((struct vnode *)fp->f_data);
+	struct vattr vattr;
+	int error;
+
+	switch (vp->v_type) {
+
+	case VREG:
+	case VDIR:
+		if (com == FIONREAD) {
+			if (error = VOP_GETATTR(vp, &vattr, p->p_ucred, p))
+				return (error);
+			*(int *)data = vattr.va_size - fp->f_offset;
+			return (0);
+		}
+		if (com == FIONBIO || com == FIOASYNC)	/* XXX */
+			return (0);			/* XXX */
+		/* fall into ... */
+
+	default:
+		return (ENOTTY);
+
+	case VFIFO:
+	case VCHR:
+	case VBLK:
+		error = VOP_IOCTL(vp, com, data, fp->f_flag, p->p_ucred, p);
+		if (error == 0 && com == TIOCSCTTY) {
+			if (p->p_session->s_ttyvp)
+				vrele(p->p_session->s_ttyvp);
+			p->p_session->s_ttyvp = vp;
+			VREF(vp);
+		}
+		return (error);
+	}
+}
+
+/*
+ * File table vnode select routine.
+ */
+vn_select(fp, which, p)
+	struct file *fp;
+	int which;
+	struct proc *p;
+{
+
+	return (VOP_SELECT(((struct vnode *)fp->f_data), which, fp->f_flag,
+		fp->f_cred, p));
+}
+
+/*
+ * Check that the vnode is still valid, and if so
+ * acquire requested lock.
+ */
+int
+vn_lock(vp, flags, p)
+	struct vnode *vp;
+	int flags;
+	struct proc *p;
+{
+	int error;
+	
+	do {
+		if ((flags & LK_INTERLOCK) == 0)
+			simple_lock(&vp->v_interlock);
+		if (vp->v_flag & VXLOCK) {
+			vp->v_flag |= VXWANT;
+			simple_unlock(&vp->v_interlock);
+			tsleep((caddr_t)vp, PINOD, "vn_lock", 0);
+			error = ENOENT;
+		} else {
+			error = VOP_LOCK(vp, flags | LK_INTERLOCK, p);
+			if (error == 0)
+				return (error);
+		}
+		flags &= ~LK_INTERLOCK;
+	} while (flags & LK_RETRY);
+	return (error);
+}
+
+/*
+ * File table vnode close routine.
+ */
+vn_closefile(fp, p)
+	struct file *fp;
+	struct proc *p;
+{
+
+	return (vn_close(((struct vnode *)fp->f_data), fp->f_flag,
+		fp->f_cred, p));
+}

--- a/src-uland/libkern_sched/Makefile
+++ b/src-uland/libkern_sched/Makefile
@@ -1,0 +1,13 @@
+OBJS = kern_sched.o
+LIB = libkern_sched.a
+CC ?= cc
+AR ?= ar
+CFLAGS ?= -O2
+all: $(LIB)
+	$(LIB): $(OBJS)
+	$(AR) rcs $@ $(OBJS)
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+clean:
+	rm -f $(OBJS) $(LIB)
+

--- a/src-uland/libkern_sched/kern_sched.c
+++ b/src-uland/libkern_sched/kern_sched.c
@@ -1,0 +1,672 @@
+/* Copied from sys/kern/kern_synch.c */
+/*-
+ * Copyright (c) 1982, 1986, 1990, 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)kern_synch.c	8.9 (Berkeley) 5/19/95
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/kernel.h>
+#include <sys/buf.h>
+#include <sys/signalvar.h>
+#include <sys/resourcevar.h>
+#include <sys/vmmeter.h>
+#ifdef KTRACE
+#include <sys/ktrace.h>
+#endif
+
+#include <machine/cpu.h>
+
+u_char	curpriority;		/* usrpri of curproc */
+int	lbolt;			/* once a second sleep address */
+
+/*
+ * Force switch among equal priority processes every 100ms.
+ */
+/* ARGSUSED */
+void
+roundrobin(arg)
+	void *arg;
+{
+
+	need_resched();
+	timeout(roundrobin, NULL, hz / 10);
+}
+
+/*
+ * Constants for digital decay and forget:
+ *	90% of (p_estcpu) usage in 5 * loadav time
+ *	95% of (p_pctcpu) usage in 60 seconds (load insensitive)
+ *          Note that, as ps(1) mentions, this can let percentages
+ *          total over 100% (I've seen 137.9% for 3 processes).
+ *
+ * Note that hardclock updates p_estcpu and p_cpticks independently.
+ *
+ * We wish to decay away 90% of p_estcpu in (5 * loadavg) seconds.
+ * That is, the system wants to compute a value of decay such
+ * that the following for loop:
+ * 	for (i = 0; i < (5 * loadavg); i++)
+ * 		p_estcpu *= decay;
+ * will compute
+ * 	p_estcpu *= 0.1;
+ * for all values of loadavg:
+ *
+ * Mathematically this loop can be expressed by saying:
+ * 	decay ** (5 * loadavg) ~= .1
+ *
+ * The system computes decay as:
+ * 	decay = (2 * loadavg) / (2 * loadavg + 1)
+ *
+ * We wish to prove that the system's computation of decay
+ * will always fulfill the equation:
+ * 	decay ** (5 * loadavg) ~= .1
+ *
+ * If we compute b as:
+ * 	b = 2 * loadavg
+ * then
+ * 	decay = b / (b + 1)
+ *
+ * We now need to prove two things:
+ *	1) Given factor ** (5 * loadavg) ~= .1, prove factor == b/(b+1)
+ *	2) Given b/(b+1) ** power ~= .1, prove power == (5 * loadavg)
+ *	
+ * Facts:
+ *         For x close to zero, exp(x) =~ 1 + x, since
+ *              exp(x) = 0! + x**1/1! + x**2/2! + ... .
+ *              therefore exp(-1/b) =~ 1 - (1/b) = (b-1)/b.
+ *         For x close to zero, ln(1+x) =~ x, since
+ *              ln(1+x) = x - x**2/2 + x**3/3 - ...     -1 < x < 1
+ *              therefore ln(b/(b+1)) = ln(1 - 1/(b+1)) =~ -1/(b+1).
+ *         ln(.1) =~ -2.30
+ *
+ * Proof of (1):
+ *    Solve (factor)**(power) =~ .1 given power (5*loadav):
+ *	solving for factor,
+ *      ln(factor) =~ (-2.30/5*loadav), or
+ *      factor =~ exp(-1/((5/2.30)*loadav)) =~ exp(-1/(2*loadav)) =
+ *          exp(-1/b) =~ (b-1)/b =~ b/(b+1).                    QED
+ *
+ * Proof of (2):
+ *    Solve (factor)**(power) =~ .1 given factor == (b/(b+1)):
+ *	solving for power,
+ *      power*ln(b/(b+1)) =~ -2.30, or
+ *      power =~ 2.3 * (b + 1) = 4.6*loadav + 2.3 =~ 5*loadav.  QED
+ *
+ * Actual power values for the implemented algorithm are as follows:
+ *      loadav: 1       2       3       4
+ *      power:  5.68    10.32   14.94   19.55
+ */
+
+/* calculations for digital decay to forget 90% of usage in 5*loadav sec */
+#define	loadfactor(loadav)	(2 * (loadav))
+#define	decay_cpu(loadfac, cpu)	(((loadfac) * (cpu)) / ((loadfac) + FSCALE))
+
+/* decay 95% of `p_pctcpu' in 60 seconds; see CCPU_SHIFT before changing */
+fixpt_t	ccpu = 0.95122942450071400909 * FSCALE;		/* exp(-1/20) */
+
+/*
+ * If `ccpu' is not equal to `exp(-1/20)' and you still want to use the
+ * faster/more-accurate formula, you'll have to estimate CCPU_SHIFT below
+ * and possibly adjust FSHIFT in "param.h" so that (FSHIFT >= CCPU_SHIFT).
+ *
+ * To estimate CCPU_SHIFT for exp(-1/20), the following formula was used:
+ *	1 - exp(-1/20) ~= 0.0487 ~= 0.0488 == 1 (fixed pt, *11* bits).
+ *
+ * If you dont want to bother with the faster/more-accurate formula, you
+ * can set CCPU_SHIFT to (FSHIFT + 1) which will use a slower/less-accurate
+ * (more general) method of calculating the %age of CPU used by a process.
+ */
+#define	CCPU_SHIFT	11
+
+/*
+ * Recompute process priorities, every hz ticks.
+ */
+/* ARGSUSED */
+void
+schedcpu(arg)
+	void *arg;
+{
+	register fixpt_t loadfac = loadfactor(averunnable.ldavg[0]);
+	register struct proc *p;
+	register int s;
+	register unsigned int newcpu;
+
+	wakeup((caddr_t)&lbolt);
+	for (p = allproc.lh_first; p != 0; p = p->p_list.le_next) {
+		/*
+		 * Increment time in/out of memory and sleep time
+		 * (if sleeping).  We ignore overflow; with 16-bit int's
+		 * (remember them?) overflow takes 45 days.
+		 */
+		p->p_swtime++;
+		if (p->p_stat == SSLEEP || p->p_stat == SSTOP)
+			p->p_slptime++;
+		p->p_pctcpu = (p->p_pctcpu * ccpu) >> FSHIFT;
+		/*
+		 * If the process has slept the entire second,
+		 * stop recalculating its priority until it wakes up.
+		 */
+		if (p->p_slptime > 1)
+			continue;
+		s = splstatclock();	/* prevent state changes */
+		/*
+		 * p_pctcpu is only for ps.
+		 */
+#if	(FSHIFT >= CCPU_SHIFT)
+		p->p_pctcpu += (hz == 100)?
+			((fixpt_t) p->p_cpticks) << (FSHIFT - CCPU_SHIFT):
+                	100 * (((fixpt_t) p->p_cpticks)
+				<< (FSHIFT - CCPU_SHIFT)) / hz;
+#else
+		p->p_pctcpu += ((FSCALE - ccpu) *
+			(p->p_cpticks * FSCALE / hz)) >> FSHIFT;
+#endif
+		p->p_cpticks = 0;
+		newcpu = (u_int) decay_cpu(loadfac, p->p_estcpu) + p->p_nice;
+		p->p_estcpu = min(newcpu, UCHAR_MAX);
+		resetpriority(p);
+		if (p->p_priority >= PUSER) {
+#define	PPQ	(128 / NQS)		/* priorities per queue */
+			if ((p != curproc) &&
+			    p->p_stat == SRUN &&
+			    (p->p_flag & P_INMEM) &&
+			    (p->p_priority / PPQ) != (p->p_usrpri / PPQ)) {
+				remrq(p);
+				p->p_priority = p->p_usrpri;
+				setrunqueue(p);
+			} else
+				p->p_priority = p->p_usrpri;
+		}
+		splx(s);
+	}
+	vmmeter();
+	if (bclnlist != NULL)
+		wakeup((caddr_t)pageproc);
+	timeout(schedcpu, (void *)0, hz);
+}
+
+/*
+ * Recalculate the priority of a process after it has slept for a while.
+ * For all load averages >= 1 and max p_estcpu of 255, sleeping for at
+ * least six times the loadfactor will decay p_estcpu to zero.
+ */
+void
+updatepri(p)
+	register struct proc *p;
+{
+	register unsigned int newcpu = p->p_estcpu;
+	register fixpt_t loadfac = loadfactor(averunnable.ldavg[0]);
+
+	if (p->p_slptime > 5 * loadfac)
+		p->p_estcpu = 0;
+	else {
+		p->p_slptime--;	/* the first time was done in schedcpu */
+		while (newcpu && --p->p_slptime)
+			newcpu = (int) decay_cpu(loadfac, newcpu);
+		p->p_estcpu = min(newcpu, UCHAR_MAX);
+	}
+	resetpriority(p);
+}
+
+/*
+ * We're only looking at 7 bits of the address; everything is
+ * aligned to 4, lots of things are aligned to greater powers
+ * of 2.  Shift right by 8, i.e. drop the bottom 256 worth.
+ */
+#define TABLESIZE	128
+#define LOOKUP(x)	(((long)(x) >> 8) & (TABLESIZE - 1))
+struct slpque {
+	struct proc *sq_head;
+	struct proc **sq_tailp;
+} slpque[TABLESIZE];
+
+/*
+ * During autoconfiguration or after a panic, a sleep will simply
+ * lower the priority briefly to allow interrupts, then return.
+ * The priority to be used (safepri) is machine-dependent, thus this
+ * value is initialized and maintained in the machine-dependent layers.
+ * This priority will typically be 0, or the lowest priority
+ * that is safe for use on the interrupt stack; it can be made
+ * higher to block network software interrupts after panics.
+ */
+int safepri;
+
+/*
+ * General sleep call.  Suspends the current process until a wakeup is
+ * performed on the specified identifier.  The process will then be made
+ * runnable with the specified priority.  Sleeps at most timo/hz seconds
+ * (0 means no timeout).  If pri includes PCATCH flag, signals are checked
+ * before and after sleeping, else signals are not checked.  Returns 0 if
+ * awakened, EWOULDBLOCK if the timeout expires.  If PCATCH is set and a
+ * signal needs to be delivered, ERESTART is returned if the current system
+ * call should be restarted if possible, and EINTR is returned if the system
+ * call should be interrupted by the signal (return EINTR).
+ */
+int
+tsleep(ident, priority, wmesg, timo)
+	void *ident;
+	int priority, timo;
+	char *wmesg;
+{
+	register struct proc *p = curproc;
+	register struct slpque *qp;
+	register s;
+	int sig, catch = priority & PCATCH;
+	extern int cold;
+	void endtsleep __P((void *));
+
+#ifdef KTRACE
+	if (KTRPOINT(p, KTR_CSW))
+		ktrcsw(p->p_tracep, 1, 0);
+#endif
+	s = splhigh();
+	if (cold || panicstr) {
+		/*
+		 * After a panic, or during autoconfiguration,
+		 * just give interrupts a chance, then just return;
+		 * don't run any other procs or panic below,
+		 * in case this is the idle process and already asleep.
+		 */
+		splx(safepri);
+		splx(s);
+		return (0);
+	}
+#ifdef DIAGNOSTIC
+	if (ident == NULL || p->p_stat != SRUN || p->p_back)
+		panic("tsleep");
+#endif
+	p->p_wchan = ident;
+	p->p_wmesg = wmesg;
+	p->p_slptime = 0;
+	p->p_priority = priority & PRIMASK;
+	qp = &slpque[LOOKUP(ident)];
+	if (qp->sq_head == 0)
+		qp->sq_head = p;
+	else
+		*qp->sq_tailp = p;
+	*(qp->sq_tailp = &p->p_forw) = 0;
+	if (timo)
+		timeout(endtsleep, (void *)p, timo);
+	/*
+	 * We put ourselves on the sleep queue and start our timeout
+	 * before calling CURSIG, as we could stop there, and a wakeup
+	 * or a SIGCONT (or both) could occur while we were stopped.
+	 * A SIGCONT would cause us to be marked as SSLEEP
+	 * without resuming us, thus we must be ready for sleep
+	 * when CURSIG is called.  If the wakeup happens while we're
+	 * stopped, p->p_wchan will be 0 upon return from CURSIG.
+	 */
+	if (catch) {
+		p->p_flag |= P_SINTR;
+		if (sig = CURSIG(p)) {
+			if (p->p_wchan)
+				unsleep(p);
+			p->p_stat = SRUN;
+			goto resume;
+		}
+		if (p->p_wchan == 0) {
+			catch = 0;
+			goto resume;
+		}
+	} else
+		sig = 0;
+	p->p_stat = SSLEEP;
+	p->p_stats->p_ru.ru_nvcsw++;
+	mi_switch();
+resume:
+	curpriority = p->p_usrpri;
+	splx(s);
+	p->p_flag &= ~P_SINTR;
+	if (p->p_flag & P_TIMEOUT) {
+		p->p_flag &= ~P_TIMEOUT;
+		if (sig == 0) {
+#ifdef KTRACE
+			if (KTRPOINT(p, KTR_CSW))
+				ktrcsw(p->p_tracep, 0, 0);
+#endif
+			return (EWOULDBLOCK);
+		}
+	} else if (timo)
+		untimeout(endtsleep, (void *)p);
+	if (catch && (sig != 0 || (sig = CURSIG(p)))) {
+#ifdef KTRACE
+		if (KTRPOINT(p, KTR_CSW))
+			ktrcsw(p->p_tracep, 0, 0);
+#endif
+		if (p->p_sigacts->ps_sigintr & sigmask(sig))
+			return (EINTR);
+		return (ERESTART);
+	}
+#ifdef KTRACE
+	if (KTRPOINT(p, KTR_CSW))
+		ktrcsw(p->p_tracep, 0, 0);
+#endif
+	return (0);
+}
+
+/*
+ * Implement timeout for tsleep.
+ * If process hasn't been awakened (wchan non-zero),
+ * set timeout flag and undo the sleep.  If proc
+ * is stopped, just unsleep so it will remain stopped.
+ */
+void
+endtsleep(arg)
+	void *arg;
+{
+	register struct proc *p;
+	int s;
+
+	p = (struct proc *)arg;
+	s = splhigh();
+	if (p->p_wchan) {
+		if (p->p_stat == SSLEEP)
+			setrunnable(p);
+		else
+			unsleep(p);
+		p->p_flag |= P_TIMEOUT;
+	}
+	splx(s);
+}
+
+/*
+ * Short-term, non-interruptable sleep.
+ */
+void
+sleep(ident, priority)
+	void *ident;
+	int priority;
+{
+	register struct proc *p = curproc;
+	register struct slpque *qp;
+	register s;
+	extern int cold;
+
+#ifdef DIAGNOSTIC
+	if (priority > PZERO) {
+		printf("sleep called with priority %d > PZERO, wchan: %x\n",
+		    priority, ident);
+		panic("old sleep");
+	}
+#endif
+	s = splhigh();
+	if (cold || panicstr) {
+		/*
+		 * After a panic, or during autoconfiguration,
+		 * just give interrupts a chance, then just return;
+		 * don't run any other procs or panic below,
+		 * in case this is the idle process and already asleep.
+		 */
+		splx(safepri);
+		splx(s);
+		return;
+	}
+#ifdef DIAGNOSTIC
+	if (ident == NULL || p->p_stat != SRUN || p->p_back)
+		panic("sleep");
+#endif
+	p->p_wchan = ident;
+	p->p_wmesg = NULL;
+	p->p_slptime = 0;
+	p->p_priority = priority;
+	qp = &slpque[LOOKUP(ident)];
+	if (qp->sq_head == 0)
+		qp->sq_head = p;
+	else
+		*qp->sq_tailp = p;
+	*(qp->sq_tailp = &p->p_forw) = 0;
+	p->p_stat = SSLEEP;
+	p->p_stats->p_ru.ru_nvcsw++;
+#ifdef KTRACE
+	if (KTRPOINT(p, KTR_CSW))
+		ktrcsw(p->p_tracep, 1, 0);
+#endif
+	mi_switch();
+#ifdef KTRACE
+	if (KTRPOINT(p, KTR_CSW))
+		ktrcsw(p->p_tracep, 0, 0);
+#endif
+	curpriority = p->p_usrpri;
+	splx(s);
+}
+
+/*
+ * Remove a process from its wait queue
+ */
+void
+unsleep(p)
+	register struct proc *p;
+{
+	register struct slpque *qp;
+	register struct proc **hp;
+	int s;
+
+	s = splhigh();
+	if (p->p_wchan) {
+		hp = &(qp = &slpque[LOOKUP(p->p_wchan)])->sq_head;
+		while (*hp != p)
+			hp = &(*hp)->p_forw;
+		*hp = p->p_forw;
+		if (qp->sq_tailp == &p->p_forw)
+			qp->sq_tailp = hp;
+		p->p_wchan = 0;
+	}
+	splx(s);
+}
+
+/*
+ * Make all processes sleeping on the specified identifier runnable.
+ */
+void
+wakeup(ident)
+	register void *ident;
+{
+	register struct slpque *qp;
+	register struct proc *p, **q;
+	int s;
+
+	s = splhigh();
+	qp = &slpque[LOOKUP(ident)];
+restart:
+	for (q = &qp->sq_head; p = *q; ) {
+#ifdef DIAGNOSTIC
+		if (p->p_back || p->p_stat != SSLEEP && p->p_stat != SSTOP)
+			panic("wakeup");
+#endif
+		if (p->p_wchan == ident) {
+			p->p_wchan = 0;
+			*q = p->p_forw;
+			if (qp->sq_tailp == &p->p_forw)
+				qp->sq_tailp = q;
+			if (p->p_stat == SSLEEP) {
+				/* OPTIMIZED EXPANSION OF setrunnable(p); */
+				if (p->p_slptime > 1)
+					updatepri(p);
+				p->p_slptime = 0;
+				p->p_stat = SRUN;
+				if (p->p_flag & P_INMEM)
+					setrunqueue(p);
+				/*
+				 * Since curpriority is a user priority,
+				 * p->p_priority is always better than
+				 * curpriority.
+				 */
+				if ((p->p_flag & P_INMEM) == 0)
+					wakeup((caddr_t)&proc0);
+				else
+					need_resched();
+				/* END INLINE EXPANSION */
+				goto restart;
+			}
+		} else
+			q = &p->p_forw;
+	}
+	splx(s);
+}
+
+/*
+ * The machine independent parts of mi_switch().
+ * Must be called at splstatclock() or higher.
+ */
+void
+mi_switch()
+{
+	register struct proc *p = curproc;	/* XXX */
+	register struct rlimit *rlim;
+	register long s, u;
+	struct timeval tv;
+
+#ifdef DEBUG
+	if (p->p_simple_locks)
+		panic("sleep: holding simple lock");
+#endif
+	/*
+	 * Compute the amount of time during which the current
+	 * process was running, and add that to its total so far.
+	 */
+	microtime(&tv);
+	u = p->p_rtime.tv_usec + (tv.tv_usec - runtime.tv_usec);
+	s = p->p_rtime.tv_sec + (tv.tv_sec - runtime.tv_sec);
+	if (u < 0) {
+		u += 1000000;
+		s--;
+	} else if (u >= 1000000) {
+		u -= 1000000;
+		s++;
+	}
+	p->p_rtime.tv_usec = u;
+	p->p_rtime.tv_sec = s;
+
+	/*
+	 * Check if the process exceeds its cpu resource allocation.
+	 * If over max, kill it.  In any case, if it has run for more
+	 * than 10 minutes, reduce priority to give others a chance.
+	 */
+	rlim = &p->p_rlimit[RLIMIT_CPU];
+	if (s >= rlim->rlim_cur) {
+		if (s >= rlim->rlim_max)
+			psignal(p, SIGKILL);
+		else {
+			psignal(p, SIGXCPU);
+			if (rlim->rlim_cur < rlim->rlim_max)
+				rlim->rlim_cur += 5;
+		}
+	}
+	if (s > 10 * 60 && p->p_ucred->cr_uid && p->p_nice == NZERO) {
+		p->p_nice = NZERO + 4;
+		resetpriority(p);
+	}
+
+	/*
+	 * Pick a new current process and record its start time.
+	 */
+	cnt.v_swtch++;
+	cpu_switch(p);
+	microtime(&runtime);
+}
+
+/*
+ * Initialize the (doubly-linked) run queues
+ * to be empty.
+ */
+void
+rqinit()
+{
+	register int i;
+
+	for (i = 0; i < NQS; i++)
+		qs[i].ph_link = qs[i].ph_rlink = (struct proc *)&qs[i];
+}
+
+/*
+ * Change process state to be runnable,
+ * placing it on the run queue if it is in memory,
+ * and awakening the swapper if it isn't in memory.
+ */
+void
+setrunnable(p)
+	register struct proc *p;
+{
+	register int s;
+
+	s = splhigh();
+	switch (p->p_stat) {
+	case 0:
+	case SRUN:
+	case SZOMB:
+	default:
+		panic("setrunnable");
+	case SSTOP:
+	case SSLEEP:
+		unsleep(p);		/* e.g. when sending signals */
+		break;
+
+	case SIDL:
+		break;
+	}
+	p->p_stat = SRUN;
+	if (p->p_flag & P_INMEM)
+		setrunqueue(p);
+	splx(s);
+	if (p->p_slptime > 1)
+		updatepri(p);
+	p->p_slptime = 0;
+	if ((p->p_flag & P_INMEM) == 0)
+		wakeup((caddr_t)&proc0);
+	else if (p->p_priority < curpriority)
+		need_resched();
+}
+
+/*
+ * Compute the priority of a process when running in user mode.
+ * Arrange to reschedule if the resulting priority is better
+ * than that of the current process.
+ */
+void
+resetpriority(p)
+	register struct proc *p;
+{
+	register unsigned int newpriority;
+
+	newpriority = PUSER + p->p_estcpu / 4 + 2 * p->p_nice;
+	newpriority = min(newpriority, MAXPRI);
+	p->p_usrpri = newpriority;
+	if (newpriority < curpriority)
+		need_resched();
+}

--- a/src-uland/libvm/Makefile
+++ b/src-uland/libvm/Makefile
@@ -1,0 +1,12 @@
+SRCS = $(wildcard *.c)
+OBJS = $(SRCS:.c=.o)
+LIB = libvm.a
+CC?=cc
+AR?=ar
+CFLAGS?=-O2
+
+all: $(LIB)
+	$(LIB): $(OBJS)
+	$(AR) rcs $@ $(OBJS)
+	clean:
+	rm -f $(OBJS) $(LIB)

--- a/src-uland/libvm/device_pager.c
+++ b/src-uland/libvm/device_pager.c
@@ -1,0 +1,369 @@
+/* Copied from sys/vm/device_pager.c */
+/*
+ * Copyright (c) 1990 University of Utah.
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * the Systems Programming Group of the University of Utah Computer
+ * Science Department.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)device_pager.c	8.5 (Berkeley) 1/12/94
+ */
+
+/*
+ * Page to/from special files.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/conf.h>
+#include <sys/mman.h>
+#include <sys/malloc.h>
+
+#include <vm/vm.h>
+#include <vm/vm_kern.h>
+#include <vm/vm_page.h>
+#include <vm/device_pager.h>
+
+struct pagerlst	dev_pager_list;		/* list of managed devices */
+struct pglist	dev_pager_fakelist;	/* list of available vm_page_t's */
+
+#ifdef DEBUG
+int	dpagerdebug = 0;
+#define	DDB_FOLLOW	0x01
+#define DDB_INIT	0x02
+#define DDB_ALLOC	0x04
+#define DDB_FAIL	0x08
+#endif
+
+static vm_pager_t	 dev_pager_alloc
+			    __P((caddr_t, vm_size_t, vm_prot_t, vm_offset_t));
+static void		 dev_pager_dealloc __P((vm_pager_t));
+static int		 dev_pager_getpage
+			    __P((vm_pager_t, vm_page_t *, int, boolean_t));
+static boolean_t	 dev_pager_haspage __P((vm_pager_t, vm_offset_t));
+static void		 dev_pager_init __P((void));
+static int		 dev_pager_putpage
+			    __P((vm_pager_t, vm_page_t *, int, boolean_t));
+static vm_page_t	 dev_pager_getfake __P((vm_offset_t));
+static void		 dev_pager_putfake __P((vm_page_t));
+
+struct pagerops devicepagerops = {
+	dev_pager_init,
+	dev_pager_alloc,
+	dev_pager_dealloc,
+	dev_pager_getpage,
+	dev_pager_putpage,
+	dev_pager_haspage,
+	vm_pager_clusternull
+};
+
+static void
+dev_pager_init()
+{
+#ifdef DEBUG
+	if (dpagerdebug & DDB_FOLLOW)
+		printf("dev_pager_init()\n");
+#endif
+	TAILQ_INIT(&dev_pager_list);
+	TAILQ_INIT(&dev_pager_fakelist);
+}
+
+static vm_pager_t
+dev_pager_alloc(handle, size, prot, foff)
+	caddr_t handle;
+	vm_size_t size;
+	vm_prot_t prot;
+	vm_offset_t foff;
+{
+	dev_t dev;
+	vm_pager_t pager;
+	int (*mapfunc)();
+	vm_object_t object;
+	dev_pager_t devp;
+	int npages, off;
+
+#ifdef DEBUG
+	if (dpagerdebug & DDB_FOLLOW)
+		printf("dev_pager_alloc(%x, %x, %x, %x)\n",
+		       handle, size, prot, foff);
+#endif
+#ifdef DIAGNOSTIC
+	/*
+	 * Pageout to device, should never happen.
+	 */
+	if (handle == NULL)
+		panic("dev_pager_alloc called");
+#endif
+
+	/*
+	 * Make sure this device can be mapped.
+	 */
+	dev = (dev_t)handle;
+	mapfunc = cdevsw[major(dev)].d_mmap;
+	if (mapfunc == NULL || mapfunc == enodev || mapfunc == nullop)
+		return(NULL);
+
+	/*
+	 * Offset should be page aligned.
+	 */
+	if (foff & PAGE_MASK)
+		return(NULL);
+
+	/*
+	 * Check that the specified range of the device allows the
+	 * desired protection.
+	 *
+	 * XXX assumes VM_PROT_* == PROT_*
+	 */
+	npages = atop(round_page(size));
+	for (off = foff; npages--; off += PAGE_SIZE)
+		if ((*mapfunc)(dev, off, (int)prot) == -1)
+			return(NULL);
+
+	/*
+	 * Look up pager, creating as necessary.
+	 */
+top:
+	pager = vm_pager_lookup(&dev_pager_list, handle);
+	if (pager == NULL) {
+		/*
+		 * Allocate and initialize pager structs
+		 */
+		pager = (vm_pager_t)malloc(sizeof *pager, M_VMPAGER, M_WAITOK);
+		if (pager == NULL)
+			return(NULL);
+		devp = (dev_pager_t)malloc(sizeof *devp, M_VMPGDATA, M_WAITOK);
+		if (devp == NULL) {
+			free((caddr_t)pager, M_VMPAGER);
+			return(NULL);
+		}
+		pager->pg_handle = handle;
+		pager->pg_ops = &devicepagerops;
+		pager->pg_type = PG_DEVICE;
+		pager->pg_flags = 0;
+		pager->pg_data = devp;
+		TAILQ_INIT(&devp->devp_pglist);
+		/*
+		 * Allocate object and associate it with the pager.
+		 */
+		object = devp->devp_object = vm_object_allocate(0);
+		vm_object_enter(object, pager);
+		vm_object_setpager(object, pager, (vm_offset_t)0, FALSE);
+		/*
+		 * Finally, put it on the managed list so other can find it.
+		 * First we re-lookup in case someone else beat us to this
+		 * point (due to blocking in the various mallocs).  If so,
+		 * we free everything and start over.
+		 */
+		if (vm_pager_lookup(&dev_pager_list, handle)) {
+			free((caddr_t)devp, M_VMPGDATA);
+			free((caddr_t)pager, M_VMPAGER);
+			goto top;
+		}
+		TAILQ_INSERT_TAIL(&dev_pager_list, pager, pg_list);
+#ifdef DEBUG
+		if (dpagerdebug & DDB_ALLOC) {
+			printf("dev_pager_alloc: pager %x devp %x object %x\n",
+			       pager, devp, object);
+			vm_object_print(object, FALSE);
+		}
+#endif
+	} else {
+		/*
+		 * vm_object_lookup() gains a reference and also
+		 * removes the object from the cache.
+		 */
+		object = vm_object_lookup(pager);
+#ifdef DIAGNOSTIC
+		devp = (dev_pager_t)pager->pg_data;
+		if (object != devp->devp_object)
+			panic("dev_pager_setup: bad object");
+#endif
+	}
+	return(pager);
+}
+
+static void
+dev_pager_dealloc(pager)
+	vm_pager_t pager;
+{
+	dev_pager_t devp;
+	vm_object_t object;
+	vm_page_t m;
+
+#ifdef DEBUG
+	if (dpagerdebug & DDB_FOLLOW)
+		printf("dev_pager_dealloc(%x)\n", pager);
+#endif
+	TAILQ_REMOVE(&dev_pager_list, pager, pg_list);
+	/*
+	 * Get the object.
+	 * Note: cannot use vm_object_lookup since object has already
+	 * been removed from the hash chain.
+	 */
+	devp = (dev_pager_t)pager->pg_data;
+	object = devp->devp_object;
+#ifdef DEBUG
+	if (dpagerdebug & DDB_ALLOC)
+		printf("dev_pager_dealloc: devp %x object %x\n", devp, object);
+#endif
+	/*
+	 * Free up our fake pages.
+	 */
+	while ((m = devp->devp_pglist.tqh_first) != NULL) {
+		TAILQ_REMOVE(&devp->devp_pglist, m, pageq);
+		dev_pager_putfake(m);
+	}
+	free((caddr_t)devp, M_VMPGDATA);
+	free((caddr_t)pager, M_VMPAGER);
+}
+
+static int
+dev_pager_getpage(pager, mlist, npages, sync)
+	vm_pager_t pager;
+	vm_page_t *mlist;
+	int npages;
+	boolean_t sync;
+{
+	register vm_object_t object;
+	vm_offset_t offset, paddr;
+	vm_page_t page;
+	dev_t dev;
+	int (*mapfunc)(), prot;
+	vm_page_t m;
+
+#ifdef DEBUG
+	if (dpagerdebug & DDB_FOLLOW)
+		printf("dev_pager_getpage(%x, %x, %x, %x)\n",
+		       pager, mlist, npages, sync);
+#endif
+
+	if (npages != 1)
+		panic("dev_pager_getpage: cannot handle multiple pages");
+	m = *mlist;
+
+	object = m->object;
+	dev = (dev_t)pager->pg_handle;
+	offset = m->offset + object->paging_offset;
+	prot = PROT_READ;	/* XXX should pass in? */
+	mapfunc = cdevsw[major(dev)].d_mmap;
+#ifdef DIAGNOSTIC
+	if (mapfunc == NULL || mapfunc == enodev || mapfunc == nullop)
+		panic("dev_pager_getpage: no map function");
+#endif
+	paddr = pmap_phys_address((*mapfunc)(dev, (int)offset, prot));
+#ifdef DIAGNOSTIC
+	if (paddr == -1)
+		panic("dev_pager_getpage: map function returns error");
+#endif
+	/*
+	 * Replace the passed in page with our own fake page and free
+	 * up the original.
+	 */
+	page = dev_pager_getfake(paddr);
+	TAILQ_INSERT_TAIL(&((dev_pager_t)pager->pg_data)->devp_pglist, page,
+	    pageq);
+	vm_object_lock(object);
+	vm_page_lock_queues();
+	vm_page_free(m);
+	vm_page_insert(page, object, offset);
+	vm_page_unlock_queues();
+	PAGE_WAKEUP(m);
+	if (offset + PAGE_SIZE > object->size)
+		object->size = offset + PAGE_SIZE;	/* XXX anal */
+	vm_object_unlock(object);
+
+	return(VM_PAGER_OK);
+}
+
+static int
+dev_pager_putpage(pager, mlist, npages, sync)
+	vm_pager_t pager;
+	vm_page_t *mlist;
+	int npages;
+	boolean_t sync;
+{
+#ifdef DEBUG
+	if (dpagerdebug & DDB_FOLLOW)
+		printf("dev_pager_putpage(%x, %x, %x, %x)\n",
+		       pager, mlist, npages, sync);
+#endif
+	if (pager == NULL)
+		return;
+	panic("dev_pager_putpage called");
+}
+
+static boolean_t
+dev_pager_haspage(pager, offset)
+	vm_pager_t pager;
+	vm_offset_t offset;
+{
+#ifdef DEBUG
+	if (dpagerdebug & DDB_FOLLOW)
+		printf("dev_pager_haspage(%x, %x)\n", pager, offset);
+#endif
+	return(TRUE);
+}
+
+static vm_page_t
+dev_pager_getfake(paddr)
+	vm_offset_t paddr;
+{
+	vm_page_t m;
+	int i;
+
+	if (dev_pager_fakelist.tqh_first == NULL) {
+		m = (vm_page_t)malloc(PAGE_SIZE, M_VMPGDATA, M_WAITOK);
+		for (i = PAGE_SIZE / sizeof(*m); i > 0; i--) {
+			TAILQ_INSERT_TAIL(&dev_pager_fakelist, m, pageq);
+			m++;
+		}
+	}
+	m = dev_pager_fakelist.tqh_first;
+	TAILQ_REMOVE(&dev_pager_fakelist, m, pageq);
+	m->flags = PG_BUSY | PG_CLEAN | PG_FAKE | PG_FICTITIOUS;
+	m->phys_addr = paddr;
+	m->wire_count = 1;
+	return(m);
+}
+
+static void
+dev_pager_putfake(m)
+	vm_page_t m;
+{
+#ifdef DIAGNOSTIC
+	if (!(m->flags & PG_FICTITIOUS))
+		panic("dev_pager_putfake: bad page");
+#endif
+	TAILQ_INSERT_TAIL(&dev_pager_fakelist, m, pageq);
+}

--- a/src-uland/libvm/swap_pager.c
+++ b/src-uland/libvm/swap_pager.c
@@ -1,0 +1,1010 @@
+/* Copied from sys/vm/swap_pager.c */
+/*
+ * Copyright (c) 1990 University of Utah.
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * the Systems Programming Group of the University of Utah Computer
+ * Science Department.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * from: Utah $Hdr: swap_pager.c 1.4 91/04/30$
+ *
+ *	@(#)swap_pager.c	8.9 (Berkeley) 3/21/94
+ */
+
+/*
+ * Quick hack to page to dedicated partition(s).
+ * TODO:
+ *	Add multiprocessor locks
+ *	Deal with async writes in a better fashion
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/buf.h>
+#include <sys/map.h>
+#include <sys/vnode.h>
+#include <sys/malloc.h>
+
+#include <miscfs/specfs/specdev.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vm_pageout.h>
+#include <vm/swap_pager.h>
+
+#define NSWSIZES	16	/* size of swtab */
+#define MAXDADDRS	64	/* max # of disk addrs for fixed allocations */
+#ifndef NPENDINGIO
+#define NPENDINGIO	64	/* max # of pending cleans */
+#endif
+
+#ifdef DEBUG
+int	swpagerdebug = 0x100;
+#define	SDB_FOLLOW	0x001
+#define SDB_INIT	0x002
+#define SDB_ALLOC	0x004
+#define SDB_IO		0x008
+#define SDB_WRITE	0x010
+#define SDB_FAIL	0x020
+#define SDB_ALLOCBLK	0x040
+#define SDB_FULL	0x080
+#define SDB_ANOM	0x100
+#define SDB_ANOMPANIC	0x200
+#define SDB_CLUSTER	0x400
+#define SDB_PARANOIA	0x800
+#endif
+
+TAILQ_HEAD(swpclean, swpagerclean);
+
+struct swpagerclean {
+	TAILQ_ENTRY(swpagerclean)	spc_list;
+	int				spc_flags;
+	struct buf			*spc_bp;
+	sw_pager_t			spc_swp;
+	vm_offset_t			spc_kva;
+	vm_page_t			spc_m;
+	int				spc_npages;
+} swcleanlist[NPENDINGIO];
+typedef struct swpagerclean *swp_clean_t;
+
+/* spc_flags values */
+#define SPC_FREE	0x00
+#define SPC_BUSY	0x01
+#define SPC_DONE	0x02
+#define SPC_ERROR	0x04
+
+struct swtab {
+	vm_size_t st_osize;	/* size of object (bytes) */
+	int	  st_bsize;	/* vs. size of swap block (DEV_BSIZE units) */
+#ifdef DEBUG
+	u_long	  st_inuse;	/* number in this range in use */
+	u_long	  st_usecnt;	/* total used of this size */
+#endif
+} swtab[NSWSIZES+1];
+
+#ifdef DEBUG
+int		swap_pager_poip;	/* pageouts in progress */
+int		swap_pager_piip;	/* pageins in progress */
+#endif
+
+int		swap_pager_maxcluster;	/* maximum cluster size */
+int		swap_pager_npendingio;	/* number of pager clean structs */
+
+struct swpclean	swap_pager_inuse;	/* list of pending page cleans */
+struct swpclean	swap_pager_free;	/* list of free pager clean structs */
+struct pagerlst	swap_pager_list;	/* list of "named" anon regions */
+
+static void 		swap_pager_init __P((void));
+static vm_pager_t	swap_pager_alloc
+			    __P((caddr_t, vm_size_t, vm_prot_t, vm_offset_t));
+static void		swap_pager_clean __P((int));
+#ifdef DEBUG
+static void		swap_pager_clean_check __P((vm_page_t *, int, int));
+#endif
+static void		swap_pager_cluster
+			    __P((vm_pager_t, vm_offset_t,
+				 vm_offset_t *, vm_offset_t *));
+static void		swap_pager_dealloc __P((vm_pager_t));
+static int		swap_pager_getpage
+			    __P((vm_pager_t, vm_page_t *, int, boolean_t));
+static boolean_t	swap_pager_haspage __P((vm_pager_t, vm_offset_t));
+static int		swap_pager_io __P((sw_pager_t, vm_page_t *, int, int));
+static void		swap_pager_iodone __P((struct buf *));
+static int		swap_pager_putpage
+			    __P((vm_pager_t, vm_page_t *, int, boolean_t));
+
+struct pagerops swappagerops = {
+	swap_pager_init,
+	swap_pager_alloc,
+	swap_pager_dealloc,
+	swap_pager_getpage,
+	swap_pager_putpage,
+	swap_pager_haspage,
+	swap_pager_cluster
+};
+
+static void
+swap_pager_init()
+{
+	register swp_clean_t spc;
+	register int i, bsize;
+	extern int dmmin, dmmax;
+	int maxbsize;
+
+#ifdef DEBUG
+	if (swpagerdebug & (SDB_FOLLOW|SDB_INIT))
+		printf("swpg_init()\n");
+#endif
+	dfltpagerops = &swappagerops;
+	TAILQ_INIT(&swap_pager_list);
+
+	/*
+	 * Allocate async IO structures.
+	 *
+	 * XXX it would be nice if we could do this dynamically based on
+	 * the value of nswbuf (since we are ultimately limited by that)
+	 * but neither nswbuf or malloc has been initialized yet.  So the
+	 * structs are statically allocated above.
+	 */
+	swap_pager_npendingio = NPENDINGIO;
+
+	/*
+	 * Initialize clean lists
+	 */
+	TAILQ_INIT(&swap_pager_inuse);
+	TAILQ_INIT(&swap_pager_free);
+	for (i = 0, spc = swcleanlist; i < swap_pager_npendingio; i++, spc++) {
+		TAILQ_INSERT_TAIL(&swap_pager_free, spc, spc_list);
+		spc->spc_flags = SPC_FREE;
+	}
+
+	/*
+	 * Calculate the swap allocation constants.
+	 */
+        if (dmmin == 0) {
+                dmmin = DMMIN;
+		if (dmmin < CLBYTES/DEV_BSIZE)
+			dmmin = CLBYTES/DEV_BSIZE;
+	}
+        if (dmmax == 0)
+                dmmax = DMMAX;
+
+	/*
+	 * Fill in our table of object size vs. allocation size
+	 */
+	bsize = btodb(PAGE_SIZE);
+	if (bsize < dmmin)
+		bsize = dmmin;
+	maxbsize = btodb(sizeof(sw_bm_t) * NBBY * PAGE_SIZE);
+	if (maxbsize > dmmax)
+		maxbsize = dmmax;
+	for (i = 0; i < NSWSIZES; i++) {
+		swtab[i].st_osize = (vm_size_t) (MAXDADDRS * dbtob(bsize));
+		swtab[i].st_bsize = bsize;
+		if (bsize <= btodb(MAXPHYS))
+			swap_pager_maxcluster = dbtob(bsize);
+#ifdef DEBUG
+		if (swpagerdebug & SDB_INIT)
+			printf("swpg_init: ix %d, size %x, bsize %x\n",
+			       i, swtab[i].st_osize, swtab[i].st_bsize);
+#endif
+		if (bsize >= maxbsize)
+			break;
+		bsize *= 2;
+	}
+	swtab[i].st_osize = 0;
+	swtab[i].st_bsize = bsize;
+}
+
+/*
+ * Allocate a pager structure and associated resources.
+ * Note that if we are called from the pageout daemon (handle == NULL)
+ * we should not wait for memory as it could resulting in deadlock.
+ */
+static vm_pager_t
+swap_pager_alloc(handle, size, prot, foff)
+	caddr_t handle;
+	register vm_size_t size;
+	vm_prot_t prot;
+	vm_offset_t foff;
+{
+	register vm_pager_t pager;
+	register sw_pager_t swp;
+	struct swtab *swt;
+	int waitok;
+
+#ifdef DEBUG
+	if (swpagerdebug & (SDB_FOLLOW|SDB_ALLOC))
+		printf("swpg_alloc(%x, %x, %x)\n", handle, size, prot);
+#endif
+	/*
+	 * If this is a "named" anonymous region, look it up and
+	 * return the appropriate pager if it exists.
+	 */
+	if (handle) {
+		pager = vm_pager_lookup(&swap_pager_list, handle);
+		if (pager != NULL) {
+			/*
+			 * Use vm_object_lookup to gain a reference
+			 * to the object and also to remove from the
+			 * object cache.
+			 */
+			if (vm_object_lookup(pager) == NULL)
+				panic("swap_pager_alloc: bad object");
+			return(pager);
+		}
+	}
+	/*
+	 * Pager doesn't exist, allocate swap management resources
+	 * and initialize.
+	 */
+	waitok = handle ? M_WAITOK : M_NOWAIT;
+	pager = (vm_pager_t)malloc(sizeof *pager, M_VMPAGER, waitok);
+	if (pager == NULL)
+		return(NULL);
+	swp = (sw_pager_t)malloc(sizeof *swp, M_VMPGDATA, waitok);
+	if (swp == NULL) {
+#ifdef DEBUG
+		if (swpagerdebug & SDB_FAIL)
+			printf("swpg_alloc: swpager malloc failed\n");
+#endif
+		free((caddr_t)pager, M_VMPAGER);
+		return(NULL);
+	}
+	size = round_page(size);
+	for (swt = swtab; swt->st_osize; swt++)
+		if (size <= swt->st_osize)
+			break;
+#ifdef DEBUG
+	swt->st_inuse++;
+	swt->st_usecnt++;
+#endif
+	swp->sw_osize = size;
+	swp->sw_bsize = swt->st_bsize;
+	swp->sw_nblocks = (btodb(size) + swp->sw_bsize - 1) / swp->sw_bsize;
+	swp->sw_blocks = (sw_blk_t)
+		malloc(swp->sw_nblocks*sizeof(*swp->sw_blocks),
+		       M_VMPGDATA, M_NOWAIT);
+	if (swp->sw_blocks == NULL) {
+		free((caddr_t)swp, M_VMPGDATA);
+		free((caddr_t)pager, M_VMPAGER);
+#ifdef DEBUG
+		if (swpagerdebug & SDB_FAIL)
+			printf("swpg_alloc: sw_blocks malloc failed\n");
+		swt->st_inuse--;
+		swt->st_usecnt--;
+#endif
+		return(FALSE);
+	}
+	bzero((caddr_t)swp->sw_blocks,
+	      swp->sw_nblocks * sizeof(*swp->sw_blocks));
+	swp->sw_poip = 0;
+	if (handle) {
+		vm_object_t object;
+
+		swp->sw_flags = SW_NAMED;
+		TAILQ_INSERT_TAIL(&swap_pager_list, pager, pg_list);
+		/*
+		 * Consistant with other pagers: return with object
+		 * referenced.  Can't do this with handle == NULL
+		 * since it might be the pageout daemon calling.
+		 */
+		object = vm_object_allocate(size);
+		vm_object_enter(object, pager);
+		vm_object_setpager(object, pager, 0, FALSE);
+	} else {
+		swp->sw_flags = 0;
+		pager->pg_list.tqe_next = NULL;
+		pager->pg_list.tqe_prev = NULL;
+	}
+	pager->pg_handle = handle;
+	pager->pg_ops = &swappagerops;
+	pager->pg_type = PG_SWAP;
+	pager->pg_flags = PG_CLUSTERPUT;
+	pager->pg_data = swp;
+
+#ifdef DEBUG
+	if (swpagerdebug & SDB_ALLOC)
+		printf("swpg_alloc: pg_data %x, %x of %x at %x\n",
+		       swp, swp->sw_nblocks, swp->sw_bsize, swp->sw_blocks);
+#endif
+	return(pager);
+}
+
+static void
+swap_pager_dealloc(pager)
+	vm_pager_t pager;
+{
+	register int i;
+	register sw_blk_t bp;
+	register sw_pager_t swp;
+	struct swtab *swt;
+	int s;
+
+#ifdef DEBUG
+	/* save panic time state */
+	if ((swpagerdebug & SDB_ANOMPANIC) && panicstr)
+		return;
+	if (swpagerdebug & (SDB_FOLLOW|SDB_ALLOC))
+		printf("swpg_dealloc(%x)\n", pager);
+#endif
+	/*
+	 * Remove from list right away so lookups will fail if we
+	 * block for pageout completion.
+	 */
+	swp = (sw_pager_t) pager->pg_data;
+	if (swp->sw_flags & SW_NAMED) {
+		TAILQ_REMOVE(&swap_pager_list, pager, pg_list);
+		swp->sw_flags &= ~SW_NAMED;
+	}
+#ifdef DEBUG
+	for (swt = swtab; swt->st_osize; swt++)
+		if (swp->sw_osize <= swt->st_osize)
+			break;
+	swt->st_inuse--;
+#endif
+
+	/*
+	 * Wait for all pageouts to finish and remove
+	 * all entries from cleaning list.
+	 */
+	s = splbio();
+	while (swp->sw_poip) {
+		swp->sw_flags |= SW_WANTED;
+		(void) tsleep(swp, PVM, "swpgdealloc", 0);
+	}
+	splx(s);
+	swap_pager_clean(B_WRITE);
+
+	/*
+	 * Free left over swap blocks
+	 */
+	for (i = 0, bp = swp->sw_blocks; i < swp->sw_nblocks; i++, bp++)
+		if (bp->swb_block) {
+#ifdef DEBUG
+			if (swpagerdebug & (SDB_ALLOCBLK|SDB_FULL))
+				printf("swpg_dealloc: blk %x\n",
+				       bp->swb_block);
+#endif
+			rmfree(swapmap, swp->sw_bsize, bp->swb_block);
+		}
+	/*
+	 * Free swap management resources
+	 */
+	free((caddr_t)swp->sw_blocks, M_VMPGDATA);
+	free((caddr_t)swp, M_VMPGDATA);
+	free((caddr_t)pager, M_VMPAGER);
+}
+
+static int
+swap_pager_getpage(pager, mlist, npages, sync)
+	vm_pager_t pager;
+	vm_page_t *mlist;
+	int npages;
+	boolean_t sync;
+{
+#ifdef DEBUG
+	if (swpagerdebug & SDB_FOLLOW)
+		printf("swpg_getpage(%x, %x, %x, %x)\n",
+		       pager, mlist, npages, sync);
+#endif
+	return(swap_pager_io((sw_pager_t)pager->pg_data,
+			     mlist, npages, B_READ));
+}
+
+static int
+swap_pager_putpage(pager, mlist, npages, sync)
+	vm_pager_t pager;
+	vm_page_t *mlist;
+	int npages;
+	boolean_t sync;
+{
+	int flags;
+
+#ifdef DEBUG
+	if (swpagerdebug & SDB_FOLLOW)
+		printf("swpg_putpage(%x, %x, %x, %x)\n",
+		       pager, mlist, npages, sync);
+#endif
+	if (pager == NULL) {
+		swap_pager_clean(B_WRITE);
+		return (VM_PAGER_OK);		/* ??? */
+	}
+	flags = B_WRITE;
+	if (!sync)
+		flags |= B_ASYNC;
+	return(swap_pager_io((sw_pager_t)pager->pg_data,
+			     mlist, npages, flags));
+}
+
+static boolean_t
+swap_pager_haspage(pager, offset)
+	vm_pager_t pager;
+	vm_offset_t offset;
+{
+	register sw_pager_t swp;
+	register sw_blk_t swb;
+	int ix;
+
+#ifdef DEBUG
+	if (swpagerdebug & (SDB_FOLLOW|SDB_ALLOCBLK))
+		printf("swpg_haspage(%x, %x) ", pager, offset);
+#endif
+	swp = (sw_pager_t) pager->pg_data;
+	ix = offset / dbtob(swp->sw_bsize);
+	if (swp->sw_blocks == NULL || ix >= swp->sw_nblocks) {
+#ifdef DEBUG
+		if (swpagerdebug & (SDB_FAIL|SDB_FOLLOW|SDB_ALLOCBLK))
+			printf("swpg_haspage: %x bad offset %x, ix %x\n",
+			       swp->sw_blocks, offset, ix);
+#endif
+		return(FALSE);
+	}
+	swb = &swp->sw_blocks[ix];
+	if (swb->swb_block)
+		ix = atop(offset % dbtob(swp->sw_bsize));
+#ifdef DEBUG
+	if (swpagerdebug & SDB_ALLOCBLK)
+		printf("%x blk %x+%x ", swp->sw_blocks, swb->swb_block, ix);
+	if (swpagerdebug & (SDB_FOLLOW|SDB_ALLOCBLK))
+		printf("-> %c\n",
+		       "FT"[swb->swb_block && (swb->swb_mask & (1 << ix))]);
+#endif
+	if (swb->swb_block && (swb->swb_mask & (1 << ix)))
+		return(TRUE);
+	return(FALSE);
+}
+
+static void
+swap_pager_cluster(pager, offset, loffset, hoffset)
+	vm_pager_t	pager;
+	vm_offset_t	offset;
+	vm_offset_t	*loffset;
+	vm_offset_t	*hoffset;
+{
+	sw_pager_t swp;
+	register int bsize;
+	vm_offset_t loff, hoff;
+
+#ifdef DEBUG
+	if (swpagerdebug & (SDB_FOLLOW|SDB_CLUSTER))
+		printf("swpg_cluster(%x, %x) ", pager, offset);
+#endif
+	swp = (sw_pager_t) pager->pg_data;
+	bsize = dbtob(swp->sw_bsize);
+	if (bsize > swap_pager_maxcluster)
+		bsize = swap_pager_maxcluster;
+
+	loff = offset - (offset % bsize);
+	if (loff >= swp->sw_osize)
+		panic("swap_pager_cluster: bad offset");
+
+	hoff = loff + bsize;
+	if (hoff > swp->sw_osize)
+		hoff = swp->sw_osize;
+
+	*loffset = loff;
+	*hoffset = hoff;
+#ifdef DEBUG
+	if (swpagerdebug & (SDB_FOLLOW|SDB_CLUSTER))
+		printf("returns [%x-%x]\n", loff, hoff);
+#endif
+}
+
+/*
+ * Scaled down version of swap().
+ * Assumes that PAGE_SIZE < MAXPHYS; i.e. only one operation needed.
+ * BOGUS:  lower level IO routines expect a KVA so we have to map our
+ * provided physical page into the KVA to keep them happy.
+ */
+static int
+swap_pager_io(swp, mlist, npages, flags)
+	register sw_pager_t swp;
+	vm_page_t *mlist;
+	int npages;
+	int flags;
+{
+	register struct buf *bp;
+	register sw_blk_t swb;
+	register int s;
+	int ix, mask;
+	boolean_t rv;
+	vm_offset_t kva, off;
+	swp_clean_t spc;
+	vm_page_t m;
+
+#ifdef DEBUG
+	/* save panic time state */
+	if ((swpagerdebug & SDB_ANOMPANIC) && panicstr)
+		return (VM_PAGER_FAIL);		/* XXX: correct return? */
+	if (swpagerdebug & (SDB_FOLLOW|SDB_IO))
+		printf("swpg_io(%x, %x, %x, %x)\n", swp, mlist, npages, flags);
+	if (flags & B_READ) {
+		if (flags & B_ASYNC)
+			panic("swap_pager_io: cannot do ASYNC reads");
+		if (npages != 1)
+			panic("swap_pager_io: cannot do clustered reads");
+	}
+#endif
+
+	/*
+	 * First determine if the page exists in the pager if this is
+	 * a sync read.  This quickly handles cases where we are
+	 * following shadow chains looking for the top level object
+	 * with the page.
+	 */
+	m = *mlist;
+	off = m->offset + m->object->paging_offset;
+	ix = off / dbtob(swp->sw_bsize);
+	if (swp->sw_blocks == NULL || ix >= swp->sw_nblocks) {
+#ifdef DEBUG
+		if ((flags & B_READ) == 0 && (swpagerdebug & SDB_ANOM)) {
+			printf("swap_pager_io: no swap block on write\n");
+			return(VM_PAGER_BAD);
+		}
+#endif
+		return(VM_PAGER_FAIL);
+	}
+	swb = &swp->sw_blocks[ix];
+	off = off % dbtob(swp->sw_bsize);
+	if ((flags & B_READ) &&
+	    (swb->swb_block == 0 || (swb->swb_mask & (1 << atop(off))) == 0))
+		return(VM_PAGER_FAIL);
+
+	/*
+	 * For reads (pageins) and synchronous writes, we clean up
+	 * all completed async pageouts.
+	 */
+	if ((flags & B_ASYNC) == 0) {
+		s = splbio();
+		swap_pager_clean(flags&B_READ);
+#ifdef DEBUG
+		if (swpagerdebug & SDB_PARANOIA)
+			swap_pager_clean_check(mlist, npages, flags&B_READ);
+#endif
+		splx(s);
+	}
+	/*
+	 * For async writes (pageouts), we cleanup completed pageouts so
+	 * that all available resources are freed.  Also tells us if this
+	 * page is already being cleaned.  If it is, or no resources
+	 * are available, we try again later.
+	 */
+	else {
+		swap_pager_clean(B_WRITE);
+#ifdef DEBUG
+		if (swpagerdebug & SDB_PARANOIA)
+			swap_pager_clean_check(mlist, npages, B_WRITE);
+#endif
+		if (swap_pager_free.tqh_first == NULL) {
+#ifdef DEBUG
+			if (swpagerdebug & SDB_FAIL)
+				printf("%s: no available io headers\n",
+				       "swap_pager_io");
+#endif
+			return(VM_PAGER_AGAIN);
+		}
+	}
+
+	/*
+	 * Allocate a swap block if necessary.
+	 */
+	if (swb->swb_block == 0) {
+		swb->swb_block = rmalloc(swapmap, swp->sw_bsize);
+		if (swb->swb_block == 0) {
+#ifdef DEBUG
+			if (swpagerdebug & SDB_FAIL)
+				printf("swpg_io: rmalloc of %x failed\n",
+				       swp->sw_bsize);
+#endif
+			/*
+			 * XXX this is technically a resource shortage that
+			 * should return AGAIN, but the situation isn't likely
+			 * to be remedied just by delaying a little while and
+			 * trying again (the pageout daemon's current response
+			 * to AGAIN) so we just return FAIL.
+			 */
+			return(VM_PAGER_FAIL);
+		}
+#ifdef DEBUG
+		if (swpagerdebug & (SDB_FULL|SDB_ALLOCBLK))
+			printf("swpg_io: %x alloc blk %x at ix %x\n",
+			       swp->sw_blocks, swb->swb_block, ix);
+#endif
+	}
+
+	/*
+	 * Allocate a kernel virtual address and initialize so that PTE
+	 * is available for lower level IO drivers.
+	 */
+	kva = vm_pager_map_pages(mlist, npages, !(flags & B_ASYNC));
+	if (kva == NULL) {
+#ifdef DEBUG
+		if (swpagerdebug & SDB_FAIL)
+			printf("%s: no KVA space to map pages\n",
+			       "swap_pager_io");
+#endif
+		return(VM_PAGER_AGAIN);
+	}
+
+	/*
+	 * Get a swap buffer header and initialize it.
+	 */
+	s = splbio();
+	while (bswlist.b_actf == NULL) {
+#ifdef DEBUG
+		if (swpagerdebug & SDB_ANOM)
+			printf("swap_pager_io: wait on swbuf for %x (%d)\n",
+			       m, flags);
+#endif
+		bswlist.b_flags |= B_WANTED;
+		tsleep((caddr_t)&bswlist, PSWP+1, "swpgiobuf", 0);
+	}
+	bp = bswlist.b_actf;
+	bswlist.b_actf = bp->b_actf;
+	splx(s);
+	bp->b_flags = B_BUSY | (flags & B_READ);
+	bp->b_proc = &proc0;	/* XXX (but without B_PHYS set this is ok) */
+	bp->b_data = (caddr_t)kva;
+	bp->b_blkno = swb->swb_block + btodb(off);
+	VHOLD(swapdev_vp);
+	bp->b_vp = swapdev_vp;
+	if (swapdev_vp->v_type == VBLK)
+		bp->b_dev = swapdev_vp->v_rdev;
+	bp->b_bcount = npages * PAGE_SIZE;
+
+	/*
+	 * For writes we set up additional buffer fields, record a pageout
+	 * in progress and mark that these swap blocks are now allocated.
+	 */
+	if ((bp->b_flags & B_READ) == 0) {
+		bp->b_dirtyoff = 0;
+		bp->b_dirtyend = npages * PAGE_SIZE;
+		swapdev_vp->v_numoutput++;
+		s = splbio();
+		swp->sw_poip++;
+		splx(s);
+		mask = (~(~0 << npages)) << atop(off);
+#ifdef DEBUG
+		swap_pager_poip++;
+		if (swpagerdebug & SDB_WRITE)
+			printf("swpg_io: write: bp=%x swp=%x poip=%d\n",
+			       bp, swp, swp->sw_poip);
+		if ((swpagerdebug & SDB_ALLOCBLK) &&
+		    (swb->swb_mask & mask) != mask)
+			printf("swpg_io: %x write %d pages at %x+%x\n",
+			       swp->sw_blocks, npages, swb->swb_block,
+			       atop(off));
+		if (swpagerdebug & SDB_CLUSTER)
+			printf("swpg_io: off=%x, npg=%x, mask=%x, bmask=%x\n",
+			       off, npages, mask, swb->swb_mask);
+#endif
+		swb->swb_mask |= mask;
+	}
+	/*
+	 * If this is an async write we set up still more buffer fields
+	 * and place a "cleaning" entry on the inuse queue.
+	 */
+	if ((flags & (B_READ|B_ASYNC)) == B_ASYNC) {
+#ifdef DEBUG
+		if (swap_pager_free.tqh_first == NULL)
+			panic("swpg_io: lost spc");
+#endif
+		spc = swap_pager_free.tqh_first;
+		TAILQ_REMOVE(&swap_pager_free, spc, spc_list);
+#ifdef DEBUG
+		if (spc->spc_flags != SPC_FREE)
+			panic("swpg_io: bad free spc");
+#endif
+		spc->spc_flags = SPC_BUSY;
+		spc->spc_bp = bp;
+		spc->spc_swp = swp;
+		spc->spc_kva = kva;
+		/*
+		 * Record the first page.  This allows swap_pager_clean
+		 * to efficiently handle the common case of a single page.
+		 * For clusters, it allows us to locate the object easily
+		 * and we then reconstruct the rest of the mlist from spc_kva.
+		 */
+		spc->spc_m = m;
+		spc->spc_npages = npages;
+		bp->b_flags |= B_CALL;
+		bp->b_iodone = swap_pager_iodone;
+		s = splbio();
+		TAILQ_INSERT_TAIL(&swap_pager_inuse, spc, spc_list);
+		splx(s);
+	}
+
+	/*
+	 * Finally, start the IO operation.
+	 * If it is async we are all done, otherwise we must wait for
+	 * completion and cleanup afterwards.
+	 */
+#ifdef DEBUG
+	if (swpagerdebug & SDB_IO)
+		printf("swpg_io: IO start: bp %x, db %x, va %x, pa %x\n",
+		       bp, swb->swb_block+btodb(off), kva, VM_PAGE_TO_PHYS(m));
+#endif
+	VOP_STRATEGY(bp);
+	if ((flags & (B_READ|B_ASYNC)) == B_ASYNC) {
+#ifdef DEBUG
+		if (swpagerdebug & SDB_IO)
+			printf("swpg_io:  IO started: bp %x\n", bp);
+#endif
+		return(VM_PAGER_PEND);
+	}
+	s = splbio();
+#ifdef DEBUG
+	if (flags & B_READ)
+		swap_pager_piip++;
+	else
+		swap_pager_poip++;
+#endif
+	while ((bp->b_flags & B_DONE) == 0)
+		(void) tsleep(bp, PVM, "swpgio", 0);
+	if ((flags & B_READ) == 0)
+		--swp->sw_poip;
+#ifdef DEBUG
+	if (flags & B_READ)
+		--swap_pager_piip;
+	else
+		--swap_pager_poip;
+#endif
+	rv = (bp->b_flags & B_ERROR) ? VM_PAGER_ERROR : VM_PAGER_OK;
+	bp->b_flags &= ~(B_BUSY|B_WANTED|B_PHYS|B_PAGET|B_UAREA|B_DIRTY);
+	bp->b_actf = bswlist.b_actf;
+	bswlist.b_actf = bp;
+	if (bp->b_vp)
+		brelvp(bp);
+	if (bswlist.b_flags & B_WANTED) {
+		bswlist.b_flags &= ~B_WANTED;
+		wakeup(&bswlist);
+	}
+	if ((flags & B_READ) == 0 && rv == VM_PAGER_OK) {
+		m->flags |= PG_CLEAN;
+		pmap_clear_modify(VM_PAGE_TO_PHYS(m));
+	}
+	splx(s);
+#ifdef DEBUG
+	if (swpagerdebug & SDB_IO)
+		printf("swpg_io:  IO done: bp %x, rv %d\n", bp, rv);
+	if ((swpagerdebug & SDB_FAIL) && rv == VM_PAGER_ERROR)
+		printf("swpg_io: IO error\n");
+#endif
+	vm_pager_unmap_pages(kva, npages);
+	return(rv);
+}
+
+static void
+swap_pager_clean(rw)
+	int rw;
+{
+	register swp_clean_t spc;
+	register int s, i;
+	vm_object_t object;
+	vm_page_t m;
+
+#ifdef DEBUG
+	/* save panic time state */
+	if ((swpagerdebug & SDB_ANOMPANIC) && panicstr)
+		return;
+	if (swpagerdebug & SDB_FOLLOW)
+		printf("swpg_clean(%x)\n", rw);
+#endif
+
+	for (;;) {
+		/*
+		 * Look up and removal from inuse list must be done
+		 * at splbio() to avoid conflicts with swap_pager_iodone.
+		 */
+		s = splbio();
+		for (spc = swap_pager_inuse.tqh_first;
+		     spc != NULL;
+		     spc = spc->spc_list.tqe_next) {
+			/*
+			 * If the operation is done, remove it from the
+			 * list and process it.
+			 *
+			 * XXX if we can't get the object lock we also
+			 * leave it on the list and try again later.
+			 * Is there something better we could do?
+			 */
+			if ((spc->spc_flags & SPC_DONE) &&
+			    vm_object_lock_try(spc->spc_m->object)) {
+				TAILQ_REMOVE(&swap_pager_inuse, spc, spc_list);
+				break;
+			}
+		}
+		splx(s);
+
+		/*
+		 * No operations done, thats all we can do for now.
+		 */
+		if (spc == NULL)
+			break;
+
+		/*
+		 * Found a completed operation so finish it off.
+		 * Note: no longer at splbio since entry is off the list.
+		 */
+		m = spc->spc_m;
+		object = m->object;
+
+		/*
+		 * Process each page in the cluster.
+		 * The first page is explicitly kept in the cleaning
+		 * entry, others must be reconstructed from the KVA.
+		 */
+		for (i = 0; i < spc->spc_npages; i++) {
+			if (i)
+				m = vm_pager_atop(spc->spc_kva + ptoa(i));
+			/*
+			 * If no error mark as clean and inform the pmap
+			 * system.  If there was an error, mark as dirty
+			 * so we will try again.
+			 *
+			 * XXX could get stuck doing this, should give up
+			 * after awhile.
+			 */
+			if (spc->spc_flags & SPC_ERROR) {
+				printf("%s: clean of page %x failed\n",
+				       "swap_pager_clean",
+				       VM_PAGE_TO_PHYS(m));
+				m->flags |= PG_LAUNDRY;
+			} else {
+				m->flags |= PG_CLEAN;
+				pmap_clear_modify(VM_PAGE_TO_PHYS(m));
+			}
+			m->flags &= ~PG_BUSY;
+			PAGE_WAKEUP(m);
+		}
+
+		/*
+		 * Done with the object, decrement the paging count
+		 * and unlock it.
+		 */
+		if (--object->paging_in_progress == 0)
+			wakeup(object);
+		vm_object_unlock(object);
+
+		/*
+		 * Free up KVM used and put the entry back on the list.
+		 */
+		vm_pager_unmap_pages(spc->spc_kva, spc->spc_npages);
+		spc->spc_flags = SPC_FREE;
+		TAILQ_INSERT_TAIL(&swap_pager_free, spc, spc_list);
+#ifdef DEBUG
+		if (swpagerdebug & SDB_WRITE)
+			printf("swpg_clean: free spc %x\n", spc);
+#endif
+	}
+}
+
+#ifdef DEBUG
+static void
+swap_pager_clean_check(mlist, npages, rw)
+	vm_page_t *mlist;
+	int npages;
+	int rw;
+{
+	register swp_clean_t spc;
+	boolean_t bad;
+	int i, j, s;
+	vm_page_t m;
+
+	if (panicstr)
+		return;
+
+	bad = FALSE;
+	s = splbio();
+	for (spc = swap_pager_inuse.tqh_first;
+	     spc != NULL;
+	     spc = spc->spc_list.tqe_next) {
+		for (j = 0; j < spc->spc_npages; j++) {
+			m = vm_pager_atop(spc->spc_kva + ptoa(j));
+			for (i = 0; i < npages; i++)
+				if (m == mlist[i]) {
+					if (swpagerdebug & SDB_ANOM)
+						printf(
+		"swpg_clean_check: %s: page %x on list, flags %x\n",
+		rw == B_WRITE ? "write" : "read", mlist[i], spc->spc_flags);
+					bad = TRUE;
+				}
+		}
+	}
+	splx(s);
+	if (bad)
+		panic("swpg_clean_check");
+}
+#endif
+
+static void
+swap_pager_iodone(bp)
+	register struct buf *bp;
+{
+	register swp_clean_t spc;
+	daddr_t blk;
+	int s;
+
+#ifdef DEBUG
+	/* save panic time state */
+	if ((swpagerdebug & SDB_ANOMPANIC) && panicstr)
+		return;
+	if (swpagerdebug & SDB_FOLLOW)
+		printf("swpg_iodone(%x)\n", bp);
+#endif
+	s = splbio();
+	for (spc = swap_pager_inuse.tqh_first;
+	     spc != NULL;
+	     spc = spc->spc_list.tqe_next)
+		if (spc->spc_bp == bp)
+			break;
+#ifdef DEBUG
+	if (spc == NULL)
+		panic("swap_pager_iodone: bp not found");
+#endif
+
+	spc->spc_flags &= ~SPC_BUSY;
+	spc->spc_flags |= SPC_DONE;
+	if (bp->b_flags & B_ERROR)
+		spc->spc_flags |= SPC_ERROR;
+	spc->spc_bp = NULL;
+	blk = bp->b_blkno;
+
+#ifdef DEBUG
+	--swap_pager_poip;
+	if (swpagerdebug & SDB_WRITE)
+		printf("swpg_iodone: bp=%x swp=%x flags=%x spc=%x poip=%x\n",
+		       bp, spc->spc_swp, spc->spc_swp->sw_flags,
+		       spc, spc->spc_swp->sw_poip);
+#endif
+
+	spc->spc_swp->sw_poip--;
+	if (spc->spc_swp->sw_flags & SW_WANTED) {
+		spc->spc_swp->sw_flags &= ~SW_WANTED;
+		wakeup(spc->spc_swp);
+	}
+		
+	bp->b_flags &= ~(B_BUSY|B_WANTED|B_PHYS|B_PAGET|B_UAREA|B_DIRTY);
+	bp->b_actf = bswlist.b_actf;
+	bswlist.b_actf = bp;
+	if (bp->b_vp)
+		brelvp(bp);
+	if (bswlist.b_flags & B_WANTED) {
+		bswlist.b_flags &= ~B_WANTED;
+		wakeup(&bswlist);
+	}
+	wakeup(&vm_pages_needed);
+	splx(s);
+}

--- a/src-uland/libvm/vm_fault.c
+++ b/src-uland/libvm/vm_fault.c
@@ -1,0 +1,1038 @@
+/* Copied from sys/vm/vm_fault.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_fault.c	8.5 (Berkeley) 1/9/95
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	Page fault handling module.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vm_pageout.h>
+
+/*
+ *	vm_fault:
+ *
+ *	Handle a page fault occuring at the given address,
+ *	requiring the given permissions, in the map specified.
+ *	If successful, the page is inserted into the
+ *	associated physical map.
+ *
+ *	NOTE: the given address should be truncated to the
+ *	proper page address.
+ *
+ *	KERN_SUCCESS is returned if the page fault is handled; otherwise,
+ *	a standard error specifying why the fault is fatal is returned.
+ *
+ *
+ *	The map in question must be referenced, and remains so.
+ *	Caller may hold no locks.
+ */
+int
+vm_fault(map, vaddr, fault_type, change_wiring)
+	vm_map_t	map;
+	vm_offset_t	vaddr;
+	vm_prot_t	fault_type;
+	boolean_t	change_wiring;
+{
+	vm_object_t		first_object;
+	vm_offset_t		first_offset;
+	vm_map_entry_t		entry;
+	register vm_object_t	object;
+	register vm_offset_t	offset;
+	register vm_page_t	m;
+	vm_page_t		first_m;
+	vm_prot_t		prot;
+	int			result;
+	boolean_t		wired;
+	boolean_t		su;
+	boolean_t		lookup_still_valid;
+	boolean_t		page_exists;
+	vm_page_t		old_m;
+	vm_object_t		next_object;
+
+	cnt.v_faults++;		/* needs lock XXX */
+/*
+ *	Recovery actions
+ */
+#define	FREE_PAGE(m)	{				\
+	PAGE_WAKEUP(m);					\
+	vm_page_lock_queues();				\
+	vm_page_free(m);				\
+	vm_page_unlock_queues();			\
+}
+
+#define	RELEASE_PAGE(m)	{				\
+	PAGE_WAKEUP(m);					\
+	vm_page_lock_queues();				\
+	vm_page_activate(m);				\
+	vm_page_unlock_queues();			\
+}
+
+#define	UNLOCK_MAP	{				\
+	if (lookup_still_valid) {			\
+		vm_map_lookup_done(map, entry);		\
+		lookup_still_valid = FALSE;		\
+	}						\
+}
+
+#define	UNLOCK_THINGS	{				\
+	object->paging_in_progress--;			\
+	vm_object_unlock(object);			\
+	if (object != first_object) {			\
+		vm_object_lock(first_object);		\
+		FREE_PAGE(first_m);			\
+		first_object->paging_in_progress--;	\
+		vm_object_unlock(first_object);		\
+	}						\
+	UNLOCK_MAP;					\
+}
+
+#define	UNLOCK_AND_DEALLOCATE	{			\
+	UNLOCK_THINGS;					\
+	vm_object_deallocate(first_object);		\
+}
+
+    RetryFault: ;
+
+	/*
+	 *	Find the backing store object and offset into
+	 *	it to begin the search.
+	 */
+
+	if ((result = vm_map_lookup(&map, vaddr, fault_type, &entry,
+			&first_object, &first_offset,
+			&prot, &wired, &su)) != KERN_SUCCESS) {
+		return(result);
+	}
+	lookup_still_valid = TRUE;
+
+	if (wired)
+		fault_type = prot;
+
+	first_m = NULL;
+
+   	/*
+	 *	Make a reference to this object to
+	 *	prevent its disposal while we are messing with
+	 *	it.  Once we have the reference, the map is free
+	 *	to be diddled.  Since objects reference their
+	 *	shadows (and copies), they will stay around as well.
+	 */
+
+	vm_object_lock(first_object);
+
+	first_object->ref_count++;
+	first_object->paging_in_progress++;
+
+	/*
+	 *	INVARIANTS (through entire routine):
+	 *
+	 *	1)	At all times, we must either have the object
+	 *		lock or a busy page in some object to prevent
+	 *		some other thread from trying to bring in
+	 *		the same page.
+	 *
+	 *		Note that we cannot hold any locks during the
+	 *		pager access or when waiting for memory, so
+	 *		we use a busy page then.
+	 *
+	 *		Note also that we aren't as concerned about
+	 *		more than one thead attempting to pager_data_unlock
+	 *		the same page at once, so we don't hold the page
+	 *		as busy then, but do record the highest unlock
+	 *		value so far.  [Unlock requests may also be delivered
+	 *		out of order.]
+	 *
+	 *	2)	Once we have a busy page, we must remove it from
+	 *		the pageout queues, so that the pageout daemon
+	 *		will not grab it away.
+	 *
+	 *	3)	To prevent another thread from racing us down the
+	 *		shadow chain and entering a new page in the top
+	 *		object before we do, we must keep a busy page in
+	 *		the top object while following the shadow chain.
+	 *
+	 *	4)	We must increment paging_in_progress on any object
+	 *		for which we have a busy page, to prevent
+	 *		vm_object_collapse from removing the busy page
+	 *		without our noticing.
+	 */
+
+	/*
+	 *	Search for the page at object/offset.
+	 */
+
+	object = first_object;
+	offset = first_offset;
+
+	/*
+	 *	See whether this page is resident
+	 */
+
+	while (TRUE) {
+		m = vm_page_lookup(object, offset);
+		if (m != NULL) {
+			/*
+			 *	If the page is being brought in,
+			 *	wait for it and then retry.
+			 */
+			if (m->flags & PG_BUSY) {
+#ifdef DOTHREADS
+				int	wait_result;
+
+				PAGE_ASSERT_WAIT(m, !change_wiring);
+				UNLOCK_THINGS;
+				thread_block();
+				wait_result = current_thread()->wait_result;
+				vm_object_deallocate(first_object);
+				if (wait_result != THREAD_AWAKENED)
+					return(KERN_SUCCESS);
+				goto RetryFault;
+#else
+				PAGE_ASSERT_WAIT(m, !change_wiring);
+				UNLOCK_THINGS;
+				cnt.v_intrans++;
+				thread_block();
+				vm_object_deallocate(first_object);
+				goto RetryFault;
+#endif
+			}
+
+			/*
+			 *	Remove the page from the pageout daemon's
+			 *	reach while we play with it.
+			 */
+
+			vm_page_lock_queues();
+			if (m->flags & PG_INACTIVE) {
+				TAILQ_REMOVE(&vm_page_queue_inactive, m, pageq);
+				m->flags &= ~PG_INACTIVE;
+				cnt.v_inactive_count--;
+				cnt.v_reactivated++;
+			} 
+
+			if (m->flags & PG_ACTIVE) {
+				TAILQ_REMOVE(&vm_page_queue_active, m, pageq);
+				m->flags &= ~PG_ACTIVE;
+				cnt.v_active_count--;
+			}
+			vm_page_unlock_queues();
+
+			/*
+			 *	Mark page busy for other threads.
+			 */
+			m->flags |= PG_BUSY;
+			break;
+		}
+
+		if (((object->pager != NULL) &&
+				(!change_wiring || wired))
+		    || (object == first_object)) {
+
+			/*
+			 *	Allocate a new page for this object/offset
+			 *	pair.
+			 */
+
+			m = vm_page_alloc(object, offset);
+
+			if (m == NULL) {
+				UNLOCK_AND_DEALLOCATE;
+				VM_WAIT;
+				goto RetryFault;
+			}
+		}
+
+		if (object->pager != NULL && (!change_wiring || wired)) {
+			int rv;
+
+			/*
+			 *	Now that we have a busy page, we can
+			 *	release the object lock.
+			 */
+			vm_object_unlock(object);
+
+			/*
+			 *	Call the pager to retrieve the data, if any,
+			 *	after releasing the lock on the map.
+			 */
+			UNLOCK_MAP;
+			cnt.v_pageins++;
+			rv = vm_pager_get(object->pager, m, TRUE);
+
+			/*
+			 *	Reaquire the object lock to preserve our
+			 *	invariant.
+			 */
+			vm_object_lock(object);
+
+			/*
+			 *	Found the page.
+			 *	Leave it busy while we play with it.
+			 */
+			if (rv == VM_PAGER_OK) {
+				/*
+				 *	Relookup in case pager changed page.
+				 *	Pager is responsible for disposition
+				 *	of old page if moved.
+				 */
+				m = vm_page_lookup(object, offset);
+
+				cnt.v_pgpgin++;
+				m->flags &= ~PG_FAKE;
+				m->flags |= PG_CLEAN;
+				pmap_clear_modify(VM_PAGE_TO_PHYS(m));
+				break;
+			}
+
+			/*
+			 * IO error or page outside the range of the pager:
+			 * cleanup and return an error.
+			 */
+			if (rv == VM_PAGER_ERROR || rv == VM_PAGER_BAD) {
+				FREE_PAGE(m);
+				UNLOCK_AND_DEALLOCATE;
+				return(KERN_PROTECTION_FAILURE); /* XXX */
+			}
+			/*
+			 * rv == VM_PAGER_FAIL:
+			 *
+			 * Page does not exist at this object/offset.
+			 * Free the bogus page (waking up anyone waiting
+			 * for it) and continue on to the next object.
+			 *
+			 * If this is the top-level object, we must
+			 * leave the busy page to prevent another
+			 * thread from rushing past us, and inserting
+			 * the page in that object at the same time
+			 * that we are.
+			 */
+			if (object != first_object) {
+				FREE_PAGE(m);
+				/* note that `m' is not used after this */
+			}
+		}
+
+		/*
+		 * We get here if the object has no pager (or unwiring)
+		 * or the pager doesn't have the page.
+		 */
+		if (object == first_object)
+			first_m = m;
+
+		/*
+		 *	Move on to the next object.  Lock the next
+		 *	object before unlocking the current one.
+		 */
+
+		offset += object->shadow_offset;
+		next_object = object->shadow;
+		if (next_object == NULL) {
+			/*
+			 *	If there's no object left, fill the page
+			 *	in the top object with zeros.
+			 */
+			if (object != first_object) {
+				object->paging_in_progress--;
+				vm_object_unlock(object);
+
+				object = first_object;
+				offset = first_offset;
+				m = first_m;
+				vm_object_lock(object);
+			}
+			first_m = NULL;
+
+			vm_page_zero_fill(m);
+			cnt.v_zfod++;
+			m->flags &= ~PG_FAKE;
+			break;
+		}
+		else {
+			vm_object_lock(next_object);
+			if (object != first_object)
+				object->paging_in_progress--;
+			vm_object_unlock(object);
+			object = next_object;
+			object->paging_in_progress++;
+		}
+	}
+
+	if ((m->flags & (PG_ACTIVE | PG_INACTIVE | PG_BUSY)) != PG_BUSY)
+		panic("vm_fault: active, inactive or !busy after main loop");
+
+	/*
+	 *	PAGE HAS BEEN FOUND.
+	 *	[Loop invariant still holds -- the object lock
+	 *	is held.]
+	 */
+
+	old_m = m;	/* save page that would be copied */
+
+	/*
+	 *	If the page is being written, but isn't
+	 *	already owned by the top-level object,
+	 *	we have to copy it into a new page owned
+	 *	by the top-level object.
+	 */
+
+	if (object != first_object) {
+	    	/*
+		 *	We only really need to copy if we
+		 *	want to write it.
+		 */
+
+	    	if (fault_type & VM_PROT_WRITE) {
+
+			/*
+			 *	If we try to collapse first_object at this
+			 *	point, we may deadlock when we try to get
+			 *	the lock on an intermediate object (since we
+			 *	have the bottom object locked).  We can't
+			 *	unlock the bottom object, because the page
+			 *	we found may move (by collapse) if we do.
+			 *
+			 *	Instead, we first copy the page.  Then, when
+			 *	we have no more use for the bottom object,
+			 *	we unlock it and try to collapse.
+			 *
+			 *	Note that we copy the page even if we didn't
+			 *	need to... that's the breaks.
+			 */
+
+		    	/*
+			 *	We already have an empty page in
+			 *	first_object - use it.
+			 */
+
+			vm_page_copy(m, first_m);
+			first_m->flags &= ~PG_FAKE;
+
+			/*
+			 *	If another map is truly sharing this
+			 *	page with us, we have to flush all
+			 *	uses of the original page, since we
+			 *	can't distinguish those which want the
+			 *	original from those which need the
+			 *	new copy.
+			 *
+			 *	XXX If we know that only one map has
+			 *	access to this page, then we could
+			 *	avoid the pmap_page_protect() call.
+			 */
+
+			vm_page_lock_queues();
+			vm_page_activate(m);
+			vm_page_deactivate(m);
+			pmap_page_protect(VM_PAGE_TO_PHYS(m), VM_PROT_NONE);
+			vm_page_unlock_queues();
+
+			/*
+			 *	We no longer need the old page or object.
+			 */
+			PAGE_WAKEUP(m);
+			object->paging_in_progress--;
+			vm_object_unlock(object);
+
+			/*
+			 *	Only use the new page below...
+			 */
+
+			cnt.v_cow_faults++;
+			m = first_m;
+			object = first_object;
+			offset = first_offset;
+
+			/*
+			 *	Now that we've gotten the copy out of the
+			 *	way, let's try to collapse the top object.
+			 */
+			vm_object_lock(object);
+			/*
+			 *	But we have to play ugly games with
+			 *	paging_in_progress to do that...
+			 */
+			object->paging_in_progress--;
+			vm_object_collapse(object);
+			object->paging_in_progress++;
+		}
+		else {
+		    	prot &= ~VM_PROT_WRITE;
+			m->flags |= PG_COPYONWRITE;
+		}
+	}
+
+	if (m->flags & (PG_ACTIVE|PG_INACTIVE))
+		panic("vm_fault: active or inactive before copy object handling");
+
+	/*
+	 *	If the page is being written, but hasn't been
+	 *	copied to the copy-object, we have to copy it there.
+	 */
+    RetryCopy:
+	if (first_object->copy != NULL) {
+		vm_object_t copy_object = first_object->copy;
+		vm_offset_t copy_offset;
+		vm_page_t copy_m;
+
+		/*
+		 *	We only need to copy if we want to write it.
+		 */
+		if ((fault_type & VM_PROT_WRITE) == 0) {
+			prot &= ~VM_PROT_WRITE;
+			m->flags |= PG_COPYONWRITE;
+		}
+		else {
+			/*
+			 *	Try to get the lock on the copy_object.
+			 */
+			if (!vm_object_lock_try(copy_object)) {
+				vm_object_unlock(object);
+				/* should spin a bit here... */
+				vm_object_lock(object);
+				goto RetryCopy;
+			}
+
+			/*
+			 *	Make another reference to the copy-object,
+			 *	to keep it from disappearing during the
+			 *	copy.
+			 */
+			copy_object->ref_count++;
+
+			/*
+			 *	Does the page exist in the copy?
+			 */
+			copy_offset = first_offset
+				- copy_object->shadow_offset;
+			copy_m = vm_page_lookup(copy_object, copy_offset);
+			if (page_exists = (copy_m != NULL)) {
+				if (copy_m->flags & PG_BUSY) {
+#ifdef DOTHREADS
+					int	wait_result;
+
+					/*
+					 *	If the page is being brought
+					 *	in, wait for it and then retry.
+					 */
+					PAGE_ASSERT_WAIT(copy_m, !change_wiring);
+					RELEASE_PAGE(m);
+					copy_object->ref_count--;
+					vm_object_unlock(copy_object);
+					UNLOCK_THINGS;
+					thread_block();
+					wait_result = current_thread()->wait_result;
+					vm_object_deallocate(first_object);
+					if (wait_result != THREAD_AWAKENED)
+						return(KERN_SUCCESS);
+					goto RetryFault;
+#else
+					/*
+					 *	If the page is being brought
+					 *	in, wait for it and then retry.
+					 */
+					PAGE_ASSERT_WAIT(copy_m, !change_wiring);
+					RELEASE_PAGE(m);
+					copy_object->ref_count--;
+					vm_object_unlock(copy_object);
+					UNLOCK_THINGS;
+					thread_block();
+					vm_object_deallocate(first_object);
+					goto RetryFault;
+#endif
+				}
+			}
+
+			/*
+			 *	If the page is not in memory (in the object)
+			 *	and the object has a pager, we have to check
+			 *	if the pager has the data in secondary
+			 *	storage.
+			 */
+			if (!page_exists) {
+
+				/*
+				 *	If we don't allocate a (blank) page
+				 *	here... another thread could try
+				 *	to page it in, allocate a page, and
+				 *	then block on the busy page in its
+				 *	shadow (first_object).  Then we'd
+				 *	trip over the busy page after we
+				 *	found that the copy_object's pager
+				 *	doesn't have the page...
+				 */
+				copy_m = vm_page_alloc(copy_object,
+								copy_offset);
+				if (copy_m == NULL) {
+					/*
+					 *	Wait for a page, then retry.
+					 */
+					RELEASE_PAGE(m);
+					copy_object->ref_count--;
+					vm_object_unlock(copy_object);
+					UNLOCK_AND_DEALLOCATE;
+					VM_WAIT;
+					goto RetryFault;
+				}
+
+			 	if (copy_object->pager != NULL) {
+					vm_object_unlock(object);
+					vm_object_unlock(copy_object);
+					UNLOCK_MAP;
+
+					page_exists = vm_pager_has_page(
+							copy_object->pager,
+							(copy_offset + copy_object->paging_offset));
+
+					vm_object_lock(copy_object);
+
+					/*
+					 * Since the map is unlocked, someone
+					 * else could have copied this object
+					 * and put a different copy_object
+					 * between the two.  Or, the last
+					 * reference to the copy-object (other
+					 * than the one we have) may have
+					 * disappeared - if that has happened,
+					 * we don't need to make the copy.
+					 */
+					if (copy_object->shadow != object ||
+					    copy_object->ref_count == 1) {
+						/*
+						 *	Gaah... start over!
+						 */
+						FREE_PAGE(copy_m);
+						vm_object_unlock(copy_object);
+						vm_object_deallocate(copy_object);
+							/* may block */
+						vm_object_lock(object);
+						goto RetryCopy;
+					}
+					vm_object_lock(object);
+
+					if (page_exists) {
+						/*
+						 *	We didn't need the page
+						 */
+						FREE_PAGE(copy_m);
+					}
+				}
+			}
+			if (!page_exists) {
+				/*
+				 *	Must copy page into copy-object.
+				 */
+				vm_page_copy(m, copy_m);
+				copy_m->flags &= ~PG_FAKE;
+
+				/*
+				 * Things to remember:
+				 * 1. The copied page must be marked 'dirty'
+				 *    so it will be paged out to the copy
+				 *    object.
+				 * 2. If the old page was in use by any users
+				 *    of the copy-object, it must be removed
+				 *    from all pmaps.  (We can't know which
+				 *    pmaps use it.)
+				 */
+				vm_page_lock_queues();
+				pmap_page_protect(VM_PAGE_TO_PHYS(old_m),
+						  VM_PROT_NONE);
+				copy_m->flags &= ~PG_CLEAN;
+				vm_page_activate(copy_m);	/* XXX */
+				vm_page_unlock_queues();
+
+				PAGE_WAKEUP(copy_m);
+			}
+			/*
+			 *	The reference count on copy_object must be
+			 *	at least 2: one for our extra reference,
+			 *	and at least one from the outside world
+			 *	(we checked that when we last locked
+			 *	copy_object).
+			 */
+			copy_object->ref_count--;
+			vm_object_unlock(copy_object);
+			m->flags &= ~PG_COPYONWRITE;
+		}
+	}
+
+	if (m->flags & (PG_ACTIVE | PG_INACTIVE))
+		panic("vm_fault: active or inactive before retrying lookup");
+
+	/*
+	 *	We must verify that the maps have not changed
+	 *	since our last lookup.
+	 */
+
+	if (!lookup_still_valid) {
+		vm_object_t	retry_object;
+		vm_offset_t	retry_offset;
+		vm_prot_t	retry_prot;
+
+		/*
+		 *	Since map entries may be pageable, make sure we can
+		 *	take a page fault on them.
+		 */
+		vm_object_unlock(object);
+
+		/*
+		 *	To avoid trying to write_lock the map while another
+		 *	thread has it read_locked (in vm_map_pageable), we
+		 *	do not try for write permission.  If the page is
+		 *	still writable, we will get write permission.  If it
+		 *	is not, or has been marked needs_copy, we enter the
+		 *	mapping without write permission, and will merely
+		 *	take another fault.
+		 */
+		result = vm_map_lookup(&map, vaddr,
+				fault_type & ~VM_PROT_WRITE, &entry,
+				&retry_object, &retry_offset, &retry_prot,
+				&wired, &su);
+
+		vm_object_lock(object);
+
+		/*
+		 *	If we don't need the page any longer, put it on the
+		 *	active list (the easiest thing to do here).  If no
+		 *	one needs it, pageout will grab it eventually.
+		 */
+
+		if (result != KERN_SUCCESS) {
+			RELEASE_PAGE(m);
+			UNLOCK_AND_DEALLOCATE;
+			return(result);
+		}
+
+		lookup_still_valid = TRUE;
+
+		if ((retry_object != first_object) ||
+				(retry_offset != first_offset)) {
+			RELEASE_PAGE(m);
+			UNLOCK_AND_DEALLOCATE;
+			goto RetryFault;
+		}
+
+		/*
+		 *	Check whether the protection has changed or the object
+		 *	has been copied while we left the map unlocked.
+		 *	Changing from read to write permission is OK - we leave
+		 *	the page write-protected, and catch the write fault.
+		 *	Changing from write to read permission means that we
+		 *	can't mark the page write-enabled after all.
+		 */
+		prot &= retry_prot;
+		if (m->flags & PG_COPYONWRITE)
+			prot &= ~VM_PROT_WRITE;
+	}
+
+	/*
+	 * (the various bits we're fiddling with here are locked by
+	 * the object's lock)
+	 */
+
+	/* XXX This distorts the meaning of the copy_on_write bit */
+
+	if (prot & VM_PROT_WRITE)
+		m->flags &= ~PG_COPYONWRITE;
+
+	/*
+	 *	It's critically important that a wired-down page be faulted
+	 *	only once in each map for which it is wired.
+	 */
+
+	if (m->flags & (PG_ACTIVE | PG_INACTIVE))
+		panic("vm_fault: active or inactive before pmap_enter");
+
+	vm_object_unlock(object);
+
+	/*
+	 *	Put this page into the physical map.
+	 *	We had to do the unlock above because pmap_enter
+	 *	may cause other faults.   We don't put the
+	 *	page back on the active queue until later so
+	 *	that the page-out daemon won't find us (yet).
+	 */
+
+	pmap_enter(map->pmap, vaddr, VM_PAGE_TO_PHYS(m), prot, wired);
+
+	/*
+	 *	If the page is not wired down, then put it where the
+	 *	pageout daemon can find it.
+	 */
+	vm_object_lock(object);
+	vm_page_lock_queues();
+	if (change_wiring) {
+		if (wired)
+			vm_page_wire(m);
+		else
+			vm_page_unwire(m);
+	}
+	else
+		vm_page_activate(m);
+	vm_page_unlock_queues();
+
+	/*
+	 *	Unlock everything, and return
+	 */
+
+	PAGE_WAKEUP(m);
+	UNLOCK_AND_DEALLOCATE;
+
+	return(KERN_SUCCESS);
+
+}
+
+/*
+ *	vm_fault_wire:
+ *
+ *	Wire down a range of virtual addresses in a map.
+ */
+int
+vm_fault_wire(map, start, end)
+	vm_map_t	map;
+	vm_offset_t	start, end;
+{
+	register vm_offset_t	va;
+	register pmap_t		pmap;
+	int			rv;
+
+	pmap = vm_map_pmap(map);
+
+	/*
+	 *	Inform the physical mapping system that the
+	 *	range of addresses may not fault, so that
+	 *	page tables and such can be locked down as well.
+	 */
+
+	pmap_pageable(pmap, start, end, FALSE);
+
+	/*
+	 *	We simulate a fault to get the page and enter it
+	 *	in the physical map.
+	 */
+
+	for (va = start; va < end; va += PAGE_SIZE) {
+		rv = vm_fault(map, va, VM_PROT_NONE, TRUE);
+		if (rv) {
+			if (va != start)
+				vm_fault_unwire(map, start, va);
+			return(rv);
+		}
+	}
+	return(KERN_SUCCESS);
+}
+
+
+/*
+ *	vm_fault_unwire:
+ *
+ *	Unwire a range of virtual addresses in a map.
+ */
+void
+vm_fault_unwire(map, start, end)
+	vm_map_t	map;
+	vm_offset_t	start, end;
+{
+
+	register vm_offset_t	va, pa;
+	register pmap_t		pmap;
+
+	pmap = vm_map_pmap(map);
+
+	/*
+	 *	Since the pages are wired down, we must be able to
+	 *	get their mappings from the physical map system.
+	 */
+
+	vm_page_lock_queues();
+
+	for (va = start; va < end; va += PAGE_SIZE) {
+		pa = pmap_extract(pmap, va);
+		if (pa == (vm_offset_t) 0) {
+			panic("unwire: page not in pmap");
+		}
+		pmap_change_wiring(pmap, va, FALSE);
+		vm_page_unwire(PHYS_TO_VM_PAGE(pa));
+	}
+	vm_page_unlock_queues();
+
+	/*
+	 *	Inform the physical mapping system that the range
+	 *	of addresses may fault, so that page tables and
+	 *	such may be unwired themselves.
+	 */
+
+	pmap_pageable(pmap, start, end, TRUE);
+
+}
+
+/*
+ *	Routine:
+ *		vm_fault_copy_entry
+ *	Function:
+ *		Copy all of the pages from a wired-down map entry to another.
+ *
+ *	In/out conditions:
+ *		The source and destination maps must be locked for write.
+ *		The source map entry must be wired down (or be a sharing map
+ *		entry corresponding to a main map entry that is wired down).
+ */
+
+void
+vm_fault_copy_entry(dst_map, src_map, dst_entry, src_entry)
+	vm_map_t	dst_map;
+	vm_map_t	src_map;
+	vm_map_entry_t	dst_entry;
+	vm_map_entry_t	src_entry;
+{
+
+	vm_object_t	dst_object;
+	vm_object_t	src_object;
+	vm_offset_t	dst_offset;
+	vm_offset_t	src_offset;
+	vm_prot_t	prot;
+	vm_offset_t	vaddr;
+	vm_page_t	dst_m;
+	vm_page_t	src_m;
+
+#ifdef	lint
+	src_map++;
+#endif
+
+	src_object = src_entry->object.vm_object;
+	src_offset = src_entry->offset;
+
+	/*
+	 *	Create the top-level object for the destination entry.
+	 *	(Doesn't actually shadow anything - we copy the pages
+	 *	directly.)
+	 */
+	dst_object = vm_object_allocate(
+			(vm_size_t) (dst_entry->end - dst_entry->start));
+
+	dst_entry->object.vm_object = dst_object;
+	dst_entry->offset = 0;
+
+	prot  = dst_entry->max_protection;
+
+	/*
+	 *	Loop through all of the pages in the entry's range, copying
+	 *	each one from the source object (it should be there) to the
+	 *	destination object.
+	 */
+	for (vaddr = dst_entry->start, dst_offset = 0;
+	     vaddr < dst_entry->end;
+	     vaddr += PAGE_SIZE, dst_offset += PAGE_SIZE) {
+
+		/*
+		 *	Allocate a page in the destination object
+		 */
+		vm_object_lock(dst_object);
+		do {
+			dst_m = vm_page_alloc(dst_object, dst_offset);
+			if (dst_m == NULL) {
+				vm_object_unlock(dst_object);
+				VM_WAIT;
+				vm_object_lock(dst_object);
+			}
+		} while (dst_m == NULL);
+
+		/*
+		 *	Find the page in the source object, and copy it in.
+		 *	(Because the source is wired down, the page will be
+		 *	in memory.)
+		 */
+		vm_object_lock(src_object);
+		src_m = vm_page_lookup(src_object, dst_offset + src_offset);
+		if (src_m == NULL)
+			panic("vm_fault_copy_wired: page missing");
+
+		vm_page_copy(src_m, dst_m);
+
+		/*
+		 *	Enter it in the pmap...
+		 */
+		vm_object_unlock(src_object);
+		vm_object_unlock(dst_object);
+
+		pmap_enter(dst_map->pmap, vaddr, VM_PAGE_TO_PHYS(dst_m),
+				prot, FALSE);
+
+		/*
+		 *	Mark it no longer busy, and put it on the active list.
+		 */
+		vm_object_lock(dst_object);
+		vm_page_lock_queues();
+		vm_page_activate(dst_m);
+		vm_page_unlock_queues();
+		PAGE_WAKEUP(dst_m);
+		vm_object_unlock(dst_object);
+	}
+
+}

--- a/src-uland/libvm/vm_glue.c
+++ b/src-uland/libvm/vm_glue.c
@@ -1,0 +1,608 @@
+/* Copied from sys/vm/vm_glue.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_glue.c	8.9 (Berkeley) 3/4/95
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/resourcevar.h>
+#include <sys/buf.h>
+#include <sys/user.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vm_kern.h>
+
+#include <machine/cpu.h>
+
+int	avefree = 0;		/* XXX */
+unsigned maxdmap = MAXDSIZ;	/* XXX */
+int	readbuffers = 0;	/* XXX allow kgdb to read kernel buffer pool */
+
+int
+kernacc(addr, len, rw)
+	caddr_t addr;
+	int len, rw;
+{
+	boolean_t rv;
+	vm_offset_t saddr, eaddr;
+	vm_prot_t prot = rw == B_READ ? VM_PROT_READ : VM_PROT_WRITE;
+
+	saddr = trunc_page(addr);
+	eaddr = round_page(addr+len);
+	rv = vm_map_check_protection(kernel_map, saddr, eaddr, prot);
+	/*
+	 * XXX there are still some things (e.g. the buffer cache) that
+	 * are managed behind the VM system's back so even though an
+	 * address is accessible in the mind of the VM system, there may
+	 * not be physical pages where the VM thinks there is.  This can
+	 * lead to bogus allocation of pages in the kernel address space
+	 * or worse, inconsistencies at the pmap level.  We only worry
+	 * about the buffer cache for now.
+	 */
+	if (!readbuffers && rv && (eaddr > (vm_offset_t)buffers &&
+		   saddr < (vm_offset_t)buffers + MAXBSIZE * nbuf))
+		rv = FALSE;
+	return(rv == TRUE);
+}
+
+int
+useracc(addr, len, rw)
+	caddr_t addr;
+	int len, rw;
+{
+	boolean_t rv;
+	vm_prot_t prot = rw == B_READ ? VM_PROT_READ : VM_PROT_WRITE;
+
+	rv = vm_map_check_protection(&curproc->p_vmspace->vm_map,
+	    trunc_page(addr), round_page(addr+len), prot);
+	return(rv == TRUE);
+}
+
+#ifdef KGDB
+/*
+ * Change protections on kernel pages from addr to addr+len
+ * (presumably so debugger can plant a breakpoint).
+ *
+ * We force the protection change at the pmap level.  If we were
+ * to use vm_map_protect a change to allow writing would be lazily-
+ * applied meaning we would still take a protection fault, something
+ * we really don't want to do.  It would also fragment the kernel
+ * map unnecessarily.  We cannot use pmap_protect since it also won't
+ * enforce a write-enable request.  Using pmap_enter is the only way
+ * we can ensure the change takes place properly.
+ */
+void
+chgkprot(addr, len, rw)
+	register caddr_t addr;
+	int len, rw;
+{
+	vm_prot_t prot;
+	vm_offset_t pa, sva, eva;
+
+	prot = rw == B_READ ? VM_PROT_READ : VM_PROT_READ|VM_PROT_WRITE;
+	eva = round_page(addr + len);
+	for (sva = trunc_page(addr); sva < eva; sva += PAGE_SIZE) {
+		/*
+		 * Extract physical address for the page.
+		 * We use a cheezy hack to differentiate physical
+		 * page 0 from an invalid mapping, not that it
+		 * really matters...
+		 */
+		pa = pmap_extract(kernel_pmap, sva|1);
+		if (pa == 0)
+			panic("chgkprot: invalid page");
+		pmap_enter(kernel_pmap, sva, pa&~1, prot, TRUE);
+	}
+}
+#endif
+
+void
+vslock(addr, len)
+	caddr_t	addr;
+	u_int	len;
+{
+	vm_map_pageable(&curproc->p_vmspace->vm_map, trunc_page(addr),
+			round_page(addr+len), FALSE);
+}
+
+void
+vsunlock(addr, len, dirtied)
+	caddr_t	addr;
+	u_int	len;
+	int dirtied;
+{
+#ifdef	lint
+	dirtied++;
+#endif
+	vm_map_pageable(&curproc->p_vmspace->vm_map, trunc_page(addr),
+			round_page(addr+len), TRUE);
+}
+
+/*
+ * Implement fork's actions on an address space.
+ * Here we arrange for the address space to be copied or referenced,
+ * allocate a user struct (pcb and kernel stack), then call the
+ * machine-dependent layer to fill those in and make the new process
+ * ready to run.
+ * NOTE: the kernel stack may be at a different location in the child
+ * process, and thus addresses of automatic variables may be invalid
+ * after cpu_fork returns in the child process.  We do nothing here
+ * after cpu_fork returns.
+ */
+int
+vm_fork(p1, p2, isvfork)
+	register struct proc *p1, *p2;
+	int isvfork;
+{
+	register struct user *up;
+	vm_offset_t addr;
+
+#ifdef i386
+	/*
+	 * avoid copying any of the parent's pagetables or other per-process
+	 * objects that reside in the map by marking all of them non-inheritable
+	 */
+	(void)vm_map_inherit(&p1->p_vmspace->vm_map,
+		UPT_MIN_ADDRESS-UPAGES*NBPG, VM_MAX_ADDRESS, VM_INHERIT_NONE);
+#endif
+	p2->p_vmspace = vmspace_fork(p1->p_vmspace);
+
+#ifdef SYSVSHM
+	if (p1->p_vmspace->vm_shm)
+		shmfork(p1, p2, isvfork);
+#endif
+
+#ifndef	i386
+	/*
+	 * Allocate a wired-down (for now) pcb and kernel stack for the process
+	 */
+	addr = kmem_alloc_pageable(kernel_map, ctob(UPAGES));
+	if (addr == 0)
+		panic("vm_fork: no more kernel virtual memory");
+	vm_map_pageable(kernel_map, addr, addr + ctob(UPAGES), FALSE);
+#else
+/* XXX somehow, on 386, ocassionally pageout removes active, wired down kstack,
+and pagetables, WITHOUT going thru vm_page_unwire! Why this appears to work is
+not yet clear, yet it does... */
+	addr = kmem_alloc(kernel_map, ctob(UPAGES));
+	if (addr == 0)
+		panic("vm_fork: no more kernel virtual memory");
+#endif
+	up = (struct user *)addr;
+	p2->p_addr = up;
+
+	/*
+	 * p_stats and p_sigacts currently point at fields
+	 * in the user struct but not at &u, instead at p_addr.
+	 * Copy p_sigacts and parts of p_stats; zero the rest
+	 * of p_stats (statistics).
+	 */
+	p2->p_stats = &up->u_stats;
+	p2->p_sigacts = &up->u_sigacts;
+	up->u_sigacts = *p1->p_sigacts;
+	bzero(&up->u_stats.pstat_startzero,
+	    (unsigned) ((caddr_t)&up->u_stats.pstat_endzero -
+	    (caddr_t)&up->u_stats.pstat_startzero));
+	bcopy(&p1->p_stats->pstat_startcopy, &up->u_stats.pstat_startcopy,
+	    ((caddr_t)&up->u_stats.pstat_endcopy -
+	     (caddr_t)&up->u_stats.pstat_startcopy));
+
+#ifdef i386
+	{ u_int addr = UPT_MIN_ADDRESS - UPAGES*NBPG; struct vm_map *vp;
+
+	vp = &p2->p_vmspace->vm_map;
+	(void)vm_deallocate(vp, addr, UPT_MAX_ADDRESS - addr);
+	(void)vm_allocate(vp, &addr, UPT_MAX_ADDRESS - addr, FALSE);
+	(void)vm_map_inherit(vp, addr, UPT_MAX_ADDRESS, VM_INHERIT_NONE);
+	}
+#endif
+	/*
+	 * cpu_fork will copy and update the kernel stack and pcb,
+	 * and make the child ready to run.  It marks the child
+	 * so that it can return differently than the parent.
+	 * It returns twice, once in the parent process and
+	 * once in the child.
+	 */
+	return (cpu_fork(p1, p2));
+}
+
+/*
+ * Set default limits for VM system.
+ * Called for proc 0, and then inherited by all others.
+ */
+void
+vm_init_limits(p)
+	register struct proc *p;
+{
+
+	/*
+	 * Set up the initial limits on process VM.
+	 * Set the maximum resident set size to be all
+	 * of (reasonably) available memory.  This causes
+	 * any single, large process to start random page
+	 * replacement once it fills memory.
+	 */
+        p->p_rlimit[RLIMIT_STACK].rlim_cur = DFLSSIZ;
+        p->p_rlimit[RLIMIT_STACK].rlim_max = MAXSSIZ;
+        p->p_rlimit[RLIMIT_DATA].rlim_cur = DFLDSIZ;
+        p->p_rlimit[RLIMIT_DATA].rlim_max = MAXDSIZ;
+	p->p_rlimit[RLIMIT_RSS].rlim_cur = ptoa(cnt.v_free_count);
+}
+
+#include <vm/vm_pageout.h>
+
+#ifdef DEBUG
+int	enableswap = 1;
+int	swapdebug = 0;
+#define	SDB_FOLLOW	1
+#define SDB_SWAPIN	2
+#define SDB_SWAPOUT	4
+#endif
+
+/*
+ * Brutally simple:
+ *	1. Attempt to swapin every swaped-out, runnable process in
+ *	   order of priority.
+ *	2. If not enough memory, wake the pageout daemon and let it
+ *	   clear some space.
+ */
+void
+scheduler()
+{
+	register struct proc *p;
+	register int pri;
+	struct proc *pp;
+	int ppri;
+	vm_offset_t addr;
+	vm_size_t size;
+
+loop:
+#ifdef DEBUG
+	while (!enableswap)
+		tsleep((caddr_t)&proc0, PVM, "noswap", 0);
+#endif
+	pp = NULL;
+	ppri = INT_MIN;
+	for (p = allproc.lh_first; p != 0; p = p->p_list.le_next) {
+		if (p->p_stat == SRUN && (p->p_flag & P_INMEM) == 0) {
+			/* XXX should also penalize based on vm_swrss */
+			pri = p->p_swtime + p->p_slptime - p->p_nice * 8;
+			if (pri > ppri) {
+				pp = p;
+				ppri = pri;
+			}
+		}
+	}
+#ifdef DEBUG
+	if (swapdebug & SDB_FOLLOW)
+		printf("scheduler: running, procp %x pri %d\n", pp, ppri);
+#endif
+	/*
+	 * Nothing to do, back to sleep
+	 */
+	if ((p = pp) == NULL) {
+		tsleep((caddr_t)&proc0, PVM, "scheduler", 0);
+		goto loop;
+	}
+
+	/*
+	 * We would like to bring someone in.
+	 * This part is really bogus cuz we could deadlock on memory
+	 * despite our feeble check.
+	 * XXX should require at least vm_swrss / 2
+	 */
+	size = round_page(ctob(UPAGES));
+	addr = (vm_offset_t) p->p_addr;
+	if (cnt.v_free_count > atop(size)) {
+#ifdef DEBUG
+		if (swapdebug & SDB_SWAPIN)
+			printf("swapin: pid %d(%s)@%x, pri %d free %d\n",
+			       p->p_pid, p->p_comm, p->p_addr,
+			       ppri, cnt.v_free_count);
+#endif
+		vm_map_pageable(kernel_map, addr, addr+size, FALSE);
+		/*
+		 * Some architectures need to be notified when the
+		 * user area has moved to new physical page(s) (e.g.
+		 * see pmax/pmax/vm_machdep.c).
+		 */
+		cpu_swapin(p);
+		(void) splstatclock();
+		if (p->p_stat == SRUN)
+			setrunqueue(p);
+		p->p_flag |= P_INMEM;
+		(void) spl0();
+		p->p_swtime = 0;
+		goto loop;
+	}
+	/*
+	 * Not enough memory, jab the pageout daemon and wait til the
+	 * coast is clear.
+	 */
+#ifdef DEBUG
+	if (swapdebug & SDB_FOLLOW)
+		printf("scheduler: no room for pid %d(%s), free %d\n",
+		       p->p_pid, p->p_comm, cnt.v_free_count);
+#endif
+	(void) splhigh();
+	VM_WAIT;
+	(void) spl0();
+#ifdef DEBUG
+	if (swapdebug & SDB_FOLLOW)
+		printf("scheduler: room again, free %d\n", cnt.v_free_count);
+#endif
+	goto loop;
+}
+
+#define	swappable(p)							\
+	(((p)->p_flag &							\
+	    (P_SYSTEM | P_INMEM | P_NOSWAP | P_WEXIT | P_PHYSIO)) == P_INMEM)
+
+/*
+ * Swapout is driven by the pageout daemon.  Very simple, we find eligible
+ * procs and unwire their u-areas.  We try to always "swap" at least one
+ * process in case we need the room for a swapin.
+ * If any procs have been sleeping/stopped for at least maxslp seconds,
+ * they are swapped.  Else, we swap the longest-sleeping or stopped process,
+ * if any, otherwise the longest-resident process.
+ */
+void
+swapout_threads()
+{
+	register struct proc *p;
+	struct proc *outp, *outp2;
+	int outpri, outpri2;
+	int didswap = 0;
+	extern int maxslp;
+
+#ifdef DEBUG
+	if (!enableswap)
+		return;
+#endif
+	outp = outp2 = NULL;
+	outpri = outpri2 = 0;
+	for (p = allproc.lh_first; p != 0; p = p->p_list.le_next) {
+		if (!swappable(p))
+			continue;
+		switch (p->p_stat) {
+		case SRUN:
+			if (p->p_swtime > outpri2) {
+				outp2 = p;
+				outpri2 = p->p_swtime;
+			}
+			continue;
+			
+		case SSLEEP:
+		case SSTOP:
+			if (p->p_slptime >= maxslp) {
+				swapout(p);
+				didswap++;
+			} else if (p->p_slptime > outpri) {
+				outp = p;
+				outpri = p->p_slptime;
+			}
+			continue;
+		}
+	}
+	/*
+	 * If we didn't get rid of any real duds, toss out the next most
+	 * likely sleeping/stopped or running candidate.  We only do this
+	 * if we are real low on memory since we don't gain much by doing
+	 * it (UPAGES pages).
+	 */
+	if (didswap == 0 &&
+	    cnt.v_free_count <= atop(round_page(ctob(UPAGES)))) {
+		if ((p = outp) == 0)
+			p = outp2;
+#ifdef DEBUG
+		if (swapdebug & SDB_SWAPOUT)
+			printf("swapout_threads: no duds, try procp %x\n", p);
+#endif
+		if (p)
+			swapout(p);
+	}
+}
+
+void
+swapout(p)
+	register struct proc *p;
+{
+	vm_offset_t addr;
+	vm_size_t size;
+
+#ifdef DEBUG
+	if (swapdebug & SDB_SWAPOUT)
+		printf("swapout: pid %d(%s)@%x, stat %x pri %d free %d\n",
+		       p->p_pid, p->p_comm, p->p_addr, p->p_stat,
+		       p->p_slptime, cnt.v_free_count);
+#endif
+	size = round_page(ctob(UPAGES));
+	addr = (vm_offset_t) p->p_addr;
+#if defined(hp300) || defined(luna68k)
+	/*
+	 * Ugh!  u-area is double mapped to a fixed address behind the
+	 * back of the VM system and accesses are usually through that
+	 * address rather than the per-process address.  Hence reference
+	 * and modify information are recorded at the fixed address and
+	 * lost at context switch time.  We assume the u-struct and
+	 * kernel stack are always accessed/modified and force it to be so.
+	 */
+	{
+		register int i;
+		volatile long tmp;
+
+		for (i = 0; i < UPAGES; i++) {
+			tmp = *(long *)addr; *(long *)addr = tmp;
+			addr += NBPG;
+		}
+		addr = (vm_offset_t) p->p_addr;
+	}
+#endif
+#ifdef mips
+	/*
+	 * Be sure to save the floating point coprocessor state before
+	 * paging out the u-struct.
+	 */
+	{
+		extern struct proc *machFPCurProcPtr;
+
+		if (p == machFPCurProcPtr) {
+			MachSaveCurFPState(p);
+			machFPCurProcPtr = (struct proc *)0;
+		}
+	}
+#endif
+#ifndef	i386 /* temporary measure till we find spontaineous unwire of kstack */
+	vm_map_pageable(kernel_map, addr, addr+size, TRUE);
+	pmap_collect(vm_map_pmap(&p->p_vmspace->vm_map));
+#endif
+	(void) splhigh();
+	p->p_flag &= ~P_INMEM;
+	if (p->p_stat == SRUN)
+		remrq(p);
+	(void) spl0();
+	p->p_swtime = 0;
+}
+
+/*
+ * The rest of these routines fake thread handling
+ */
+
+void
+assert_wait(event, ruptible)
+	void *event;
+	boolean_t ruptible;
+{
+#ifdef lint
+	ruptible++;
+#endif
+	curproc->p_thread = event;
+}
+
+void
+thread_block()
+{
+	int s = splhigh();
+
+	if (curproc->p_thread)
+		tsleep(curproc->p_thread, PVM, "thrd_block", 0);
+	splx(s);
+}
+
+void
+thread_sleep(event, lock, ruptible)
+	void *event;
+	simple_lock_t lock;
+	boolean_t ruptible;
+{
+	int s = splhigh();
+
+#ifdef lint
+	ruptible++;
+#endif
+	curproc->p_thread = event;
+	simple_unlock(lock);
+	if (curproc->p_thread)
+		tsleep(event, PVM, "thrd_sleep", 0);
+	splx(s);
+}
+
+void
+thread_wakeup(event)
+	void *event;
+{
+	int s = splhigh();
+
+	wakeup(event);
+	splx(s);
+}
+
+/*
+ * DEBUG stuff
+ */
+
+int indent = 0;
+
+#include <machine/stdarg.h>		/* see subr_prf.c */
+
+/*ARGSUSED2*/
+void
+#if __STDC__
+iprintf(const char *fmt, ...)
+#else
+iprintf(fmt /* , va_alist */)
+	char *fmt;
+	/* va_dcl */
+#endif
+{
+	register int i;
+	va_list ap;
+
+	for (i = indent; i >= 8; i -= 8)
+		printf("\t");
+	while (--i >= 0)
+		printf(" ");
+	va_start(ap, fmt);
+	printf("%r", fmt, ap);
+	va_end(ap);
+}

--- a/src-uland/libvm/vm_init.c
+++ b/src-uland/libvm/vm_init.c
@@ -1,0 +1,104 @@
+/* Copied from sys/vm/vm_init.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_init.c	8.1 (Berkeley) 6/11/93
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	Initialize the Virtual Memory subsystem.
+ */
+
+#include <sys/param.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vm_kern.h>
+
+/*
+ *	vm_init initializes the virtual memory system.
+ *	This is done only by the first cpu up.
+ *
+ *	The start and end address of physical memory is passed in.
+ */
+
+void vm_mem_init()
+{
+	extern vm_offset_t	avail_start, avail_end;
+	extern vm_offset_t	virtual_avail, virtual_end;
+
+	/*
+	 *	Initializes resident memory structures.
+	 *	From here on, all physical memory is accounted for,
+	 *	and we use only virtual addresses.
+	 */
+	vm_set_page_size();
+	vm_page_startup(&avail_start, &avail_end);
+
+	/*
+	 * Initialize other VM packages
+	 */
+	vm_object_init(virtual_end - VM_MIN_KERNEL_ADDRESS);
+	vm_map_startup();
+	kmem_init(virtual_avail, virtual_end);
+	pmap_init(avail_start, avail_end);
+	vm_pager_init();
+}

--- a/src-uland/libvm/vm_kern.c
+++ b/src-uland/libvm/vm_kern.c
@@ -1,0 +1,457 @@
+/* Copied from sys/vm/vm_kern.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_kern.c	8.4 (Berkeley) 1/9/95
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	Kernel memory management.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vm_pageout.h>
+#include <vm/vm_kern.h>
+
+/*
+ *	kmem_alloc_pageable:
+ *
+ *	Allocate pageable memory to the kernel's address map.
+ *	map must be "kernel_map" below.
+ */
+vm_offset_t
+kmem_alloc_pageable(map, size)
+	vm_map_t		map;
+	register vm_size_t	size;
+{
+	vm_offset_t		addr;
+	register int		result;
+
+#if	0
+	if (map != kernel_map)
+		panic("kmem_alloc_pageable: not called with kernel_map");
+#endif
+
+	size = round_page(size);
+
+	addr = vm_map_min(map);
+	result = vm_map_find(map, NULL, (vm_offset_t) 0,
+				&addr, size, TRUE);
+	if (result != KERN_SUCCESS) {
+		return(0);
+	}
+
+	return(addr);
+}
+
+/*
+ *	Allocate wired-down memory in the kernel's address map
+ *	or a submap.
+ */
+vm_offset_t
+kmem_alloc(map, size)
+	register vm_map_t	map;
+	register vm_size_t	size;
+{
+	vm_offset_t		addr;
+	register vm_offset_t	offset;
+	extern vm_object_t	kernel_object;
+	vm_offset_t		i;
+
+	size = round_page(size);
+
+	/*
+	 *	Use the kernel object for wired-down kernel pages.
+	 *	Assume that no region of the kernel object is
+	 *	referenced more than once.
+	 */
+
+	/*
+	 * Locate sufficient space in the map.  This will give us the
+	 * final virtual address for the new memory, and thus will tell
+	 * us the offset within the kernel map.
+	 */
+	vm_map_lock(map);
+	if (vm_map_findspace(map, 0, size, &addr)) {
+		vm_map_unlock(map);
+		return (0);
+	}
+	offset = addr - VM_MIN_KERNEL_ADDRESS;
+	vm_object_reference(kernel_object);
+	vm_map_insert(map, kernel_object, offset, addr, addr + size);
+	vm_map_unlock(map);
+
+	/*
+	 *	Guarantee that there are pages already in this object
+	 *	before calling vm_map_pageable.  This is to prevent the
+	 *	following scenario:
+	 *
+	 *		1) Threads have swapped out, so that there is a
+	 *		   pager for the kernel_object.
+	 *		2) The kmsg zone is empty, and so we are kmem_allocing
+	 *		   a new page for it.
+	 *		3) vm_map_pageable calls vm_fault; there is no page,
+	 *		   but there is a pager, so we call
+	 *		   pager_data_request.  But the kmsg zone is empty,
+	 *		   so we must kmem_alloc.
+	 *		4) goto 1
+	 *		5) Even if the kmsg zone is not empty: when we get
+	 *		   the data back from the pager, it will be (very
+	 *		   stale) non-zero data.  kmem_alloc is defined to
+	 *		   return zero-filled memory.
+	 *
+	 *	We're intentionally not activating the pages we allocate
+	 *	to prevent a race with page-out.  vm_map_pageable will wire
+	 *	the pages.
+	 */
+
+	vm_object_lock(kernel_object);
+	for (i = 0 ; i < size; i+= PAGE_SIZE) {
+		vm_page_t	mem;
+
+		while ((mem = vm_page_alloc(kernel_object, offset+i)) == NULL) {
+			vm_object_unlock(kernel_object);
+			VM_WAIT;
+			vm_object_lock(kernel_object);
+		}
+		vm_page_zero_fill(mem);
+		mem->flags &= ~PG_BUSY;
+	}
+	vm_object_unlock(kernel_object);
+		
+	/*
+	 *	And finally, mark the data as non-pageable.
+	 */
+
+	(void) vm_map_pageable(map, (vm_offset_t) addr, addr + size, FALSE);
+
+	/*
+	 *	Try to coalesce the map
+	 */
+
+	vm_map_simplify(map, addr);
+
+	return(addr);
+}
+
+/*
+ *	kmem_free:
+ *
+ *	Release a region of kernel virtual memory allocated
+ *	with kmem_alloc, and return the physical pages
+ *	associated with that region.
+ */
+void
+kmem_free(map, addr, size)
+	vm_map_t		map;
+	register vm_offset_t	addr;
+	vm_size_t		size;
+{
+	(void) vm_map_remove(map, trunc_page(addr), round_page(addr + size));
+}
+
+/*
+ *	kmem_suballoc:
+ *
+ *	Allocates a map to manage a subrange
+ *	of the kernel virtual address space.
+ *
+ *	Arguments are as follows:
+ *
+ *	parent		Map to take range from
+ *	size		Size of range to find
+ *	min, max	Returned endpoints of map
+ *	pageable	Can the region be paged
+ */
+vm_map_t
+kmem_suballoc(parent, min, max, size, pageable)
+	register vm_map_t	parent;
+	vm_offset_t		*min, *max;
+	register vm_size_t	size;
+	boolean_t		pageable;
+{
+	register int	ret;
+	vm_map_t	result;
+
+	size = round_page(size);
+
+	*min = (vm_offset_t) vm_map_min(parent);
+	ret = vm_map_find(parent, NULL, (vm_offset_t) 0,
+				min, size, TRUE);
+	if (ret != KERN_SUCCESS) {
+		printf("kmem_suballoc: bad status return of %d.\n", ret);
+		panic("kmem_suballoc");
+	}
+	*max = *min + size;
+	pmap_reference(vm_map_pmap(parent));
+	result = vm_map_create(vm_map_pmap(parent), *min, *max, pageable);
+	if (result == NULL)
+		panic("kmem_suballoc: cannot create submap");
+	if ((ret = vm_map_submap(parent, *min, *max, result)) != KERN_SUCCESS)
+		panic("kmem_suballoc: unable to change range to submap");
+	return(result);
+}
+
+/*
+ * Allocate wired-down memory in the kernel's address map for the higher
+ * level kernel memory allocator (kern/kern_malloc.c).  We cannot use
+ * kmem_alloc() because we may need to allocate memory at interrupt
+ * level where we cannot block (canwait == FALSE).
+ *
+ * This routine has its own private kernel submap (kmem_map) and object
+ * (kmem_object).  This, combined with the fact that only malloc uses
+ * this routine, ensures that we will never block in map or object waits.
+ *
+ * Note that this still only works in a uni-processor environment and
+ * when called at splhigh().
+ *
+ * We don't worry about expanding the map (adding entries) since entries
+ * for wired maps are statically allocated.
+ */
+vm_offset_t
+kmem_malloc(map, size, canwait)
+	register vm_map_t	map;
+	register vm_size_t	size;
+	boolean_t		canwait;
+{
+	register vm_offset_t	offset, i;
+	vm_map_entry_t		entry;
+	vm_offset_t		addr;
+	vm_page_t		m;
+	extern vm_object_t	kmem_object;
+
+	if (map != kmem_map && map != mb_map)
+		panic("kern_malloc_alloc: map != {kmem,mb}_map");
+
+	size = round_page(size);
+	addr = vm_map_min(map);
+
+	/*
+	 * Locate sufficient space in the map.  This will give us the
+	 * final virtual address for the new memory, and thus will tell
+	 * us the offset within the kernel map.
+	 */
+	vm_map_lock(map);
+	if (vm_map_findspace(map, 0, size, &addr)) {
+		vm_map_unlock(map);
+		if (canwait)		/* XXX  should wait */
+			panic("kmem_malloc: %s too small",
+			    map == kmem_map ? "kmem_map" : "mb_map");
+		return (0);
+	}
+	offset = addr - vm_map_min(kmem_map);
+	vm_object_reference(kmem_object);
+	vm_map_insert(map, kmem_object, offset, addr, addr + size);
+
+	/*
+	 * If we can wait, just mark the range as wired
+	 * (will fault pages as necessary).
+	 */
+	if (canwait) {
+		vm_map_unlock(map);
+		(void) vm_map_pageable(map, (vm_offset_t) addr, addr + size,
+				       FALSE);
+		vm_map_simplify(map, addr);
+		return(addr);
+	}
+
+	/*
+	 * If we cannot wait then we must allocate all memory up front,
+	 * pulling it off the active queue to prevent pageout.
+	 */
+	vm_object_lock(kmem_object);
+	for (i = 0; i < size; i += PAGE_SIZE) {
+		m = vm_page_alloc(kmem_object, offset + i);
+
+		/*
+		 * Ran out of space, free everything up and return.
+		 * Don't need to lock page queues here as we know
+		 * that the pages we got aren't on any queues.
+		 */
+		if (m == NULL) {
+			while (i != 0) {
+				i -= PAGE_SIZE;
+				m = vm_page_lookup(kmem_object, offset + i);
+				vm_page_free(m);
+			}
+			vm_object_unlock(kmem_object);
+			vm_map_delete(map, addr, addr + size);
+			vm_map_unlock(map);
+			return(0);
+		}
+#if 0
+		vm_page_zero_fill(m);
+#endif
+		m->flags &= ~PG_BUSY;
+	}
+	vm_object_unlock(kmem_object);
+
+	/*
+	 * Mark map entry as non-pageable.
+	 * Assert: vm_map_insert() will never be able to extend the previous
+	 * entry so there will be a new entry exactly corresponding to this
+	 * address range and it will have wired_count == 0.
+	 */
+	if (!vm_map_lookup_entry(map, addr, &entry) ||
+	    entry->start != addr || entry->end != addr + size ||
+	    entry->wired_count)
+		panic("kmem_malloc: entry not found or misaligned");
+	entry->wired_count++;
+
+	/*
+	 * Loop thru pages, entering them in the pmap.
+	 * (We cannot add them to the wired count without
+	 * wrapping the vm_page_queue_lock in splimp...)
+	 */
+	for (i = 0; i < size; i += PAGE_SIZE) {
+		vm_object_lock(kmem_object);
+		m = vm_page_lookup(kmem_object, offset + i);
+		vm_object_unlock(kmem_object);
+		pmap_enter(map->pmap, addr + i, VM_PAGE_TO_PHYS(m),
+			   VM_PROT_DEFAULT, TRUE);
+	}
+	vm_map_unlock(map);
+
+	vm_map_simplify(map, addr);
+	return(addr);
+}
+
+/*
+ *	kmem_alloc_wait
+ *
+ *	Allocates pageable memory from a sub-map of the kernel.  If the submap
+ *	has no room, the caller sleeps waiting for more memory in the submap.
+ *
+ */
+vm_offset_t
+kmem_alloc_wait(map, size)
+	vm_map_t	map;
+	vm_size_t	size;
+{
+	vm_offset_t	addr;
+
+	size = round_page(size);
+
+	for (;;) {
+		/*
+		 * To make this work for more than one map,
+		 * use the map's lock to lock out sleepers/wakers.
+		 */
+		vm_map_lock(map);
+		if (vm_map_findspace(map, 0, size, &addr) == 0)
+			break;
+		/* no space now; see if we can ever get space */
+		if (vm_map_max(map) - vm_map_min(map) < size) {
+			vm_map_unlock(map);
+			return (0);
+		}
+		assert_wait(map, TRUE);
+		vm_map_unlock(map);
+		thread_block();
+	}
+	vm_map_insert(map, NULL, (vm_offset_t)0, addr, addr + size);
+	vm_map_unlock(map);
+	return (addr);
+}
+
+/*
+ *	kmem_free_wakeup
+ *
+ *	Returns memory to a submap of the kernel, and wakes up any threads
+ *	waiting for memory in that map.
+ */
+void
+kmem_free_wakeup(map, addr, size)
+	vm_map_t	map;
+	vm_offset_t	addr;
+	vm_size_t	size;
+{
+	vm_map_lock(map);
+	(void) vm_map_delete(map, trunc_page(addr), round_page(addr + size));
+	thread_wakeup(map);
+	vm_map_unlock(map);
+}
+
+/*
+ * Create the kernel map; insert a mapping covering kernel text, data, bss,
+ * and all space allocated thus far (`boostrap' data).  The new map will thus
+ * map the range between VM_MIN_KERNEL_ADDRESS and `start' as allocated, and
+ * the range between `start' and `end' as free.
+ */
+void
+kmem_init(start, end)
+	vm_offset_t start, end;
+{
+	register vm_map_t m;
+
+	m = vm_map_create(kernel_pmap, VM_MIN_KERNEL_ADDRESS, end, FALSE);
+	vm_map_lock(m);
+	/* N.B.: cannot use kgdb to debug, starting with this assignment ... */
+	kernel_map = m;
+	(void) vm_map_insert(m, NULL, (vm_offset_t)0,
+	    VM_MIN_KERNEL_ADDRESS, start);
+	/* ... and ending with the completion of the above `insert' */
+	vm_map_unlock(m);
+}

--- a/src-uland/libvm/vm_map.c
+++ b/src-uland/libvm/vm_map.c
@@ -1,0 +1,2649 @@
+/* Copied from sys/vm/vm_map.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_map.c	8.9 (Berkeley) 5/17/95
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	Virtual memory mapping module.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/malloc.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+
+/*
+ *	Virtual memory maps provide for the mapping, protection,
+ *	and sharing of virtual memory objects.  In addition,
+ *	this module provides for an efficient virtual copy of
+ *	memory from one map to another.
+ *
+ *	Synchronization is required prior to most operations.
+ *
+ *	Maps consist of an ordered doubly-linked list of simple
+ *	entries; a single hint is used to speed up lookups.
+ *
+ *	In order to properly represent the sharing of virtual
+ *	memory regions among maps, the map structure is bi-level.
+ *	Top-level ("address") maps refer to regions of sharable
+ *	virtual memory.  These regions are implemented as
+ *	("sharing") maps, which then refer to the actual virtual
+ *	memory objects.  When two address maps "share" memory,
+ *	their top-level maps both have references to the same
+ *	sharing map.  When memory is virtual-copied from one
+ *	address map to another, the references in the sharing
+ *	maps are actually copied -- no copying occurs at the
+ *	virtual memory object level.
+ *
+ *	Since portions of maps are specified by start/end addreses,
+ *	which may not align with existing map entries, all
+ *	routines merely "clip" entries to these start/end values.
+ *	[That is, an entry is split into two, bordering at a
+ *	start or end value.]  Note that these clippings may not
+ *	always be necessary (as the two resulting entries are then
+ *	not changed); however, the clipping is done for convenience.
+ *	No attempt is currently made to "glue back together" two
+ *	abutting entries.
+ *
+ *	As mentioned above, virtual copy operations are performed
+ *	by copying VM object references from one sharing map to
+ *	another, and then marking both regions as copy-on-write.
+ *	It is important to note that only one writeable reference
+ *	to a VM object region exists in any map -- this means that
+ *	shadow object creation can be delayed until a write operation
+ *	occurs.
+ */
+
+/*
+ *	vm_map_startup:
+ *
+ *	Initialize the vm_map module.  Must be called before
+ *	any other vm_map routines.
+ *
+ *	Map and entry structures are allocated from the general
+ *	purpose memory pool with some exceptions:
+ *
+ *	- The kernel map and kmem submap are allocated statically.
+ *	- Kernel map entries are allocated out of a static pool.
+ *
+ *	These restrictions are necessary since malloc() uses the
+ *	maps and requires map entries.
+ */
+
+vm_offset_t	kentry_data;
+vm_size_t	kentry_data_size;
+vm_map_entry_t	kentry_free;
+vm_map_t	kmap_free;
+
+static void	_vm_map_clip_end __P((vm_map_t, vm_map_entry_t, vm_offset_t));
+static void	_vm_map_clip_start __P((vm_map_t, vm_map_entry_t, vm_offset_t));
+
+void
+vm_map_startup()
+{
+	register int i;
+	register vm_map_entry_t mep;
+	vm_map_t mp;
+
+	/*
+	 * Static map structures for allocation before initialization of
+	 * kernel map or kmem map.  vm_map_create knows how to deal with them.
+	 */
+	kmap_free = mp = (vm_map_t) kentry_data;
+	i = MAX_KMAP;
+	while (--i > 0) {
+		mp->header.next = (vm_map_entry_t) (mp + 1);
+		mp++;
+	}
+	mp++->header.next = NULL;
+
+	/*
+	 * Form a free list of statically allocated kernel map entries
+	 * with the rest.
+	 */
+	kentry_free = mep = (vm_map_entry_t) mp;
+	i = (kentry_data_size - MAX_KMAP * sizeof *mp) / sizeof *mep;
+	while (--i > 0) {
+		mep->next = mep + 1;
+		mep++;
+	}
+	mep->next = NULL;
+}
+
+/*
+ * Allocate a vmspace structure, including a vm_map and pmap,
+ * and initialize those structures.  The refcnt is set to 1.
+ * The remaining fields must be initialized by the caller.
+ */
+struct vmspace *
+vmspace_alloc(min, max, pageable)
+	vm_offset_t min, max;
+	int pageable;
+{
+	register struct vmspace *vm;
+
+	MALLOC(vm, struct vmspace *, sizeof(struct vmspace), M_VMMAP, M_WAITOK);
+	bzero(vm, (caddr_t) &vm->vm_startcopy - (caddr_t) vm);
+	vm_map_init(&vm->vm_map, min, max, pageable);
+	pmap_pinit(&vm->vm_pmap);
+	vm->vm_map.pmap = &vm->vm_pmap;		/* XXX */
+	vm->vm_refcnt = 1;
+	return (vm);
+}
+
+void
+vmspace_free(vm)
+	register struct vmspace *vm;
+{
+
+	if (--vm->vm_refcnt == 0) {
+		/*
+		 * Lock the map, to wait out all other references to it.
+		 * Delete all of the mappings and pages they hold,
+		 * then call the pmap module to reclaim anything left.
+		 */
+		vm_map_lock(&vm->vm_map);
+		(void) vm_map_delete(&vm->vm_map, vm->vm_map.min_offset,
+		    vm->vm_map.max_offset);
+		pmap_release(&vm->vm_pmap);
+		FREE(vm, M_VMMAP);
+	}
+}
+
+/*
+ *	vm_map_create:
+ *
+ *	Creates and returns a new empty VM map with
+ *	the given physical map structure, and having
+ *	the given lower and upper address bounds.
+ */
+vm_map_t
+vm_map_create(pmap, min, max, pageable)
+	pmap_t		pmap;
+	vm_offset_t	min, max;
+	boolean_t	pageable;
+{
+	register vm_map_t	result;
+	extern vm_map_t		kmem_map;
+
+	if (kmem_map == NULL) {
+		result = kmap_free;
+		if (result == NULL)
+			panic("vm_map_create: out of maps");
+		kmap_free = (vm_map_t) result->header.next;
+	} else
+		MALLOC(result, vm_map_t, sizeof(struct vm_map),
+		       M_VMMAP, M_WAITOK);
+
+	vm_map_init(result, min, max, pageable);
+	result->pmap = pmap;
+	return(result);
+}
+
+/*
+ * Initialize an existing vm_map structure
+ * such as that in the vmspace structure.
+ * The pmap is set elsewhere.
+ */
+void
+vm_map_init(map, min, max, pageable)
+	register struct vm_map *map;
+	vm_offset_t	min, max;
+	boolean_t	pageable;
+{
+	map->header.next = map->header.prev = &map->header;
+	map->nentries = 0;
+	map->size = 0;
+	map->ref_count = 1;
+	map->is_main_map = TRUE;
+	map->min_offset = min;
+	map->max_offset = max;
+	map->entries_pageable = pageable;
+	map->first_free = &map->header;
+	map->hint = &map->header;
+	map->timestamp = 0;
+	lockinit(&map->lock, PVM, "thrd_sleep", 0, 0);
+	simple_lock_init(&map->ref_lock);
+	simple_lock_init(&map->hint_lock);
+}
+
+/*
+ *	vm_map_entry_create:	[ internal use only ]
+ *
+ *	Allocates a VM map entry for insertion.
+ *	No entry fields are filled in.  This routine is
+ */
+vm_map_entry_t
+vm_map_entry_create(map)
+	vm_map_t	map;
+{
+	vm_map_entry_t	entry;
+#ifdef DEBUG
+	extern vm_map_t		kernel_map, kmem_map, mb_map, pager_map;
+	boolean_t		isspecial;
+
+	isspecial = (map == kernel_map || map == kmem_map ||
+		     map == mb_map || map == pager_map);
+	if (isspecial && map->entries_pageable ||
+	    !isspecial && !map->entries_pageable)
+		panic("vm_map_entry_create: bogus map");
+#endif
+	if (map->entries_pageable) {
+		MALLOC(entry, vm_map_entry_t, sizeof(struct vm_map_entry),
+		       M_VMMAPENT, M_WAITOK);
+	} else {
+		if (entry = kentry_free)
+			kentry_free = kentry_free->next;
+	}
+	if (entry == NULL)
+		panic("vm_map_entry_create: out of map entries");
+
+	return(entry);
+}
+
+/*
+ *	vm_map_entry_dispose:	[ internal use only ]
+ *
+ *	Inverse of vm_map_entry_create.
+ */
+void
+vm_map_entry_dispose(map, entry)
+	vm_map_t	map;
+	vm_map_entry_t	entry;
+{
+#ifdef DEBUG
+	extern vm_map_t		kernel_map, kmem_map, mb_map, pager_map;
+	boolean_t		isspecial;
+
+	isspecial = (map == kernel_map || map == kmem_map ||
+		     map == mb_map || map == pager_map);
+	if (isspecial && map->entries_pageable ||
+	    !isspecial && !map->entries_pageable)
+		panic("vm_map_entry_dispose: bogus map");
+#endif
+	if (map->entries_pageable) {
+		FREE(entry, M_VMMAPENT);
+	} else {
+		entry->next = kentry_free;
+		kentry_free = entry;
+	}
+}
+
+/*
+ *	vm_map_entry_{un,}link:
+ *
+ *	Insert/remove entries from maps.
+ */
+#define	vm_map_entry_link(map, after_where, entry) \
+		{ \
+		(map)->nentries++; \
+		(entry)->prev = (after_where); \
+		(entry)->next = (after_where)->next; \
+		(entry)->prev->next = (entry); \
+		(entry)->next->prev = (entry); \
+		}
+#define	vm_map_entry_unlink(map, entry) \
+		{ \
+		(map)->nentries--; \
+		(entry)->next->prev = (entry)->prev; \
+		(entry)->prev->next = (entry)->next; \
+		}
+
+/*
+ *	vm_map_reference:
+ *
+ *	Creates another valid reference to the given map.
+ *
+ */
+void
+vm_map_reference(map)
+	register vm_map_t	map;
+{
+	if (map == NULL)
+		return;
+
+	simple_lock(&map->ref_lock);
+#ifdef DEBUG
+	if (map->ref_count == 0)
+		panic("vm_map_reference: zero ref_count");
+#endif
+	map->ref_count++;
+	simple_unlock(&map->ref_lock);
+}
+
+/*
+ *	vm_map_deallocate:
+ *
+ *	Removes a reference from the specified map,
+ *	destroying it if no references remain.
+ *	The map should not be locked.
+ */
+void
+vm_map_deallocate(map)
+	register vm_map_t	map;
+{
+
+	if (map == NULL)
+		return;
+
+	simple_lock(&map->ref_lock);
+	if (--map->ref_count > 0) {
+		simple_unlock(&map->ref_lock);
+		return;
+	}
+
+	/*
+	 *	Lock the map, to wait out all other references
+	 *	to it.
+	 */
+
+	vm_map_lock_drain_interlock(map);
+
+	(void) vm_map_delete(map, map->min_offset, map->max_offset);
+
+	pmap_destroy(map->pmap);
+
+	vm_map_unlock(map);
+
+	FREE(map, M_VMMAP);
+}
+
+/*
+ *	vm_map_insert:
+ *
+ *	Inserts the given whole VM object into the target
+ *	map at the specified address range.  The object's
+ *	size should match that of the address range.
+ *
+ *	Requires that the map be locked, and leaves it so.
+ */
+int
+vm_map_insert(map, object, offset, start, end)
+	vm_map_t	map;
+	vm_object_t	object;
+	vm_offset_t	offset;
+	vm_offset_t	start;
+	vm_offset_t	end;
+{
+	register vm_map_entry_t		new_entry;
+	register vm_map_entry_t		prev_entry;
+	vm_map_entry_t			temp_entry;
+
+	/*
+	 *	Check that the start and end points are not bogus.
+	 */
+
+	if ((start < map->min_offset) || (end > map->max_offset) ||
+			(start >= end))
+		return(KERN_INVALID_ADDRESS);
+
+	/*
+	 *	Find the entry prior to the proposed
+	 *	starting address; if it's part of an
+	 *	existing entry, this range is bogus.
+	 */
+
+	if (vm_map_lookup_entry(map, start, &temp_entry))
+		return(KERN_NO_SPACE);
+
+	prev_entry = temp_entry;
+
+	/*
+	 *	Assert that the next entry doesn't overlap the
+	 *	end point.
+	 */
+
+	if ((prev_entry->next != &map->header) &&
+			(prev_entry->next->start < end))
+		return(KERN_NO_SPACE);
+
+	/*
+	 *	See if we can avoid creating a new entry by
+	 *	extending one of our neighbors.
+	 */
+
+	if (object == NULL) {
+		if ((prev_entry != &map->header) &&
+		    (prev_entry->end == start) &&
+		    (map->is_main_map) &&
+		    (prev_entry->is_a_map == FALSE) &&
+		    (prev_entry->is_sub_map == FALSE) &&
+		    (prev_entry->inheritance == VM_INHERIT_DEFAULT) &&
+		    (prev_entry->protection == VM_PROT_DEFAULT) &&
+		    (prev_entry->max_protection == VM_PROT_DEFAULT) &&
+		    (prev_entry->wired_count == 0)) {
+
+			if (vm_object_coalesce(prev_entry->object.vm_object,
+					NULL,
+					prev_entry->offset,
+					(vm_offset_t) 0,
+					(vm_size_t)(prev_entry->end
+						     - prev_entry->start),
+					(vm_size_t)(end - prev_entry->end))) {
+				/*
+				 *	Coalesced the two objects - can extend
+				 *	the previous map entry to include the
+				 *	new range.
+				 */
+				map->size += (end - prev_entry->end);
+				prev_entry->end = end;
+				return(KERN_SUCCESS);
+			}
+		}
+	}
+
+	/*
+	 *	Create a new entry
+	 */
+
+	new_entry = vm_map_entry_create(map);
+	new_entry->start = start;
+	new_entry->end = end;
+
+	new_entry->is_a_map = FALSE;
+	new_entry->is_sub_map = FALSE;
+	new_entry->object.vm_object = object;
+	new_entry->offset = offset;
+
+	new_entry->copy_on_write = FALSE;
+	new_entry->needs_copy = FALSE;
+
+	if (map->is_main_map) {
+		new_entry->inheritance = VM_INHERIT_DEFAULT;
+		new_entry->protection = VM_PROT_DEFAULT;
+		new_entry->max_protection = VM_PROT_DEFAULT;
+		new_entry->wired_count = 0;
+	}
+
+	/*
+	 *	Insert the new entry into the list
+	 */
+
+	vm_map_entry_link(map, prev_entry, new_entry);
+	map->size += new_entry->end - new_entry->start;
+
+	/*
+	 *	Update the free space hint
+	 */
+
+	if ((map->first_free == prev_entry) && (prev_entry->end >= new_entry->start))
+		map->first_free = new_entry;
+
+	return(KERN_SUCCESS);
+}
+
+/*
+ *	SAVE_HINT:
+ *
+ *	Saves the specified entry as the hint for
+ *	future lookups.  Performs necessary interlocks.
+ */
+#define	SAVE_HINT(map,value) \
+		simple_lock(&(map)->hint_lock); \
+		(map)->hint = (value); \
+		simple_unlock(&(map)->hint_lock);
+
+/*
+ *	vm_map_lookup_entry:	[ internal use only ]
+ *
+ *	Finds the map entry containing (or
+ *	immediately preceding) the specified address
+ *	in the given map; the entry is returned
+ *	in the "entry" parameter.  The boolean
+ *	result indicates whether the address is
+ *	actually contained in the map.
+ */
+boolean_t
+vm_map_lookup_entry(map, address, entry)
+	register vm_map_t	map;
+	register vm_offset_t	address;
+	vm_map_entry_t		*entry;		/* OUT */
+{
+	register vm_map_entry_t		cur;
+	register vm_map_entry_t		last;
+
+	/*
+	 *	Start looking either from the head of the
+	 *	list, or from the hint.
+	 */
+
+	simple_lock(&map->hint_lock);
+	cur = map->hint;
+	simple_unlock(&map->hint_lock);
+
+	if (cur == &map->header)
+		cur = cur->next;
+
+	if (address >= cur->start) {
+	    	/*
+		 *	Go from hint to end of list.
+		 *
+		 *	But first, make a quick check to see if
+		 *	we are already looking at the entry we
+		 *	want (which is usually the case).
+		 *	Note also that we don't need to save the hint
+		 *	here... it is the same hint (unless we are
+		 *	at the header, in which case the hint didn't
+		 *	buy us anything anyway).
+		 */
+		last = &map->header;
+		if ((cur != last) && (cur->end > address)) {
+			*entry = cur;
+			return(TRUE);
+		}
+	}
+	else {
+	    	/*
+		 *	Go from start to hint, *inclusively*
+		 */
+		last = cur->next;
+		cur = map->header.next;
+	}
+
+	/*
+	 *	Search linearly
+	 */
+
+	while (cur != last) {
+		if (cur->end > address) {
+			if (address >= cur->start) {
+			    	/*
+				 *	Save this lookup for future
+				 *	hints, and return
+				 */
+
+				*entry = cur;
+				SAVE_HINT(map, cur);
+				return(TRUE);
+			}
+			break;
+		}
+		cur = cur->next;
+	}
+	*entry = cur->prev;
+	SAVE_HINT(map, *entry);
+	return(FALSE);
+}
+
+/*
+ * Find sufficient space for `length' bytes in the given map, starting at
+ * `start'.  The map must be locked.  Returns 0 on success, 1 on no space.
+ */
+int
+vm_map_findspace(map, start, length, addr)
+	register vm_map_t map;
+	register vm_offset_t start;
+	vm_size_t length;
+	vm_offset_t *addr;
+{
+	register vm_map_entry_t entry, next;
+	register vm_offset_t end;
+
+	if (start < map->min_offset)
+		start = map->min_offset;
+	if (start > map->max_offset)
+		return (1);
+
+	/*
+	 * Look for the first possible address; if there's already
+	 * something at this address, we have to start after it.
+	 */
+	if (start == map->min_offset) {
+		if ((entry = map->first_free) != &map->header)
+			start = entry->end;
+	} else {
+		vm_map_entry_t tmp;
+		if (vm_map_lookup_entry(map, start, &tmp))
+			start = tmp->end;
+		entry = tmp;
+	}
+
+	/*
+	 * Look through the rest of the map, trying to fit a new region in
+	 * the gap between existing regions, or after the very last region.
+	 */
+	for (;; start = (entry = next)->end) {
+		/*
+		 * Find the end of the proposed new region.  Be sure we didn't
+		 * go beyond the end of the map, or wrap around the address;
+		 * if so, we lose.  Otherwise, if this is the last entry, or
+		 * if the proposed new region fits before the next entry, we
+		 * win.
+		 */
+		end = start + length;
+		if (end > map->max_offset || end < start)
+			return (1);
+		next = entry->next;
+		if (next == &map->header || next->start >= end)
+			break;
+	}
+	SAVE_HINT(map, entry);
+	*addr = start;
+	return (0);
+}
+
+/*
+ *	vm_map_find finds an unallocated region in the target address
+ *	map with the given length.  The search is defined to be
+ *	first-fit from the specified address; the region found is
+ *	returned in the same parameter.
+ *
+ */
+int
+vm_map_find(map, object, offset, addr, length, find_space)
+	vm_map_t	map;
+	vm_object_t	object;
+	vm_offset_t	offset;
+	vm_offset_t	*addr;		/* IN/OUT */
+	vm_size_t	length;
+	boolean_t	find_space;
+{
+	register vm_offset_t	start;
+	int			result;
+
+	start = *addr;
+	vm_map_lock(map);
+	if (find_space) {
+		if (vm_map_findspace(map, start, length, addr)) {
+			vm_map_unlock(map);
+			return (KERN_NO_SPACE);
+		}
+		start = *addr;
+	}
+	result = vm_map_insert(map, object, offset, start, start + length);
+	vm_map_unlock(map);
+	return (result);
+}
+
+/*
+ *	vm_map_simplify_entry:	[ internal use only ]
+ *
+ *	Simplify the given map entry by:
+ *		removing extra sharing maps
+ *		[XXX maybe later] merging with a neighbor
+ */
+void
+vm_map_simplify_entry(map, entry)
+	vm_map_t	map;
+	vm_map_entry_t	entry;
+{
+#ifdef	lint
+	map++;
+#endif
+
+	/*
+	 *	If this entry corresponds to a sharing map, then
+	 *	see if we can remove the level of indirection.
+	 *	If it's not a sharing map, then it points to
+	 *	a VM object, so see if we can merge with either
+	 *	of our neighbors.
+	 */
+
+	if (entry->is_sub_map)
+		return;
+	if (entry->is_a_map) {
+#if	0
+		vm_map_t	my_share_map;
+		int		count;
+
+		my_share_map = entry->object.share_map;	
+		simple_lock(&my_share_map->ref_lock);
+		count = my_share_map->ref_count;
+		simple_unlock(&my_share_map->ref_lock);
+		
+		if (count == 1) {
+			/* Can move the region from
+			 * entry->start to entry->end (+ entry->offset)
+			 * in my_share_map into place of entry.
+			 * Later.
+			 */
+		}
+#endif
+	}
+	else {
+		/*
+		 *	Try to merge with our neighbors.
+		 *
+		 *	Conditions for merge are:
+		 *
+		 *	1.  entries are adjacent.
+		 *	2.  both entries point to objects
+		 *	    with null pagers.
+		 *
+		 * 	If a merge is possible, we replace the two
+		 *	entries with a single entry, then merge
+		 *	the two objects into a single object.
+		 *
+		 *	Now, all that is left to do is write the
+		 *	code!
+		 */
+	}
+}
+
+/*
+ *	vm_map_clip_start:	[ internal use only ]
+ *
+ *	Asserts that the given entry begins at or after
+ *	the specified address; if necessary,
+ *	it splits the entry into two.
+ */
+#define vm_map_clip_start(map, entry, startaddr) \
+{ \
+	if (startaddr > entry->start) \
+		_vm_map_clip_start(map, entry, startaddr); \
+}
+
+/*
+ *	This routine is called only when it is known that
+ *	the entry must be split.
+ */
+static void
+_vm_map_clip_start(map, entry, start)
+	register vm_map_t	map;
+	register vm_map_entry_t	entry;
+	register vm_offset_t	start;
+{
+	register vm_map_entry_t	new_entry;
+
+	/*
+	 *	See if we can simplify this entry first
+	 */
+		 
+	vm_map_simplify_entry(map, entry);
+
+	/*
+	 *	Split off the front portion --
+	 *	note that we must insert the new
+	 *	entry BEFORE this one, so that
+	 *	this entry has the specified starting
+	 *	address.
+	 */
+
+	new_entry = vm_map_entry_create(map);
+	*new_entry = *entry;
+
+	new_entry->end = start;
+	entry->offset += (start - entry->start);
+	entry->start = start;
+
+	vm_map_entry_link(map, entry->prev, new_entry);
+
+	if (entry->is_a_map || entry->is_sub_map)
+	 	vm_map_reference(new_entry->object.share_map);
+	else
+		vm_object_reference(new_entry->object.vm_object);
+}
+
+/*
+ *	vm_map_clip_end:	[ internal use only ]
+ *
+ *	Asserts that the given entry ends at or before
+ *	the specified address; if necessary,
+ *	it splits the entry into two.
+ */
+
+#define vm_map_clip_end(map, entry, endaddr) \
+{ \
+	if (endaddr < entry->end) \
+		_vm_map_clip_end(map, entry, endaddr); \
+}
+
+/*
+ *	This routine is called only when it is known that
+ *	the entry must be split.
+ */
+static void
+_vm_map_clip_end(map, entry, end)
+	register vm_map_t	map;
+	register vm_map_entry_t	entry;
+	register vm_offset_t	end;
+{
+	register vm_map_entry_t	new_entry;
+
+	/*
+	 *	Create a new entry and insert it
+	 *	AFTER the specified entry
+	 */
+
+	new_entry = vm_map_entry_create(map);
+	*new_entry = *entry;
+
+	new_entry->start = entry->end = end;
+	new_entry->offset += (end - entry->start);
+
+	vm_map_entry_link(map, entry, new_entry);
+
+	if (entry->is_a_map || entry->is_sub_map)
+	 	vm_map_reference(new_entry->object.share_map);
+	else
+		vm_object_reference(new_entry->object.vm_object);
+}
+
+/*
+ *	VM_MAP_RANGE_CHECK:	[ internal use only ]
+ *
+ *	Asserts that the starting and ending region
+ *	addresses fall within the valid range of the map.
+ */
+#define	VM_MAP_RANGE_CHECK(map, start, end)		\
+		{					\
+		if (start < vm_map_min(map))		\
+			start = vm_map_min(map);	\
+		if (end > vm_map_max(map))		\
+			end = vm_map_max(map);		\
+		if (start > end)			\
+			start = end;			\
+		}
+
+/*
+ *	vm_map_submap:		[ kernel use only ]
+ *
+ *	Mark the given range as handled by a subordinate map.
+ *
+ *	This range must have been created with vm_map_find,
+ *	and no other operations may have been performed on this
+ *	range prior to calling vm_map_submap.
+ *
+ *	Only a limited number of operations can be performed
+ *	within this rage after calling vm_map_submap:
+ *		vm_fault
+ *	[Don't try vm_map_copy!]
+ *
+ *	To remove a submapping, one must first remove the
+ *	range from the superior map, and then destroy the
+ *	submap (if desired).  [Better yet, don't try it.]
+ */
+int
+vm_map_submap(map, start, end, submap)
+	register vm_map_t	map;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+	vm_map_t		submap;
+{
+	vm_map_entry_t		entry;
+	register int		result = KERN_INVALID_ARGUMENT;
+
+	vm_map_lock(map);
+
+	VM_MAP_RANGE_CHECK(map, start, end);
+
+	if (vm_map_lookup_entry(map, start, &entry)) {
+		vm_map_clip_start(map, entry, start);
+	}
+	 else
+		entry = entry->next;
+
+	vm_map_clip_end(map, entry, end);
+
+	if ((entry->start == start) && (entry->end == end) &&
+	    (!entry->is_a_map) &&
+	    (entry->object.vm_object == NULL) &&
+	    (!entry->copy_on_write)) {
+		entry->is_a_map = FALSE;
+		entry->is_sub_map = TRUE;
+		vm_map_reference(entry->object.sub_map = submap);
+		result = KERN_SUCCESS;
+	}
+	vm_map_unlock(map);
+
+	return(result);
+}
+
+/*
+ *	vm_map_protect:
+ *
+ *	Sets the protection of the specified address
+ *	region in the target map.  If "set_max" is
+ *	specified, the maximum protection is to be set;
+ *	otherwise, only the current protection is affected.
+ */
+int
+vm_map_protect(map, start, end, new_prot, set_max)
+	register vm_map_t	map;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+	register vm_prot_t	new_prot;
+	register boolean_t	set_max;
+{
+	register vm_map_entry_t		current;
+	vm_map_entry_t			entry;
+
+	vm_map_lock(map);
+
+	VM_MAP_RANGE_CHECK(map, start, end);
+
+	if (vm_map_lookup_entry(map, start, &entry)) {
+		vm_map_clip_start(map, entry, start);
+	}
+	 else
+		entry = entry->next;
+
+	/*
+	 *	Make a first pass to check for protection
+	 *	violations.
+	 */
+
+	current = entry;
+	while ((current != &map->header) && (current->start < end)) {
+		if (current->is_sub_map)
+			return(KERN_INVALID_ARGUMENT);
+		if ((new_prot & current->max_protection) != new_prot) {
+			vm_map_unlock(map);
+			return(KERN_PROTECTION_FAILURE);
+		}
+
+		current = current->next;
+	}
+
+	/*
+	 *	Go back and fix up protections.
+	 *	[Note that clipping is not necessary the second time.]
+	 */
+
+	current = entry;
+
+	while ((current != &map->header) && (current->start < end)) {
+		vm_prot_t	old_prot;
+
+		vm_map_clip_end(map, current, end);
+
+		old_prot = current->protection;
+		if (set_max)
+			current->protection =
+				(current->max_protection = new_prot) &
+					old_prot;
+		else
+			current->protection = new_prot;
+
+		/*
+		 *	Update physical map if necessary.
+		 *	Worry about copy-on-write here -- CHECK THIS XXX
+		 */
+
+		if (current->protection != old_prot) {
+
+#define MASK(entry)	((entry)->copy_on_write ? ~VM_PROT_WRITE : \
+							VM_PROT_ALL)
+#define	max(a,b)	((a) > (b) ? (a) : (b))
+
+			if (current->is_a_map) {
+				vm_map_entry_t	share_entry;
+				vm_offset_t	share_end;
+
+				vm_map_lock(current->object.share_map);
+				(void) vm_map_lookup_entry(
+						current->object.share_map,
+						current->offset,
+						&share_entry);
+				share_end = current->offset +
+					(current->end - current->start);
+				while ((share_entry !=
+					&current->object.share_map->header) &&
+					(share_entry->start < share_end)) {
+
+					pmap_protect(map->pmap,
+						(max(share_entry->start,
+							current->offset) -
+							current->offset +
+							current->start),
+						min(share_entry->end,
+							share_end) -
+						current->offset +
+						current->start,
+						current->protection &
+							MASK(share_entry));
+
+					share_entry = share_entry->next;
+				}
+				vm_map_unlock(current->object.share_map);
+			}
+			else
+			 	pmap_protect(map->pmap, current->start,
+					current->end,
+					current->protection & MASK(entry));
+#undef	max
+#undef	MASK
+		}
+		current = current->next;
+	}
+
+	vm_map_unlock(map);
+	return(KERN_SUCCESS);
+}
+
+/*
+ *	vm_map_inherit:
+ *
+ *	Sets the inheritance of the specified address
+ *	range in the target map.  Inheritance
+ *	affects how the map will be shared with
+ *	child maps at the time of vm_map_fork.
+ */
+int
+vm_map_inherit(map, start, end, new_inheritance)
+	register vm_map_t	map;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+	register vm_inherit_t	new_inheritance;
+{
+	register vm_map_entry_t	entry;
+	vm_map_entry_t	temp_entry;
+
+	switch (new_inheritance) {
+	case VM_INHERIT_NONE:
+	case VM_INHERIT_COPY:
+	case VM_INHERIT_SHARE:
+		break;
+	default:
+		return(KERN_INVALID_ARGUMENT);
+	}
+
+	vm_map_lock(map);
+
+	VM_MAP_RANGE_CHECK(map, start, end);
+
+	if (vm_map_lookup_entry(map, start, &temp_entry)) {
+		entry = temp_entry;
+		vm_map_clip_start(map, entry, start);
+	}
+	else
+		entry = temp_entry->next;
+
+	while ((entry != &map->header) && (entry->start < end)) {
+		vm_map_clip_end(map, entry, end);
+
+		entry->inheritance = new_inheritance;
+
+		entry = entry->next;
+	}
+
+	vm_map_unlock(map);
+	return(KERN_SUCCESS);
+}
+
+/*
+ *	vm_map_pageable:
+ *
+ *	Sets the pageability of the specified address
+ *	range in the target map.  Regions specified
+ *	as not pageable require locked-down physical
+ *	memory and physical page maps.
+ *
+ *	The map must not be locked, but a reference
+ *	must remain to the map throughout the call.
+ */
+int
+vm_map_pageable(map, start, end, new_pageable)
+	register vm_map_t	map;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+	register boolean_t	new_pageable;
+{
+	register vm_map_entry_t	entry;
+	vm_map_entry_t		start_entry;
+	register vm_offset_t	failed;
+	int			rv;
+
+	vm_map_lock(map);
+
+	VM_MAP_RANGE_CHECK(map, start, end);
+
+	/*
+	 *	Only one pageability change may take place at one
+	 *	time, since vm_fault assumes it will be called
+	 *	only once for each wiring/unwiring.  Therefore, we
+	 *	have to make sure we're actually changing the pageability
+	 *	for the entire region.  We do so before making any changes.
+	 */
+
+	if (vm_map_lookup_entry(map, start, &start_entry) == FALSE) {
+		vm_map_unlock(map);
+		return(KERN_INVALID_ADDRESS);
+	}
+	entry = start_entry;
+
+	/*
+	 *	Actions are rather different for wiring and unwiring,
+	 *	so we have two separate cases.
+	 */
+
+	if (new_pageable) {
+
+		vm_map_clip_start(map, entry, start);
+
+		/*
+		 *	Unwiring.  First ensure that the range to be
+		 *	unwired is really wired down and that there
+		 *	are no holes.
+		 */
+		while ((entry != &map->header) && (entry->start < end)) {
+
+		    if (entry->wired_count == 0 ||
+			(entry->end < end &&
+			 (entry->next == &map->header ||
+			  entry->next->start > entry->end))) {
+			vm_map_unlock(map);
+			return(KERN_INVALID_ARGUMENT);
+		    }
+		    entry = entry->next;
+		}
+
+		/*
+		 *	Now decrement the wiring count for each region.
+		 *	If a region becomes completely unwired,
+		 *	unwire its physical pages and mappings.
+		 */
+		vm_map_set_recursive(&map->lock);
+
+		entry = start_entry;
+		while ((entry != &map->header) && (entry->start < end)) {
+		    vm_map_clip_end(map, entry, end);
+
+		    entry->wired_count--;
+		    if (entry->wired_count == 0)
+			vm_fault_unwire(map, entry->start, entry->end);
+
+		    entry = entry->next;
+		}
+		vm_map_clear_recursive(&map->lock);
+	}
+
+	else {
+		/*
+		 *	Wiring.  We must do this in two passes:
+		 *
+		 *	1.  Holding the write lock, we create any shadow
+		 *	    or zero-fill objects that need to be created.
+		 *	    Then we clip each map entry to the region to be
+		 *	    wired and increment its wiring count.  We
+		 *	    create objects before clipping the map entries
+		 *	    to avoid object proliferation.
+		 *
+		 *	2.  We downgrade to a read lock, and call
+		 *	    vm_fault_wire to fault in the pages for any
+		 *	    newly wired area (wired_count is 1).
+		 *
+		 *	Downgrading to a read lock for vm_fault_wire avoids
+		 *	a possible deadlock with another thread that may have
+		 *	faulted on one of the pages to be wired (it would mark
+		 *	the page busy, blocking us, then in turn block on the
+		 *	map lock that we hold).  Because of problems in the
+		 *	recursive lock package, we cannot upgrade to a write
+		 *	lock in vm_map_lookup.  Thus, any actions that require
+		 *	the write lock must be done beforehand.  Because we
+		 *	keep the read lock on the map, the copy-on-write status
+		 *	of the entries we modify here cannot change.
+		 */
+
+		/*
+		 *	Pass 1.
+		 */
+		while ((entry != &map->header) && (entry->start < end)) {
+		    if (entry->wired_count == 0) {
+
+			/*
+			 *	Perform actions of vm_map_lookup that need
+			 *	the write lock on the map: create a shadow
+			 *	object for a copy-on-write region, or an
+			 *	object for a zero-fill region.
+			 *
+			 *	We don't have to do this for entries that
+			 *	point to sharing maps, because we won't hold
+			 *	the lock on the sharing map.
+			 */
+			if (!entry->is_a_map) {
+			    if (entry->needs_copy &&
+				((entry->protection & VM_PROT_WRITE) != 0)) {
+
+				vm_object_shadow(&entry->object.vm_object,
+						&entry->offset,
+						(vm_size_t)(entry->end
+							- entry->start));
+				entry->needs_copy = FALSE;
+			    }
+			    else if (entry->object.vm_object == NULL) {
+				entry->object.vm_object =
+				    vm_object_allocate((vm_size_t)(entry->end
+				    			- entry->start));
+				entry->offset = (vm_offset_t)0;
+			    }
+			}
+		    }
+		    vm_map_clip_start(map, entry, start);
+		    vm_map_clip_end(map, entry, end);
+		    entry->wired_count++;
+
+		    /*
+		     * Check for holes
+		     */
+		    if (entry->end < end &&
+			(entry->next == &map->header ||
+			 entry->next->start > entry->end)) {
+			/*
+			 *	Found one.  Object creation actions
+			 *	do not need to be undone, but the
+			 *	wired counts need to be restored.
+			 */
+			while (entry != &map->header && entry->end > start) {
+			    entry->wired_count--;
+			    entry = entry->prev;
+			}
+			vm_map_unlock(map);
+			return(KERN_INVALID_ARGUMENT);
+		    }
+		    entry = entry->next;
+		}
+
+		/*
+		 *	Pass 2.
+		 */
+
+		/*
+		 * HACK HACK HACK HACK
+		 *
+		 * If we are wiring in the kernel map or a submap of it,
+		 * unlock the map to avoid deadlocks.  We trust that the
+		 * kernel threads are well-behaved, and therefore will
+		 * not do anything destructive to this region of the map
+		 * while we have it unlocked.  We cannot trust user threads
+		 * to do the same.
+		 *
+		 * HACK HACK HACK HACK
+		 */
+		if (vm_map_pmap(map) == kernel_pmap) {
+		    vm_map_unlock(map);		/* trust me ... */
+		}
+		else {
+		    vm_map_set_recursive(&map->lock);
+		    lockmgr(&map->lock, LK_DOWNGRADE, (void *)0, curproc);
+		}
+
+		rv = 0;
+		entry = start_entry;
+		while (entry != &map->header && entry->start < end) {
+		    /*
+		     * If vm_fault_wire fails for any page we need to
+		     * undo what has been done.  We decrement the wiring
+		     * count for those pages which have not yet been
+		     * wired (now) and unwire those that have (later).
+		     *
+		     * XXX this violates the locking protocol on the map,
+		     * needs to be fixed.
+		     */
+		    if (rv)
+			entry->wired_count--;
+		    else if (entry->wired_count == 1) {
+			rv = vm_fault_wire(map, entry->start, entry->end);
+			if (rv) {
+			    failed = entry->start;
+			    entry->wired_count--;
+			}
+		    }
+		    entry = entry->next;
+		}
+
+		if (vm_map_pmap(map) == kernel_pmap) {
+		    vm_map_lock(map);
+		}
+		else {
+		    vm_map_clear_recursive(&map->lock);
+		}
+		if (rv) {
+		    vm_map_unlock(map);
+		    (void) vm_map_pageable(map, start, failed, TRUE);
+		    return(rv);
+		}
+	}
+
+	vm_map_unlock(map);
+
+	return(KERN_SUCCESS);
+}
+
+/*
+ * vm_map_clean
+ *
+ * Push any dirty cached pages in the address range to their pager.
+ * If syncio is TRUE, dirty pages are written synchronously.
+ * If invalidate is TRUE, any cached pages are freed as well.
+ *
+ * Returns an error if any part of the specified range is not mapped.
+ */
+int
+vm_map_clean(map, start, end, syncio, invalidate)
+	vm_map_t	map;
+	vm_offset_t	start;
+	vm_offset_t	end;
+	boolean_t	syncio;
+	boolean_t	invalidate;
+{
+	register vm_map_entry_t current;
+	vm_map_entry_t entry;
+	vm_size_t size;
+	vm_object_t object;
+	vm_offset_t offset;
+
+	vm_map_lock_read(map);
+	VM_MAP_RANGE_CHECK(map, start, end);
+	if (!vm_map_lookup_entry(map, start, &entry)) {
+		vm_map_unlock_read(map);
+		return(KERN_INVALID_ADDRESS);
+	}
+
+	/*
+	 * Make a first pass to check for holes.
+	 */
+	for (current = entry; current->start < end; current = current->next) {
+		if (current->is_sub_map) {
+			vm_map_unlock_read(map);
+			return(KERN_INVALID_ARGUMENT);
+		}
+		if (end > current->end &&
+		    (current->next == &map->header ||
+		     current->end != current->next->start)) {
+			vm_map_unlock_read(map);
+			return(KERN_INVALID_ADDRESS);
+		}
+	}
+
+	/*
+	 * Make a second pass, cleaning/uncaching pages from the indicated
+	 * objects as we go.
+	 */
+	for (current = entry; current->start < end; current = current->next) {
+		offset = current->offset + (start - current->start);
+		size = (end <= current->end ? end : current->end) - start;
+		if (current->is_a_map) {
+			register vm_map_t smap;
+			vm_map_entry_t tentry;
+			vm_size_t tsize;
+
+			smap = current->object.share_map;
+			vm_map_lock_read(smap);
+			(void) vm_map_lookup_entry(smap, offset, &tentry);
+			tsize = tentry->end - offset;
+			if (tsize < size)
+				size = tsize;
+			object = tentry->object.vm_object;
+			offset = tentry->offset + (offset - tentry->start);
+			vm_object_lock(object);
+			vm_map_unlock_read(smap);
+		} else {
+			object = current->object.vm_object;
+			vm_object_lock(object);
+		}
+		/*
+		 * Flush pages if writing is allowed.
+		 * XXX should we continue on an error?
+		 */
+		if ((current->protection & VM_PROT_WRITE) &&
+		    !vm_object_page_clean(object, offset, offset+size,
+					  syncio, FALSE)) {
+			vm_object_unlock(object);
+			vm_map_unlock_read(map);
+			return(KERN_FAILURE);
+		}
+		if (invalidate)
+			vm_object_page_remove(object, offset, offset+size);
+		vm_object_unlock(object);
+		start += size;
+	}
+
+	vm_map_unlock_read(map);
+	return(KERN_SUCCESS);
+}
+
+/*
+ *	vm_map_entry_unwire:	[ internal use only ]
+ *
+ *	Make the region specified by this entry pageable.
+ *
+ *	The map in question should be locked.
+ *	[This is the reason for this routine's existence.]
+ */
+void
+vm_map_entry_unwire(map, entry)
+	vm_map_t		map;
+	register vm_map_entry_t	entry;
+{
+	vm_fault_unwire(map, entry->start, entry->end);
+	entry->wired_count = 0;
+}
+
+/*
+ *	vm_map_entry_delete:	[ internal use only ]
+ *
+ *	Deallocate the given entry from the target map.
+ */		
+void
+vm_map_entry_delete(map, entry)
+	register vm_map_t	map;
+	register vm_map_entry_t	entry;
+{
+	if (entry->wired_count != 0)
+		vm_map_entry_unwire(map, entry);
+		
+	vm_map_entry_unlink(map, entry);
+	map->size -= entry->end - entry->start;
+
+	if (entry->is_a_map || entry->is_sub_map)
+		vm_map_deallocate(entry->object.share_map);
+	else
+	 	vm_object_deallocate(entry->object.vm_object);
+
+	vm_map_entry_dispose(map, entry);
+}
+
+/*
+ *	vm_map_delete:	[ internal use only ]
+ *
+ *	Deallocates the given address range from the target
+ *	map.
+ *
+ *	When called with a sharing map, removes pages from
+ *	that region from all physical maps.
+ */
+int
+vm_map_delete(map, start, end)
+	register vm_map_t	map;
+	vm_offset_t		start;
+	register vm_offset_t	end;
+{
+	register vm_map_entry_t	entry;
+	vm_map_entry_t		first_entry;
+
+	/*
+	 *	Find the start of the region, and clip it
+	 */
+
+	if (!vm_map_lookup_entry(map, start, &first_entry))
+		entry = first_entry->next;
+	else {
+		entry = first_entry;
+		vm_map_clip_start(map, entry, start);
+
+		/*
+		 *	Fix the lookup hint now, rather than each
+		 *	time though the loop.
+		 */
+
+		SAVE_HINT(map, entry->prev);
+	}
+
+	/*
+	 *	Save the free space hint
+	 */
+
+	if (map->first_free->start >= start)
+		map->first_free = entry->prev;
+
+	/*
+	 *	Step through all entries in this region
+	 */
+
+	while ((entry != &map->header) && (entry->start < end)) {
+		vm_map_entry_t		next;
+		register vm_offset_t	s, e;
+		register vm_object_t	object;
+
+		vm_map_clip_end(map, entry, end);
+
+		next = entry->next;
+		s = entry->start;
+		e = entry->end;
+
+		/*
+		 *	Unwire before removing addresses from the pmap;
+		 *	otherwise, unwiring will put the entries back in
+		 *	the pmap.
+		 */
+
+		object = entry->object.vm_object;
+		if (entry->wired_count != 0)
+			vm_map_entry_unwire(map, entry);
+
+		/*
+		 *	If this is a sharing map, we must remove
+		 *	*all* references to this data, since we can't
+		 *	find all of the physical maps which are sharing
+		 *	it.
+		 */
+
+		if (object == kernel_object || object == kmem_object)
+			vm_object_page_remove(object, entry->offset,
+					entry->offset + (e - s));
+		else if (!map->is_main_map)
+			vm_object_pmap_remove(object,
+					 entry->offset,
+					 entry->offset + (e - s));
+		else
+			pmap_remove(map->pmap, s, e);
+
+		/*
+		 *	Delete the entry (which may delete the object)
+		 *	only after removing all pmap entries pointing
+		 *	to its pages.  (Otherwise, its page frames may
+		 *	be reallocated, and any modify bits will be
+		 *	set in the wrong object!)
+		 */
+
+		vm_map_entry_delete(map, entry);
+		entry = next;
+	}
+	return(KERN_SUCCESS);
+}
+
+/*
+ *	vm_map_remove:
+ *
+ *	Remove the given address range from the target map.
+ *	This is the exported form of vm_map_delete.
+ */
+int
+vm_map_remove(map, start, end)
+	register vm_map_t	map;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+{
+	register int		result;
+
+	vm_map_lock(map);
+	VM_MAP_RANGE_CHECK(map, start, end);
+	result = vm_map_delete(map, start, end);
+	vm_map_unlock(map);
+
+	return(result);
+}
+
+/*
+ *	vm_map_check_protection:
+ *
+ *	Assert that the target map allows the specified
+ *	privilege on the entire address region given.
+ *	The entire region must be allocated.
+ */
+boolean_t
+vm_map_check_protection(map, start, end, protection)
+	register vm_map_t	map;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+	register vm_prot_t	protection;
+{
+	register vm_map_entry_t	entry;
+	vm_map_entry_t		tmp_entry;
+
+	if (!vm_map_lookup_entry(map, start, &tmp_entry)) {
+		return(FALSE);
+	}
+
+	entry = tmp_entry;
+
+	while (start < end) {
+		if (entry == &map->header) {
+			return(FALSE);
+		}
+
+		/*
+		 *	No holes allowed!
+		 */
+
+		if (start < entry->start) {
+			return(FALSE);
+		}
+
+		/*
+		 * Check protection associated with entry.
+		 */
+
+		if ((entry->protection & protection) != protection) {
+			return(FALSE);
+		}
+
+		/* go to next entry */
+
+		start = entry->end;
+		entry = entry->next;
+	}
+	return(TRUE);
+}
+
+/*
+ *	vm_map_copy_entry:
+ *
+ *	Copies the contents of the source entry to the destination
+ *	entry.  The entries *must* be aligned properly.
+ */
+void
+vm_map_copy_entry(src_map, dst_map, src_entry, dst_entry)
+	vm_map_t		src_map, dst_map;
+	register vm_map_entry_t	src_entry, dst_entry;
+{
+	vm_object_t	temp_object;
+
+	if (src_entry->is_sub_map || dst_entry->is_sub_map)
+		return;
+
+	if (dst_entry->object.vm_object != NULL &&
+	    (dst_entry->object.vm_object->flags & OBJ_INTERNAL) == 0)
+		printf("vm_map_copy_entry: copying over permanent data!\n");
+
+	/*
+	 *	If our destination map was wired down,
+	 *	unwire it now.
+	 */
+
+	if (dst_entry->wired_count != 0)
+		vm_map_entry_unwire(dst_map, dst_entry);
+
+	/*
+	 *	If we're dealing with a sharing map, we
+	 *	must remove the destination pages from
+	 *	all maps (since we cannot know which maps
+	 *	this sharing map belongs in).
+	 */
+
+	if (dst_map->is_main_map)
+		pmap_remove(dst_map->pmap, dst_entry->start, dst_entry->end);
+	else
+		vm_object_pmap_remove(dst_entry->object.vm_object,
+			dst_entry->offset,
+			dst_entry->offset +
+				(dst_entry->end - dst_entry->start));
+
+	if (src_entry->wired_count == 0) {
+
+		boolean_t	src_needs_copy;
+
+		/*
+		 *	If the source entry is marked needs_copy,
+		 *	it is already write-protected.
+		 */
+		if (!src_entry->needs_copy) {
+
+			boolean_t	su;
+
+			/*
+			 *	If the source entry has only one mapping,
+			 *	we can just protect the virtual address
+			 *	range.
+			 */
+			if (!(su = src_map->is_main_map)) {
+				simple_lock(&src_map->ref_lock);
+				su = (src_map->ref_count == 1);
+				simple_unlock(&src_map->ref_lock);
+			}
+
+			if (su) {
+				pmap_protect(src_map->pmap,
+					src_entry->start,
+					src_entry->end,
+					src_entry->protection & ~VM_PROT_WRITE);
+			}
+			else {
+				vm_object_pmap_copy(src_entry->object.vm_object,
+					src_entry->offset,
+					src_entry->offset + (src_entry->end
+							    -src_entry->start));
+			}
+		}
+
+		/*
+		 *	Make a copy of the object.
+		 */
+		temp_object = dst_entry->object.vm_object;
+		vm_object_copy(src_entry->object.vm_object,
+				src_entry->offset,
+				(vm_size_t)(src_entry->end -
+					    src_entry->start),
+				&dst_entry->object.vm_object,
+				&dst_entry->offset,
+				&src_needs_copy);
+		/*
+		 *	If we didn't get a copy-object now, mark the
+		 *	source map entry so that a shadow will be created
+		 *	to hold its changed pages.
+		 */
+		if (src_needs_copy)
+			src_entry->needs_copy = TRUE;
+
+		/*
+		 *	The destination always needs to have a shadow
+		 *	created.
+		 */
+		dst_entry->needs_copy = TRUE;
+
+		/*
+		 *	Mark the entries copy-on-write, so that write-enabling
+		 *	the entry won't make copy-on-write pages writable.
+		 */
+		src_entry->copy_on_write = TRUE;
+		dst_entry->copy_on_write = TRUE;
+		/*
+		 *	Get rid of the old object.
+		 */
+		vm_object_deallocate(temp_object);
+
+		pmap_copy(dst_map->pmap, src_map->pmap, dst_entry->start,
+			dst_entry->end - dst_entry->start, src_entry->start);
+	}
+	else {
+		/*
+		 *	Of course, wired down pages can't be set copy-on-write.
+		 *	Cause wired pages to be copied into the new
+		 *	map by simulating faults (the new pages are
+		 *	pageable)
+		 */
+		vm_fault_copy_entry(dst_map, src_map, dst_entry, src_entry);
+	}
+}
+
+/*
+ *	vm_map_copy:
+ *
+ *	Perform a virtual memory copy from the source
+ *	address map/range to the destination map/range.
+ *
+ *	If src_destroy or dst_alloc is requested,
+ *	the source and destination regions should be
+ *	disjoint, not only in the top-level map, but
+ *	in the sharing maps as well.  [The best way
+ *	to guarantee this is to use a new intermediate
+ *	map to make copies.  This also reduces map
+ *	fragmentation.]
+ */
+int
+vm_map_copy(dst_map, src_map,
+			  dst_addr, len, src_addr,
+			  dst_alloc, src_destroy)
+	vm_map_t	dst_map;
+	vm_map_t	src_map;
+	vm_offset_t	dst_addr;
+	vm_size_t	len;
+	vm_offset_t	src_addr;
+	boolean_t	dst_alloc;
+	boolean_t	src_destroy;
+{
+	register
+	vm_map_entry_t	src_entry;
+	register
+	vm_map_entry_t	dst_entry;
+	vm_map_entry_t	tmp_entry;
+	vm_offset_t	src_start;
+	vm_offset_t	src_end;
+	vm_offset_t	dst_start;
+	vm_offset_t	dst_end;
+	vm_offset_t	src_clip;
+	vm_offset_t	dst_clip;
+	int		result;
+	boolean_t	old_src_destroy;
+
+	/*
+	 *	XXX While we figure out why src_destroy screws up,
+	 *	we'll do it by explicitly vm_map_delete'ing at the end.
+	 */
+
+	old_src_destroy = src_destroy;
+	src_destroy = FALSE;
+
+	/*
+	 *	Compute start and end of region in both maps
+	 */
+
+	src_start = src_addr;
+	src_end = src_start + len;
+	dst_start = dst_addr;
+	dst_end = dst_start + len;
+
+	/*
+	 *	Check that the region can exist in both source
+	 *	and destination.
+	 */
+
+	if ((dst_end < dst_start) || (src_end < src_start))
+		return(KERN_NO_SPACE);
+
+	/*
+	 *	Lock the maps in question -- we avoid deadlock
+	 *	by ordering lock acquisition by map value
+	 */
+
+	if (src_map == dst_map) {
+		vm_map_lock(src_map);
+	}
+	else if ((long) src_map < (long) dst_map) {
+	 	vm_map_lock(src_map);
+		vm_map_lock(dst_map);
+	} else {
+		vm_map_lock(dst_map);
+	 	vm_map_lock(src_map);
+	}
+
+	result = KERN_SUCCESS;
+
+	/*
+	 *	Check protections... source must be completely readable and
+	 *	destination must be completely writable.  [Note that if we're
+	 *	allocating the destination region, we don't have to worry
+	 *	about protection, but instead about whether the region
+	 *	exists.]
+	 */
+
+	if (src_map->is_main_map && dst_map->is_main_map) {
+		if (!vm_map_check_protection(src_map, src_start, src_end,
+					VM_PROT_READ)) {
+			result = KERN_PROTECTION_FAILURE;
+			goto Return;
+		}
+
+		if (dst_alloc) {
+			/* XXX Consider making this a vm_map_find instead */
+			if ((result = vm_map_insert(dst_map, NULL,
+					(vm_offset_t) 0, dst_start, dst_end)) != KERN_SUCCESS)
+				goto Return;
+		}
+		else if (!vm_map_check_protection(dst_map, dst_start, dst_end,
+					VM_PROT_WRITE)) {
+			result = KERN_PROTECTION_FAILURE;
+			goto Return;
+		}
+	}
+
+	/*
+	 *	Find the start entries and clip.
+	 *
+	 *	Note that checking protection asserts that the
+	 *	lookup cannot fail.
+	 *
+	 *	Also note that we wait to do the second lookup
+	 *	until we have done the first clip, as the clip
+	 *	may affect which entry we get!
+	 */
+
+	(void) vm_map_lookup_entry(src_map, src_addr, &tmp_entry);
+	src_entry = tmp_entry;
+	vm_map_clip_start(src_map, src_entry, src_start);
+
+	(void) vm_map_lookup_entry(dst_map, dst_addr, &tmp_entry);
+	dst_entry = tmp_entry;
+	vm_map_clip_start(dst_map, dst_entry, dst_start);
+
+	/*
+	 *	If both source and destination entries are the same,
+	 *	retry the first lookup, as it may have changed.
+	 */
+
+	if (src_entry == dst_entry) {
+		(void) vm_map_lookup_entry(src_map, src_addr, &tmp_entry);
+		src_entry = tmp_entry;
+	}
+
+	/*
+	 *	If source and destination entries are still the same,
+	 *	a null copy is being performed.
+	 */
+
+	if (src_entry == dst_entry)
+		goto Return;
+
+	/*
+	 *	Go through entries until we get to the end of the
+	 *	region.
+	 */
+
+	while (src_start < src_end) {
+		/*
+		 *	Clip the entries to the endpoint of the entire region.
+		 */
+
+		vm_map_clip_end(src_map, src_entry, src_end);
+		vm_map_clip_end(dst_map, dst_entry, dst_end);
+
+		/*
+		 *	Clip each entry to the endpoint of the other entry.
+		 */
+
+		src_clip = src_entry->start + (dst_entry->end - dst_entry->start);
+		vm_map_clip_end(src_map, src_entry, src_clip);
+
+		dst_clip = dst_entry->start + (src_entry->end - src_entry->start);
+		vm_map_clip_end(dst_map, dst_entry, dst_clip);
+
+		/*
+		 *	Both entries now match in size and relative endpoints.
+		 *
+		 *	If both entries refer to a VM object, we can
+		 *	deal with them now.
+		 */
+
+		if (!src_entry->is_a_map && !dst_entry->is_a_map) {
+			vm_map_copy_entry(src_map, dst_map, src_entry,
+						dst_entry);
+		}
+		else {
+			register vm_map_t	new_dst_map;
+			vm_offset_t		new_dst_start;
+			vm_size_t		new_size;
+			vm_map_t		new_src_map;
+			vm_offset_t		new_src_start;
+
+			/*
+			 *	We have to follow at least one sharing map.
+			 */
+
+			new_size = (dst_entry->end - dst_entry->start);
+
+			if (src_entry->is_a_map) {
+				new_src_map = src_entry->object.share_map;
+				new_src_start = src_entry->offset;
+			}
+			else {
+			 	new_src_map = src_map;
+				new_src_start = src_entry->start;
+				vm_map_set_recursive(&src_map->lock);
+			}
+
+			if (dst_entry->is_a_map) {
+			    	vm_offset_t	new_dst_end;
+
+				new_dst_map = dst_entry->object.share_map;
+				new_dst_start = dst_entry->offset;
+
+				/*
+				 *	Since the destination sharing entries
+				 *	will be merely deallocated, we can
+				 *	do that now, and replace the region
+				 *	with a null object.  [This prevents
+				 *	splitting the source map to match
+				 *	the form of the destination map.]
+				 *	Note that we can only do so if the
+				 *	source and destination do not overlap.
+				 */
+
+				new_dst_end = new_dst_start + new_size;
+
+				if (new_dst_map != new_src_map) {
+					vm_map_lock(new_dst_map);
+					(void) vm_map_delete(new_dst_map,
+							new_dst_start,
+							new_dst_end);
+					(void) vm_map_insert(new_dst_map,
+							NULL,
+							(vm_offset_t) 0,
+							new_dst_start,
+							new_dst_end);
+					vm_map_unlock(new_dst_map);
+				}
+			}
+			else {
+			 	new_dst_map = dst_map;
+				new_dst_start = dst_entry->start;
+				vm_map_set_recursive(&dst_map->lock);
+			}
+
+			/*
+			 *	Recursively copy the sharing map.
+			 */
+
+			(void) vm_map_copy(new_dst_map, new_src_map,
+				new_dst_start, new_size, new_src_start,
+				FALSE, FALSE);
+
+			if (dst_map == new_dst_map)
+				vm_map_clear_recursive(&dst_map->lock);
+			if (src_map == new_src_map)
+				vm_map_clear_recursive(&src_map->lock);
+		}
+
+		/*
+		 *	Update variables for next pass through the loop.
+		 */
+
+		src_start = src_entry->end;
+		src_entry = src_entry->next;
+		dst_start = dst_entry->end;
+		dst_entry = dst_entry->next;
+
+		/*
+		 *	If the source is to be destroyed, here is the
+		 *	place to do it.
+		 */
+
+		if (src_destroy && src_map->is_main_map &&
+						dst_map->is_main_map)
+			vm_map_entry_delete(src_map, src_entry->prev);
+	}
+
+	/*
+	 *	Update the physical maps as appropriate
+	 */
+
+	if (src_map->is_main_map && dst_map->is_main_map) {
+		if (src_destroy)
+			pmap_remove(src_map->pmap, src_addr, src_addr + len);
+	}
+
+	/*
+	 *	Unlock the maps
+	 */
+
+	Return: ;
+
+	if (old_src_destroy)
+		vm_map_delete(src_map, src_addr, src_addr + len);
+
+	vm_map_unlock(src_map);
+	if (src_map != dst_map)
+		vm_map_unlock(dst_map);
+
+	return(result);
+}
+
+/*
+ * vmspace_fork:
+ * Create a new process vmspace structure and vm_map
+ * based on those of an existing process.  The new map
+ * is based on the old map, according to the inheritance
+ * values on the regions in that map.
+ *
+ * The source map must not be locked.
+ */
+struct vmspace *
+vmspace_fork(vm1)
+	register struct vmspace *vm1;
+{
+	register struct vmspace *vm2;
+	vm_map_t	old_map = &vm1->vm_map;
+	vm_map_t	new_map;
+	vm_map_entry_t	old_entry;
+	vm_map_entry_t	new_entry;
+	pmap_t		new_pmap;
+
+	vm_map_lock(old_map);
+
+	vm2 = vmspace_alloc(old_map->min_offset, old_map->max_offset,
+	    old_map->entries_pageable);
+	bcopy(&vm1->vm_startcopy, &vm2->vm_startcopy,
+	    (caddr_t) (vm1 + 1) - (caddr_t) &vm1->vm_startcopy);
+	new_pmap = &vm2->vm_pmap;		/* XXX */
+	new_map = &vm2->vm_map;			/* XXX */
+
+	old_entry = old_map->header.next;
+
+	while (old_entry != &old_map->header) {
+		if (old_entry->is_sub_map)
+			panic("vm_map_fork: encountered a submap");
+
+		switch (old_entry->inheritance) {
+		case VM_INHERIT_NONE:
+			break;
+
+		case VM_INHERIT_SHARE:
+			/*
+			 *	If we don't already have a sharing map:
+			 */
+
+			if (!old_entry->is_a_map) {
+			 	vm_map_t	new_share_map;
+				vm_map_entry_t	new_share_entry;
+				
+				/*
+				 *	Create a new sharing map
+				 */
+				 
+				new_share_map = vm_map_create(NULL,
+							old_entry->start,
+							old_entry->end,
+							TRUE);
+				new_share_map->is_main_map = FALSE;
+
+				/*
+				 *	Create the only sharing entry from the
+				 *	old task map entry.
+				 */
+
+				new_share_entry =
+					vm_map_entry_create(new_share_map);
+				*new_share_entry = *old_entry;
+				new_share_entry->wired_count = 0;
+
+				/*
+				 *	Insert the entry into the new sharing
+				 *	map
+				 */
+
+				vm_map_entry_link(new_share_map,
+						new_share_map->header.prev,
+						new_share_entry);
+
+				/*
+				 *	Fix up the task map entry to refer
+				 *	to the sharing map now.
+				 */
+
+				old_entry->is_a_map = TRUE;
+				old_entry->object.share_map = new_share_map;
+				old_entry->offset = old_entry->start;
+			}
+
+			/*
+			 *	Clone the entry, referencing the sharing map.
+			 */
+
+			new_entry = vm_map_entry_create(new_map);
+			*new_entry = *old_entry;
+			new_entry->wired_count = 0;
+			vm_map_reference(new_entry->object.share_map);
+
+			/*
+			 *	Insert the entry into the new map -- we
+			 *	know we're inserting at the end of the new
+			 *	map.
+			 */
+
+			vm_map_entry_link(new_map, new_map->header.prev,
+						new_entry);
+
+			/*
+			 *	Update the physical map
+			 */
+
+			pmap_copy(new_map->pmap, old_map->pmap,
+				new_entry->start,
+				(old_entry->end - old_entry->start),
+				old_entry->start);
+			break;
+
+		case VM_INHERIT_COPY:
+			/*
+			 *	Clone the entry and link into the map.
+			 */
+
+			new_entry = vm_map_entry_create(new_map);
+			*new_entry = *old_entry;
+			new_entry->wired_count = 0;
+			new_entry->object.vm_object = NULL;
+			new_entry->is_a_map = FALSE;
+			vm_map_entry_link(new_map, new_map->header.prev,
+							new_entry);
+			if (old_entry->is_a_map) {
+				int	check;
+
+				check = vm_map_copy(new_map,
+						old_entry->object.share_map,
+						new_entry->start,
+						(vm_size_t)(new_entry->end -
+							new_entry->start),
+						old_entry->offset,
+						FALSE, FALSE);
+				if (check != KERN_SUCCESS)
+					printf("vm_map_fork: copy in share_map region failed\n");
+			}
+			else {
+				vm_map_copy_entry(old_map, new_map, old_entry,
+						new_entry);
+			}
+			break;
+		}
+		old_entry = old_entry->next;
+	}
+
+	new_map->size = old_map->size;
+	vm_map_unlock(old_map);
+
+	return(vm2);
+}
+
+/*
+ *	vm_map_lookup:
+ *
+ *	Finds the VM object, offset, and
+ *	protection for a given virtual address in the
+ *	specified map, assuming a page fault of the
+ *	type specified.
+ *
+ *	Leaves the map in question locked for read; return
+ *	values are guaranteed until a vm_map_lookup_done
+ *	call is performed.  Note that the map argument
+ *	is in/out; the returned map must be used in
+ *	the call to vm_map_lookup_done.
+ *
+ *	A handle (out_entry) is returned for use in
+ *	vm_map_lookup_done, to make that fast.
+ *
+ *	If a lookup is requested with "write protection"
+ *	specified, the map may be changed to perform virtual
+ *	copying operations, although the data referenced will
+ *	remain the same.
+ */
+int
+vm_map_lookup(var_map, vaddr, fault_type, out_entry,
+				object, offset, out_prot, wired, single_use)
+	vm_map_t		*var_map;	/* IN/OUT */
+	register vm_offset_t	vaddr;
+	register vm_prot_t	fault_type;
+
+	vm_map_entry_t		*out_entry;	/* OUT */
+	vm_object_t		*object;	/* OUT */
+	vm_offset_t		*offset;	/* OUT */
+	vm_prot_t		*out_prot;	/* OUT */
+	boolean_t		*wired;		/* OUT */
+	boolean_t		*single_use;	/* OUT */
+{
+	vm_map_t			share_map;
+	vm_offset_t			share_offset;
+	register vm_map_entry_t		entry;
+	register vm_map_t		map = *var_map;
+	register vm_prot_t		prot;
+	register boolean_t		su;
+
+	RetryLookup: ;
+
+	/*
+	 *	Lookup the faulting address.
+	 */
+
+	vm_map_lock_read(map);
+
+#define	RETURN(why) \
+		{ \
+		vm_map_unlock_read(map); \
+		return(why); \
+		}
+
+	/*
+	 *	If the map has an interesting hint, try it before calling
+	 *	full blown lookup routine.
+	 */
+
+	simple_lock(&map->hint_lock);
+	entry = map->hint;
+	simple_unlock(&map->hint_lock);
+
+	*out_entry = entry;
+
+	if ((entry == &map->header) ||
+	    (vaddr < entry->start) || (vaddr >= entry->end)) {
+		vm_map_entry_t	tmp_entry;
+
+		/*
+		 *	Entry was either not a valid hint, or the vaddr
+		 *	was not contained in the entry, so do a full lookup.
+		 */
+		if (!vm_map_lookup_entry(map, vaddr, &tmp_entry))
+			RETURN(KERN_INVALID_ADDRESS);
+
+		entry = tmp_entry;
+		*out_entry = entry;
+	}
+
+	/*
+	 *	Handle submaps.
+	 */
+
+	if (entry->is_sub_map) {
+		vm_map_t	old_map = map;
+
+		*var_map = map = entry->object.sub_map;
+		vm_map_unlock_read(old_map);
+		goto RetryLookup;
+	}
+		
+	/*
+	 *	Check whether this task is allowed to have
+	 *	this page.
+	 */
+
+	prot = entry->protection;
+	if ((fault_type & (prot)) != fault_type)
+		RETURN(KERN_PROTECTION_FAILURE);
+
+	/*
+	 *	If this page is not pageable, we have to get
+	 *	it for all possible accesses.
+	 */
+
+	if (*wired = (entry->wired_count != 0))
+		prot = fault_type = entry->protection;
+
+	/*
+	 *	If we don't already have a VM object, track
+	 *	it down.
+	 */
+
+	if (su = !entry->is_a_map) {
+	 	share_map = map;
+		share_offset = vaddr;
+	}
+	else {
+		vm_map_entry_t	share_entry;
+
+		/*
+		 *	Compute the sharing map, and offset into it.
+		 */
+
+		share_map = entry->object.share_map;
+		share_offset = (vaddr - entry->start) + entry->offset;
+
+		/*
+		 *	Look for the backing store object and offset
+		 */
+
+		vm_map_lock_read(share_map);
+
+		if (!vm_map_lookup_entry(share_map, share_offset,
+					&share_entry)) {
+			vm_map_unlock_read(share_map);
+			RETURN(KERN_INVALID_ADDRESS);
+		}
+		entry = share_entry;
+	}
+
+	/*
+	 *	If the entry was copy-on-write, we either ...
+	 */
+
+	if (entry->needs_copy) {
+	    	/*
+		 *	If we want to write the page, we may as well
+		 *	handle that now since we've got the sharing
+		 *	map locked.
+		 *
+		 *	If we don't need to write the page, we just
+		 *	demote the permissions allowed.
+		 */
+
+		if (fault_type & VM_PROT_WRITE) {
+			/*
+			 *	Make a new object, and place it in the
+			 *	object chain.  Note that no new references
+			 *	have appeared -- one just moved from the
+			 *	share map to the new object.
+			 */
+
+			if (lockmgr(&share_map->lock, LK_EXCLUPGRADE,
+				    (void *)0, curproc)) {
+				if (share_map != map)
+					vm_map_unlock_read(map);
+				goto RetryLookup;
+			}
+
+			vm_object_shadow(
+				&entry->object.vm_object,
+				&entry->offset,
+				(vm_size_t) (entry->end - entry->start));
+				
+			entry->needs_copy = FALSE;
+			
+			lockmgr(&share_map->lock, LK_DOWNGRADE,
+				(void *)0, curproc);
+		}
+		else {
+			/*
+			 *	We're attempting to read a copy-on-write
+			 *	page -- don't allow writes.
+			 */
+
+			prot &= (~VM_PROT_WRITE);
+		}
+	}
+
+	/*
+	 *	Create an object if necessary.
+	 */
+	if (entry->object.vm_object == NULL) {
+
+		if (lockmgr(&share_map->lock, LK_EXCLUPGRADE,
+				(void *)0, curproc)) {
+			if (share_map != map)
+				vm_map_unlock_read(map);
+			goto RetryLookup;
+		}
+
+		entry->object.vm_object = vm_object_allocate(
+					(vm_size_t)(entry->end - entry->start));
+		entry->offset = 0;
+		lockmgr(&share_map->lock, LK_DOWNGRADE, (void *)0, curproc);
+	}
+
+	/*
+	 *	Return the object/offset from this entry.  If the entry
+	 *	was copy-on-write or empty, it has been fixed up.
+	 */
+
+	*offset = (share_offset - entry->start) + entry->offset;
+	*object = entry->object.vm_object;
+
+	/*
+	 *	Return whether this is the only map sharing this data.
+	 */
+
+	if (!su) {
+		simple_lock(&share_map->ref_lock);
+		su = (share_map->ref_count == 1);
+		simple_unlock(&share_map->ref_lock);
+	}
+
+	*out_prot = prot;
+	*single_use = su;
+
+	return(KERN_SUCCESS);
+	
+#undef	RETURN
+}
+
+/*
+ *	vm_map_lookup_done:
+ *
+ *	Releases locks acquired by a vm_map_lookup
+ *	(according to the handle returned by that lookup).
+ */
+
+void
+vm_map_lookup_done(map, entry)
+	register vm_map_t	map;
+	vm_map_entry_t		entry;
+{
+	/*
+	 *	If this entry references a map, unlock it first.
+	 */
+
+	if (entry->is_a_map)
+		vm_map_unlock_read(entry->object.share_map);
+
+	/*
+	 *	Unlock the main-level map
+	 */
+
+	vm_map_unlock_read(map);
+}
+
+/*
+ *	Routine:	vm_map_simplify
+ *	Purpose:
+ *		Attempt to simplify the map representation in
+ *		the vicinity of the given starting address.
+ *	Note:
+ *		This routine is intended primarily to keep the
+ *		kernel maps more compact -- they generally don't
+ *		benefit from the "expand a map entry" technology
+ *		at allocation time because the adjacent entry
+ *		is often wired down.
+ */
+void
+vm_map_simplify(map, start)
+	vm_map_t	map;
+	vm_offset_t	start;
+{
+	vm_map_entry_t	this_entry;
+	vm_map_entry_t	prev_entry;
+
+	vm_map_lock(map);
+	if (
+		(vm_map_lookup_entry(map, start, &this_entry)) &&
+		((prev_entry = this_entry->prev) != &map->header) &&
+
+		(prev_entry->end == start) &&
+		(map->is_main_map) &&
+
+		(prev_entry->is_a_map == FALSE) &&
+		(prev_entry->is_sub_map == FALSE) &&
+
+		(this_entry->is_a_map == FALSE) &&
+		(this_entry->is_sub_map == FALSE) &&
+
+		(prev_entry->inheritance == this_entry->inheritance) &&
+		(prev_entry->protection == this_entry->protection) &&
+		(prev_entry->max_protection == this_entry->max_protection) &&
+		(prev_entry->wired_count == this_entry->wired_count) &&
+		
+		(prev_entry->copy_on_write == this_entry->copy_on_write) &&
+		(prev_entry->needs_copy == this_entry->needs_copy) &&
+		
+		(prev_entry->object.vm_object == this_entry->object.vm_object) &&
+		((prev_entry->offset + (prev_entry->end - prev_entry->start))
+		     == this_entry->offset)
+	) {
+		if (map->first_free == this_entry)
+			map->first_free = prev_entry;
+
+		SAVE_HINT(map, prev_entry);
+		vm_map_entry_unlink(map, this_entry);
+		prev_entry->end = this_entry->end;
+	 	vm_object_deallocate(this_entry->object.vm_object);
+		vm_map_entry_dispose(map, this_entry);
+	}
+	vm_map_unlock(map);
+}
+
+/*
+ *	vm_map_print:	[ debug ]
+ */
+void
+vm_map_print(map, full)
+	register vm_map_t	map;
+	boolean_t		full;
+{
+	register vm_map_entry_t	entry;
+	extern int indent;
+
+	iprintf("%s map 0x%x: pmap=0x%x,ref=%d,nentries=%d,version=%d\n",
+		(map->is_main_map ? "Task" : "Share"),
+ 		(int) map, (int) (map->pmap), map->ref_count, map->nentries,
+		map->timestamp);
+
+	if (!full && indent)
+		return;
+
+	indent += 2;
+	for (entry = map->header.next; entry != &map->header;
+				entry = entry->next) {
+		iprintf("map entry 0x%x: start=0x%x, end=0x%x, ",
+			(int) entry, (int) entry->start, (int) entry->end);
+		if (map->is_main_map) {
+		     	static char *inheritance_name[4] =
+				{ "share", "copy", "none", "donate_copy"};
+			printf("prot=%x/%x/%s, ",
+				entry->protection,
+				entry->max_protection,
+				inheritance_name[entry->inheritance]);
+			if (entry->wired_count != 0)
+				printf("wired, ");
+		}
+
+		if (entry->is_a_map || entry->is_sub_map) {
+		 	printf("share=0x%x, offset=0x%x\n",
+				(int) entry->object.share_map,
+				(int) entry->offset);
+			if ((entry->prev == &map->header) ||
+			    (!entry->prev->is_a_map) ||
+			    (entry->prev->object.share_map !=
+			     entry->object.share_map)) {
+				indent += 2;
+				vm_map_print(entry->object.share_map, full);
+				indent -= 2;
+			}
+				
+		}
+		else {
+			printf("object=0x%x, offset=0x%x",
+				(int) entry->object.vm_object,
+				(int) entry->offset);
+			if (entry->copy_on_write)
+				printf(", copy (%s)",
+				       entry->needs_copy ? "needed" : "done");
+			printf("\n");
+
+			if ((entry->prev == &map->header) ||
+			    (entry->prev->is_a_map) ||
+			    (entry->prev->object.vm_object !=
+			     entry->object.vm_object)) {
+				indent += 2;
+				vm_object_print(entry->object.vm_object, full);
+				indent -= 2;
+			}
+		}
+	}
+	indent -= 2;
+}

--- a/src-uland/libvm/vm_meter.c
+++ b/src-uland/libvm/vm_meter.c
@@ -1,0 +1,236 @@
+/* Copied from sys/vm/vm_meter.c */
+/*
+ * Copyright (c) 1982, 1986, 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_meter.c	8.7 (Berkeley) 5/10/95
+ */
+
+#include <sys/param.h>
+#include <sys/proc.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <vm/vm.h>
+#include <sys/sysctl.h>
+
+struct	loadavg averunnable;		/* load average, of runnable procs */
+
+int	maxslp = MAXSLP;
+int	saferss = SAFERSS;
+
+void
+vmmeter()
+{
+
+	if (time.tv_sec % 5 == 0)
+		loadav(&averunnable);
+	if (proc0.p_slptime > maxslp/2)
+		wakeup((caddr_t)&proc0);
+}
+
+/*
+ * Constants for averages over 1, 5, and 15 minutes
+ * when sampling at 5 second intervals.
+ */
+fixpt_t	cexp[3] = {
+	0.9200444146293232 * FSCALE,	/* exp(-1/12) */
+	0.9834714538216174 * FSCALE,	/* exp(-1/60) */
+	0.9944598480048967 * FSCALE,	/* exp(-1/180) */
+};
+
+/*
+ * Compute a tenex style load average of a quantity on
+ * 1, 5 and 15 minute intervals.
+ */
+void
+loadav(avg)
+	register struct loadavg *avg;
+{
+	register int i, nrun;
+	register struct proc *p;
+
+	for (nrun = 0, p = allproc.lh_first; p != 0; p = p->p_list.le_next) {
+		switch (p->p_stat) {
+		case SSLEEP:
+			if (p->p_priority > PZERO || p->p_slptime != 0)
+				continue;
+			/* fall through */
+		case SRUN:
+		case SIDL:
+			nrun++;
+		}
+	}
+	for (i = 0; i < 3; i++)
+		avg->ldavg[i] = (cexp[i] * avg->ldavg[i] +
+			nrun * FSCALE * (FSCALE - cexp[i])) >> FSHIFT;
+}
+
+/*
+ * Attributes associated with virtual memory.
+ */
+vm_sysctl(name, namelen, oldp, oldlenp, newp, newlen, p)
+	int *name;
+	u_int namelen;
+	void *oldp;
+	size_t *oldlenp;
+	void *newp;
+	size_t newlen;
+	struct proc *p;
+{
+	struct vmtotal vmtotals;
+
+	/* all sysctl names at this level are terminal */
+	if (namelen != 1)
+		return (ENOTDIR);		/* overloaded */
+
+	switch (name[0]) {
+	case VM_LOADAVG:
+		averunnable.fscale = FSCALE;
+		return (sysctl_rdstruct(oldp, oldlenp, newp, &averunnable,
+		    sizeof(averunnable)));
+	case VM_METER:
+		vmtotal(&vmtotals);
+		return (sysctl_rdstruct(oldp, oldlenp, newp, &vmtotals,
+		    sizeof(vmtotals)));
+	default:
+		return (EOPNOTSUPP);
+	}
+	/* NOTREACHED */
+}
+
+/*
+ * Calculate the current state of the system.
+ * Done on demand from getkerninfo().
+ */
+void
+vmtotal(totalp)
+	register struct vmtotal *totalp;
+{
+	register struct proc *p;
+	register vm_map_entry_t	entry;
+	register vm_object_t object;
+	register vm_map_t map;
+	int paging;
+
+	bzero(totalp, sizeof *totalp);
+	/*
+	 * Mark all objects as inactive.
+	 */
+	simple_lock(&vm_object_list_lock);
+	for (object = vm_object_list.tqh_first;
+	     object != NULL;
+	     object = object->object_list.tqe_next)
+		object->flags &= ~OBJ_ACTIVE;
+	simple_unlock(&vm_object_list_lock);
+	/*
+	 * Calculate process statistics.
+	 */
+	for (p = allproc.lh_first; p != 0; p = p->p_list.le_next) {
+		if (p->p_flag & P_SYSTEM)
+			continue;
+		switch (p->p_stat) {
+		case 0:
+			continue;
+
+		case SSLEEP:
+		case SSTOP:
+			if (p->p_flag & P_INMEM) {
+				if (p->p_priority <= PZERO)
+					totalp->t_dw++;
+				else if (p->p_slptime < maxslp)
+					totalp->t_sl++;
+			} else if (p->p_slptime < maxslp)
+				totalp->t_sw++;
+			if (p->p_slptime >= maxslp)
+				continue;
+			break;
+
+		case SRUN:
+		case SIDL:
+			if (p->p_flag & P_INMEM)
+				totalp->t_rq++;
+			else
+				totalp->t_sw++;
+			if (p->p_stat == SIDL)
+				continue;
+			break;
+		}
+		/*
+		 * Note active objects.
+		 *
+		 * XXX don't count shadow objects with no resident pages.
+		 * This eliminates the forced shadows caused by MAP_PRIVATE.
+		 * Right now we require that such an object completely shadow
+		 * the original, to catch just those cases.
+		 */
+		paging = 0;
+		for (map = &p->p_vmspace->vm_map, entry = map->header.next;
+		     entry != &map->header; entry = entry->next) {
+			if (entry->is_a_map || entry->is_sub_map ||
+			    (object = entry->object.vm_object) == NULL)
+				continue;
+			while (object->shadow &&
+			       object->resident_page_count == 0 &&
+			       object->shadow_offset == 0 &&
+			       object->size == object->shadow->size)
+				object = object->shadow;
+			object->flags |= OBJ_ACTIVE;
+			paging |= object->paging_in_progress;
+		}
+		if (paging)
+			totalp->t_pw++;
+	}
+	/*
+	 * Calculate object memory usage statistics.
+	 */
+	simple_lock(&vm_object_list_lock);
+	for (object = vm_object_list.tqh_first;
+	     object != NULL;
+	     object = object->object_list.tqe_next) {
+		totalp->t_vm += num_pages(object->size);
+		totalp->t_rm += object->resident_page_count;
+		if (object->flags & OBJ_ACTIVE) {
+			totalp->t_avm += num_pages(object->size);
+			totalp->t_arm += object->resident_page_count;
+		}
+		if (object->ref_count > 1) {
+			/* shared object */
+			totalp->t_vmshr += num_pages(object->size);
+			totalp->t_rmshr += object->resident_page_count;
+			if (object->flags & OBJ_ACTIVE) {
+				totalp->t_avmshr += num_pages(object->size);
+				totalp->t_armshr += object->resident_page_count;
+			}
+		}
+	}
+	simple_unlock(&vm_object_list_lock);
+	totalp->t_free = cnt.v_free_count;
+}

--- a/src-uland/libvm/vm_mmap.c
+++ b/src-uland/libvm/vm_mmap.c
@@ -1,0 +1,845 @@
+/* Copied from sys/vm/vm_mmap.c */
+/*
+ * Copyright (c) 1988 University of Utah.
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * the Systems Programming Group of the University of Utah Computer
+ * Science Department.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * from: Utah $Hdr: vm_mmap.c 1.6 91/10/21$
+ *
+ *	@(#)vm_mmap.c	8.10 (Berkeley) 2/19/95
+ */
+
+/*
+ * Mapped file (mmap) interface to VM
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/filedesc.h>
+#include <sys/resourcevar.h>
+#include <sys/proc.h>
+#include <sys/vnode.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/conf.h>
+
+#include <sys/mount.h>
+#include <sys/syscallargs.h>
+
+#include <miscfs/specfs/specdev.h>
+
+#include <vm/vm.h>
+#include <vm/vm_pager.h>
+#include <vm/vm_prot.h>
+
+#ifdef DEBUG
+int mmapdebug = 0;
+#define MDB_FOLLOW	0x01
+#define MDB_SYNC	0x02
+#define MDB_MAPIT	0x04
+#endif
+
+/* ARGSUSED */
+int
+sbrk(p, uap, retval)
+	struct proc *p;
+	struct sbrk_args /* {
+		syscallarg(int) incr;
+	} */ *uap;
+	register_t *retval;
+{
+
+	/* Not yet implemented */
+	return (EOPNOTSUPP);
+}
+
+/* ARGSUSED */
+int
+sstk(p, uap, retval)
+	struct proc *p;
+	struct sstk_args /* {
+		syscallarg(int) incr;
+	} */ *uap;
+	register_t *retval;
+{
+
+	/* Not yet implemented */
+	return (EOPNOTSUPP);
+}
+
+#if defined(COMPAT_43) || defined(COMPAT_SUNOS)
+/* ARGSUSED */
+int
+compat_43_getpagesize(p, uap, retval)
+	struct proc *p;
+	void *uap;
+	register_t *retval;
+{
+
+	*retval = PAGE_SIZE;
+	return (0);
+}
+#endif /* COMPAT_43 || COMPAT_SUNOS */
+
+#ifdef COMPAT_43
+int
+compat_43_mmap(p, uap, retval)
+	struct proc *p;
+	register struct compat_43_mmap_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(int) len;
+		syscallarg(int) prot;
+		syscallarg(int) flags;
+		syscallarg(int) fd;
+		syscallarg(long) pos;
+	} */ *uap;
+	register_t *retval;
+{
+	struct mmap_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(size_t) len;
+		syscallarg(int) prot;
+		syscallarg(int) flags;
+		syscallarg(int) fd;
+		syscallarg(long) pad;
+		syscallarg(off_t) pos;
+	} */ nargs;
+	static const char cvtbsdprot[8] = {
+		0,
+		PROT_EXEC,
+		PROT_WRITE,
+		PROT_EXEC|PROT_WRITE,
+		PROT_READ,
+		PROT_EXEC|PROT_READ,
+		PROT_WRITE|PROT_READ,
+		PROT_EXEC|PROT_WRITE|PROT_READ,
+	};
+#define	OMAP_ANON	0x0002
+#define	OMAP_COPY	0x0020
+#define	OMAP_SHARED	0x0010
+#define	OMAP_FIXED	0x0100
+#define	OMAP_INHERIT	0x0800
+
+	SCARG(&nargs, addr) = SCARG(uap, addr);
+	SCARG(&nargs, len) = SCARG(uap, len);
+	SCARG(&nargs, prot) = cvtbsdprot[SCARG(uap, prot)&0x7];
+	SCARG(&nargs, flags) = 0;
+	if (SCARG(uap, flags) & OMAP_ANON)
+		SCARG(&nargs, flags) |= MAP_ANON;
+	if (SCARG(uap, flags) & OMAP_COPY)
+		SCARG(&nargs, flags) |= MAP_COPY;
+	if (SCARG(uap, flags) & OMAP_SHARED)
+		SCARG(&nargs, flags) |= MAP_SHARED;
+	else
+		SCARG(&nargs, flags) |= MAP_PRIVATE;
+	if (SCARG(uap, flags) & OMAP_FIXED)
+		SCARG(&nargs, flags) |= MAP_FIXED;
+	if (SCARG(uap, flags) & OMAP_INHERIT)
+		SCARG(&nargs, flags) |= MAP_INHERIT;
+	SCARG(&nargs, fd) = SCARG(uap, fd);
+	SCARG(&nargs, pos) = SCARG(uap, pos);
+	return (mmap(p, &nargs, retval));
+}
+#endif
+
+int
+mmap(p, uap, retval)
+	struct proc *p;
+	register struct mmap_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(size_t) len;
+		syscallarg(int) prot;
+		syscallarg(int) flags;
+		syscallarg(int) fd;
+		syscallarg(long) pad;
+		syscallarg(off_t) pos;
+	} */ *uap;
+	register_t *retval;
+{
+	register struct filedesc *fdp = p->p_fd;
+	register struct file *fp;
+	struct vnode *vp;
+	vm_offset_t addr, pos;
+	vm_size_t size;
+	vm_prot_t prot, maxprot;
+	caddr_t handle;
+	int flags, error;
+
+	prot = SCARG(uap, prot) & VM_PROT_ALL;
+	flags = SCARG(uap, flags);
+	pos = SCARG(uap, pos);
+#ifdef DEBUG
+	if (mmapdebug & MDB_FOLLOW)
+		printf("mmap(%d): addr %x len %x pro %x flg %x fd %d pos %x\n",
+		       p->p_pid, SCARG(uap, addr), SCARG(uap, len), prot,
+		       flags, SCARG(uap, fd), pos);
+#endif
+	/*
+	 * Address (if FIXED) must be page aligned.
+	 * Size is implicitly rounded to a page boundary.
+	 *
+	 * XXX most (all?) vendors require that the file offset be
+	 * page aligned as well.  However, we already have applications
+	 * (e.g. nlist) that rely on unrestricted alignment.  Since we
+	 * support it, let it happen.
+	 */
+	addr = (vm_offset_t) SCARG(uap, addr);
+	if (((flags & MAP_FIXED) && (addr & PAGE_MASK)) ||
+#if 0
+	    ((flags & MAP_ANON) == 0 && (pos & PAGE_MASK)) ||
+#endif
+	    (ssize_t)SCARG(uap, len) < 0 || ((flags & MAP_ANON) && SCARG(uap, fd) != -1))
+		return (EINVAL);
+	size = (vm_size_t) round_page(SCARG(uap, len));
+	/*
+	 * Check for illegal addresses.  Watch out for address wrap...
+	 * Note that VM_*_ADDRESS are not constants due to casts (argh).
+	 */
+	if (flags & MAP_FIXED) {
+		if (VM_MAXUSER_ADDRESS > 0 && addr + size >= VM_MAXUSER_ADDRESS)
+			return (EINVAL);
+		if (VM_MIN_ADDRESS > 0 && addr < VM_MIN_ADDRESS)
+			return (EINVAL);
+		if (addr > addr + size)
+			return (EINVAL);
+	}
+	/*
+	 * XXX for non-fixed mappings where no hint is provided or
+	 * the hint would fall in the potential heap space,
+	 * place it after the end of the largest possible heap.
+	 *
+	 * There should really be a pmap call to determine a reasonable
+	 * location.
+	 */
+	else if (addr < round_page(p->p_vmspace->vm_daddr + MAXDSIZ))
+		addr = round_page(p->p_vmspace->vm_daddr + MAXDSIZ);
+	if (flags & MAP_ANON) {
+		/*
+		 * Mapping blank space is trivial.
+		 */
+		handle = NULL;
+		maxprot = VM_PROT_ALL;
+		pos = 0;
+	} else {
+		/*
+		 * Mapping file, get fp for validation.
+		 * Obtain vnode and make sure it is of appropriate type.
+		 */
+		if (((unsigned)SCARG(uap, fd)) >= fdp->fd_nfiles ||
+		    (fp = fdp->fd_ofiles[SCARG(uap, fd)]) == NULL)
+			return (EBADF);
+		if (fp->f_type != DTYPE_VNODE)
+			return (EINVAL);
+		vp = (struct vnode *)fp->f_data;
+		if (vp->v_type != VREG && vp->v_type != VCHR)
+			return (EINVAL);
+		/*
+		 * XXX hack to handle use of /dev/zero to map anon
+		 * memory (ala SunOS).
+		 */
+		if (vp->v_type == VCHR && iszerodev(vp->v_rdev)) {
+			handle = NULL;
+			maxprot = VM_PROT_ALL;
+			flags |= MAP_ANON;
+		} else {
+			/*
+			 * Ensure that file and memory protections are
+			 * compatible.  Note that we only worry about
+			 * writability if mapping is shared; in this case,
+			 * current and max prot are dictated by the open file.
+			 * XXX use the vnode instead?  Problem is: what
+			 * credentials do we use for determination?
+			 * What if proc does a setuid?
+			 */
+			maxprot = VM_PROT_EXECUTE;	/* ??? */
+			if (fp->f_flag & FREAD)
+				maxprot |= VM_PROT_READ;
+			else if (prot & PROT_READ)
+				return (EACCES);
+			if (flags & MAP_SHARED) {
+				if (fp->f_flag & FWRITE)
+					maxprot |= VM_PROT_WRITE;
+				else if (prot & PROT_WRITE)
+					return (EACCES);
+			} else
+				maxprot |= VM_PROT_WRITE;
+			handle = (caddr_t)vp;
+		}
+	}
+	error = vm_mmap(&p->p_vmspace->vm_map, &addr, size, prot, maxprot,
+	    flags, handle, pos);
+	if (error == 0)
+		*retval = (register_t)addr;
+	return (error);
+}
+
+int
+msync(p, uap, retval)
+	struct proc *p;
+	struct msync_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(int) len;
+	} */ *uap;
+	register_t *retval;
+{
+	vm_offset_t addr;
+	vm_size_t size;
+	vm_map_t map;
+	int rv;
+	boolean_t syncio, invalidate;
+
+#ifdef DEBUG
+	if (mmapdebug & (MDB_FOLLOW|MDB_SYNC))
+		printf("msync(%d): addr %x len %x\n",
+		       p->p_pid, SCARG(uap, addr), SCARG(uap, len));
+#endif
+	if (((vm_offset_t)SCARG(uap, addr) & PAGE_MASK) ||
+	    SCARG(uap, addr) + SCARG(uap, len) < SCARG(uap, addr))
+		return (EINVAL);
+	map = &p->p_vmspace->vm_map;
+	addr = (vm_offset_t)SCARG(uap, addr);
+	size = (vm_size_t)SCARG(uap, len);
+	/*
+	 * XXX Gak!  If size is zero we are supposed to sync "all modified
+	 * pages with the region containing addr".  Unfortunately, we
+	 * don't really keep track of individual mmaps so we approximate
+	 * by flushing the range of the map entry containing addr.
+	 * This can be incorrect if the region splits or is coalesced
+	 * with a neighbor.
+	 */
+	if (size == 0) {
+		vm_map_entry_t entry;
+
+		vm_map_lock_read(map);
+		rv = vm_map_lookup_entry(map, addr, &entry);
+		vm_map_unlock_read(map);
+		if (!rv)
+			return (EINVAL);
+		addr = entry->start;
+		size = entry->end - entry->start;
+	}
+#ifdef DEBUG
+	if (mmapdebug & MDB_SYNC)
+		printf("msync: cleaning/flushing address range [%x-%x)\n",
+		       addr, addr+size);
+#endif
+	/*
+	 * Could pass this in as a third flag argument to implement
+	 * Sun's MS_ASYNC.
+	 */
+	syncio = TRUE;
+	/*
+	 * XXX bummer, gotta flush all cached pages to ensure
+	 * consistency with the file system cache.  Otherwise, we could
+	 * pass this in to implement Sun's MS_INVALIDATE.
+	 */
+	invalidate = TRUE;
+	/*
+	 * Clean the pages and interpret the return value.
+	 */
+	rv = vm_map_clean(map, addr, addr+size, syncio, invalidate);
+	switch (rv) {
+	case KERN_SUCCESS:
+		break;
+	case KERN_INVALID_ADDRESS:
+		return (EINVAL);	/* Sun returns ENOMEM? */
+	case KERN_FAILURE:
+		return (EIO);
+	default:
+		return (EINVAL);
+	}
+	return (0);
+}
+
+int
+munmap(p, uap, retval)
+	register struct proc *p;
+	register struct munmap_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(int) len;
+	} */ *uap;
+	register_t *retval;
+{
+	vm_offset_t addr;
+	vm_size_t size;
+	vm_map_t map;
+
+#ifdef DEBUG
+	if (mmapdebug & MDB_FOLLOW)
+		printf("munmap(%d): addr %x len %x\n",
+		       p->p_pid, SCARG(uap, addr), SCARG(uap, len));
+#endif
+
+	addr = (vm_offset_t) SCARG(uap, addr);
+	if ((addr & PAGE_MASK) || SCARG(uap, len) < 0)
+		return(EINVAL);
+	size = (vm_size_t) round_page(SCARG(uap, len));
+	if (size == 0)
+		return(0);
+	/*
+	 * Check for illegal addresses.  Watch out for address wrap...
+	 * Note that VM_*_ADDRESS are not constants due to casts (argh).
+	 */
+	if (VM_MAXUSER_ADDRESS > 0 && addr + size >= VM_MAXUSER_ADDRESS)
+		return (EINVAL);
+	if (VM_MIN_ADDRESS > 0 && addr < VM_MIN_ADDRESS)
+		return (EINVAL);
+	if (addr > addr + size)
+		return (EINVAL);
+	map = &p->p_vmspace->vm_map;
+	/*
+	 * Make sure entire range is allocated.
+	 * XXX this seemed overly restrictive, so we relaxed it.
+	 */
+#if 0
+	if (!vm_map_check_protection(map, addr, addr + size, VM_PROT_NONE))
+		return(EINVAL);
+#endif
+	/* returns nothing but KERN_SUCCESS anyway */
+	(void) vm_map_remove(map, addr, addr+size);
+	return(0);
+}
+
+void
+munmapfd(p, fd)
+	struct proc *p;
+	int fd;
+{
+#ifdef DEBUG
+	if (mmapdebug & MDB_FOLLOW)
+		printf("munmapfd(%d): fd %d\n", p->p_pid, fd);
+#endif
+
+	/*
+	 * XXX should vm_deallocate any regions mapped to this file
+	 */
+	p->p_fd->fd_ofileflags[fd] &= ~UF_MAPPED;
+}
+
+int
+mprotect(p, uap, retval)
+	struct proc *p;
+	struct mprotect_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(int) len;
+		syscallarg(int) prot;
+	} */ *uap;
+	register_t *retval;
+{
+	vm_offset_t addr;
+	vm_size_t size;
+	register vm_prot_t prot;
+
+#ifdef DEBUG
+	if (mmapdebug & MDB_FOLLOW)
+		printf("mprotect(%d): addr %x len %x prot %d\n",
+		       p->p_pid, SCARG(uap, addr), SCARG(uap, len), SCARG(uap, prot));
+#endif
+
+	addr = (vm_offset_t)SCARG(uap, addr);
+	if ((addr & PAGE_MASK) || SCARG(uap, len) < 0)
+		return(EINVAL);
+	size = (vm_size_t)SCARG(uap, len);
+	prot = SCARG(uap, prot) & VM_PROT_ALL;
+
+	switch (vm_map_protect(&p->p_vmspace->vm_map, addr, addr+size, prot,
+	    FALSE)) {
+	case KERN_SUCCESS:
+		return (0);
+	case KERN_PROTECTION_FAILURE:
+		return (EACCES);
+	}
+	return (EINVAL);
+}
+
+/* ARGSUSED */
+int
+madvise(p, uap, retval)
+	struct proc *p;
+	struct madvise_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(int) len;
+		syscallarg(int) behav;
+	} */ *uap;
+	register_t *retval;
+{
+
+	/* Not yet implemented */
+	return (EOPNOTSUPP);
+}
+
+/* ARGSUSED */
+int
+mincore(p, uap, retval)
+	struct proc *p;
+	struct mincore_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(int) len;
+		syscallarg(char *) vec;
+	} */ *uap;
+	register_t *retval;
+{
+
+	/* Not yet implemented */
+	return (EOPNOTSUPP);
+}
+
+int
+mlock(p, uap, retval)
+	struct proc *p;
+	struct mlock_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(size_t) len;
+	} */ *uap;
+	register_t *retval;
+{
+	vm_offset_t addr;
+	vm_size_t size;
+	int error;
+	extern int vm_page_max_wired;
+
+#ifdef DEBUG
+	if (mmapdebug & MDB_FOLLOW)
+		printf("mlock(%d): addr %x len %x\n",
+		       p->p_pid, SCARG(uap, addr), SCARG(uap, len));
+#endif
+	addr = (vm_offset_t)SCARG(uap, addr);
+	if ((addr & PAGE_MASK) || SCARG(uap, addr) + SCARG(uap, len) < SCARG(uap, addr))
+		return (EINVAL);
+	size = round_page((vm_size_t)SCARG(uap, len));
+	if (atop(size) + cnt.v_wire_count > vm_page_max_wired)
+		return (EAGAIN);
+#ifdef pmap_wired_count
+	if (size + ptoa(pmap_wired_count(vm_map_pmap(&p->p_vmspace->vm_map))) >
+	    p->p_rlimit[RLIMIT_MEMLOCK].rlim_cur)
+		return (EAGAIN);
+#else
+	if (error = suser(p->p_ucred, &p->p_acflag))
+		return (error);
+#endif
+
+	error = vm_map_pageable(&p->p_vmspace->vm_map, addr, addr+size, FALSE);
+	return (error == KERN_SUCCESS ? 0 : ENOMEM);
+}
+
+int
+munlock(p, uap, retval)
+	struct proc *p;
+	struct munlock_args /* {
+		syscallarg(caddr_t) addr;
+		syscallarg(size_t) len;
+	} */ *uap;
+	register_t *retval;
+{
+	vm_offset_t addr;
+	vm_size_t size;
+	int error;
+
+#ifdef DEBUG
+	if (mmapdebug & MDB_FOLLOW)
+		printf("munlock(%d): addr %x len %x\n",
+		       p->p_pid, SCARG(uap, addr), SCARG(uap, len));
+#endif
+	addr = (vm_offset_t)SCARG(uap, addr);
+	if ((addr & PAGE_MASK) || SCARG(uap, addr) + SCARG(uap, len) < SCARG(uap, addr))
+		return (EINVAL);
+#ifndef pmap_wired_count
+	if (error = suser(p->p_ucred, &p->p_acflag))
+		return (error);
+#endif
+	size = round_page((vm_size_t)SCARG(uap, len));
+
+	error = vm_map_pageable(&p->p_vmspace->vm_map, addr, addr+size, TRUE);
+	return (error == KERN_SUCCESS ? 0 : ENOMEM);
+}
+
+/*
+ * Internal version of mmap.
+ * Currently used by mmap, exec, and sys5 shared memory.
+ * Handle is either a vnode pointer or NULL for MAP_ANON.
+ */
+int
+vm_mmap(map, addr, size, prot, maxprot, flags, handle, foff)
+	register vm_map_t map;
+	register vm_offset_t *addr;
+	register vm_size_t size;
+	vm_prot_t prot, maxprot;
+	register int flags;
+	caddr_t handle;		/* XXX should be vp */
+	vm_offset_t foff;
+{
+	register vm_pager_t pager;
+	boolean_t fitit;
+	vm_object_t object;
+	struct vnode *vp = NULL;
+	int type;
+	int rv = KERN_SUCCESS;
+
+	if (size == 0)
+		return (0);
+
+	if ((flags & MAP_FIXED) == 0) {
+		fitit = TRUE;
+		*addr = round_page(*addr);
+	} else {
+		fitit = FALSE;
+		(void)vm_deallocate(map, *addr, size);
+	}
+
+	/*
+	 * Lookup/allocate pager.  All except an unnamed anonymous lookup
+	 * gain a reference to ensure continued existance of the object.
+	 * (XXX the exception is to appease the pageout daemon)
+	 */
+	if (flags & MAP_ANON)
+		type = PG_DFLT;
+	else {
+		vp = (struct vnode *)handle;
+		if (vp->v_type == VCHR) {
+			type = PG_DEVICE;
+			handle = (caddr_t)vp->v_rdev;
+		} else
+			type = PG_VNODE;
+	}
+	pager = vm_pager_allocate(type, handle, size, prot, foff);
+	if (pager == NULL)
+		return (type == PG_DEVICE ? EINVAL : ENOMEM);
+	/*
+	 * Find object and release extra reference gained by lookup
+	 */
+	object = vm_object_lookup(pager);
+	vm_object_deallocate(object);
+
+	/*
+	 * Anonymous memory.
+	 */
+	if (flags & MAP_ANON) {
+		rv = vm_allocate_with_pager(map, addr, size, fitit,
+					    pager, foff, TRUE);
+		if (rv != KERN_SUCCESS) {
+			if (handle == NULL)
+				vm_pager_deallocate(pager);
+			else
+				vm_object_deallocate(object);
+			goto out;
+		}
+		/*
+		 * Don't cache anonymous objects.
+		 * Loses the reference gained by vm_pager_allocate.
+		 * Note that object will be NULL when handle == NULL,
+		 * this is ok since vm_allocate_with_pager has made
+		 * sure that these objects are uncached.
+		 */
+		(void) pager_cache(object, FALSE);
+#ifdef DEBUG
+		if (mmapdebug & MDB_MAPIT)
+			printf("vm_mmap(%d): ANON *addr %x size %x pager %x\n",
+			       curproc->p_pid, *addr, size, pager);
+#endif
+	}
+	/*
+	 * Must be a mapped file.
+	 * Distinguish between character special and regular files.
+	 */
+	else if (vp->v_type == VCHR) {
+		rv = vm_allocate_with_pager(map, addr, size, fitit,
+					    pager, foff, FALSE);
+		/*
+		 * Uncache the object and lose the reference gained
+		 * by vm_pager_allocate().  If the call to
+		 * vm_allocate_with_pager() was sucessful, then we
+		 * gained an additional reference ensuring the object
+		 * will continue to exist.  If the call failed then
+		 * the deallocate call below will terminate the
+		 * object which is fine.
+		 */
+		(void) pager_cache(object, FALSE);
+		if (rv != KERN_SUCCESS)
+			goto out;
+	}
+	/*
+	 * A regular file
+	 */
+	else {
+#ifdef DEBUG
+		if (object == NULL)
+			printf("vm_mmap: no object: vp %x, pager %x\n",
+			       vp, pager);
+#endif
+		/*
+		 * Map it directly.
+		 * Allows modifications to go out to the vnode.
+		 */
+		if (flags & MAP_SHARED) {
+			rv = vm_allocate_with_pager(map, addr, size,
+						    fitit, pager,
+						    foff, FALSE);
+			if (rv != KERN_SUCCESS) {
+				vm_object_deallocate(object);
+				goto out;
+			}
+			/*
+			 * Don't cache the object.  This is the easiest way
+			 * of ensuring that data gets back to the filesystem
+			 * because vnode_pager_deallocate() will fsync the
+			 * vnode.  pager_cache() will lose the extra ref.
+			 */
+			if (prot & VM_PROT_WRITE)
+				pager_cache(object, FALSE);
+			else
+				vm_object_deallocate(object);
+		}
+		/*
+		 * Copy-on-write of file.  Two flavors.
+		 * MAP_COPY is true COW, you essentially get a snapshot of
+		 * the region at the time of mapping.  MAP_PRIVATE means only
+		 * that your changes are not reflected back to the object.
+		 * Changes made by others will be seen.
+		 */
+		else {
+			vm_map_t tmap;
+			vm_offset_t off;
+
+			/* locate and allocate the target address space */
+			rv = vm_map_find(map, NULL, (vm_offset_t)0,
+					 addr, size, fitit);
+			if (rv != KERN_SUCCESS) {
+				vm_object_deallocate(object);
+				goto out;
+			}
+			tmap = vm_map_create(pmap_create(size), VM_MIN_ADDRESS,
+					     VM_MIN_ADDRESS+size, TRUE);
+			off = VM_MIN_ADDRESS;
+			rv = vm_allocate_with_pager(tmap, &off, size,
+						    TRUE, pager,
+						    foff, FALSE);
+			if (rv != KERN_SUCCESS) {
+				vm_object_deallocate(object);
+				vm_map_deallocate(tmap);
+				goto out;
+			}
+			/*
+			 * (XXX)
+			 * MAP_PRIVATE implies that we see changes made by
+			 * others.  To ensure that we need to guarentee that
+			 * no copy object is created (otherwise original
+			 * pages would be pushed to the copy object and we
+			 * would never see changes made by others).  We
+			 * totally sleeze it right now by marking the object
+			 * internal temporarily.
+			 */
+			if ((flags & MAP_COPY) == 0)
+				object->flags |= OBJ_INTERNAL;
+			rv = vm_map_copy(map, tmap, *addr, size, off,
+					 FALSE, FALSE);
+			object->flags &= ~OBJ_INTERNAL;
+			/*
+			 * (XXX)
+			 * My oh my, this only gets worse...
+			 * Force creation of a shadow object so that
+			 * vm_map_fork will do the right thing.
+			 */
+			if ((flags & MAP_COPY) == 0) {
+				vm_map_t tmap;
+				vm_map_entry_t tentry;
+				vm_object_t tobject;
+				vm_offset_t toffset;
+				vm_prot_t tprot;
+				boolean_t twired, tsu;
+
+				tmap = map;
+				vm_map_lookup(&tmap, *addr, VM_PROT_WRITE,
+					      &tentry, &tobject, &toffset,
+					      &tprot, &twired, &tsu);
+				vm_map_lookup_done(tmap, tentry);
+			}
+			/*
+			 * (XXX)
+			 * Map copy code cannot detect sharing unless a
+			 * sharing map is involved.  So we cheat and write
+			 * protect everything ourselves.
+			 */
+			vm_object_pmap_copy(object, foff, foff + size);
+			vm_object_deallocate(object);
+			vm_map_deallocate(tmap);
+			if (rv != KERN_SUCCESS)
+				goto out;
+		}
+#ifdef DEBUG
+		if (mmapdebug & MDB_MAPIT)
+			printf("vm_mmap(%d): FILE *addr %x size %x pager %x\n",
+			       curproc->p_pid, *addr, size, pager);
+#endif
+	}
+	/*
+	 * Correct protection (default is VM_PROT_ALL).
+	 * If maxprot is different than prot, we must set both explicitly.
+	 */
+	rv = KERN_SUCCESS;
+	if (maxprot != VM_PROT_ALL)
+		rv = vm_map_protect(map, *addr, *addr+size, maxprot, TRUE);
+	if (rv == KERN_SUCCESS && prot != maxprot)
+		rv = vm_map_protect(map, *addr, *addr+size, prot, FALSE);
+	if (rv != KERN_SUCCESS) {
+		(void) vm_deallocate(map, *addr, size);
+		goto out;
+	}
+	/*
+	 * Shared memory is also shared with children.
+	 */
+	if (flags & MAP_SHARED) {
+		rv = vm_map_inherit(map, *addr, *addr+size, VM_INHERIT_SHARE);
+		if (rv != KERN_SUCCESS) {
+			(void) vm_deallocate(map, *addr, size);
+			goto out;
+		}
+	}
+out:
+#ifdef DEBUG
+	if (mmapdebug & MDB_MAPIT)
+		printf("vm_mmap: rv %d\n", rv);
+#endif
+	switch (rv) {
+	case KERN_SUCCESS:
+		return (0);
+	case KERN_INVALID_ADDRESS:
+	case KERN_NO_SPACE:
+		return (ENOMEM);
+	case KERN_PROTECTION_FAILURE:
+		return (EACCES);
+	default:
+		return (EINVAL);
+	}
+}

--- a/src-uland/libvm/vm_object.c
+++ b/src-uland/libvm/vm_object.c
@@ -1,0 +1,1450 @@
+/* Copied from sys/vm/vm_object.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_object.c	8.7 (Berkeley) 5/11/95
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	Virtual memory object module.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/malloc.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+
+/*
+ *	Virtual memory objects maintain the actual data
+ *	associated with allocated virtual memory.  A given
+ *	page of memory exists within exactly one object.
+ *
+ *	An object is only deallocated when all "references"
+ *	are given up.  Only one "reference" to a given
+ *	region of an object should be writeable.
+ *
+ *	Associated with each object is a list of all resident
+ *	memory pages belonging to that object; this list is
+ *	maintained by the "vm_page" module, and locked by the object's
+ *	lock.
+ *
+ *	Each object also records a "pager" routine which is
+ *	used to retrieve (and store) pages to the proper backing
+ *	storage.  In addition, objects may be backed by other
+ *	objects from which they were virtual-copied.
+ *
+ *	The only items within the object structure which are
+ *	modified after time of creation are:
+ *		reference count		locked by object's lock
+ *		pager routine		locked by object's lock
+ *
+ */
+
+struct vm_object	kernel_object_store;
+struct vm_object	kmem_object_store;
+
+#define	VM_OBJECT_HASH_COUNT	157
+
+int	vm_cache_max = 100;	/* can patch if necessary */
+struct	vm_object_hash_head vm_object_hashtable[VM_OBJECT_HASH_COUNT];
+
+long	object_collapses = 0;
+long	object_bypasses  = 0;
+
+static void _vm_object_allocate __P((vm_size_t, vm_object_t));
+
+/*
+ *	vm_object_init:
+ *
+ *	Initialize the VM objects module.
+ */
+void
+vm_object_init(size)
+	vm_size_t	size;
+{
+	register int	i;
+
+	TAILQ_INIT(&vm_object_cached_list);
+	TAILQ_INIT(&vm_object_list);
+	vm_object_count = 0;
+	simple_lock_init(&vm_cache_lock);
+	simple_lock_init(&vm_object_list_lock);
+
+	for (i = 0; i < VM_OBJECT_HASH_COUNT; i++)
+		TAILQ_INIT(&vm_object_hashtable[i]);
+
+	kernel_object = &kernel_object_store;
+	_vm_object_allocate(size, kernel_object);
+
+	kmem_object = &kmem_object_store;
+	_vm_object_allocate(VM_KMEM_SIZE + VM_MBUF_SIZE, kmem_object);
+}
+
+/*
+ *	vm_object_allocate:
+ *
+ *	Returns a new object with the given size.
+ */
+
+vm_object_t
+vm_object_allocate(size)
+	vm_size_t	size;
+{
+	register vm_object_t	result;
+
+	result = (vm_object_t)
+		malloc((u_long)sizeof *result, M_VMOBJ, M_WAITOK);
+
+	_vm_object_allocate(size, result);
+
+	return(result);
+}
+
+static void
+_vm_object_allocate(size, object)
+	vm_size_t		size;
+	register vm_object_t	object;
+{
+	TAILQ_INIT(&object->memq);
+	vm_object_lock_init(object);
+	object->ref_count = 1;
+	object->resident_page_count = 0;
+	object->size = size;
+	object->flags = OBJ_INTERNAL;	/* vm_allocate_with_pager will reset */
+	object->paging_in_progress = 0;
+	object->copy = NULL;
+
+	/*
+	 *	Object starts out read-write, with no pager.
+	 */
+
+	object->pager = NULL;
+	object->paging_offset = 0;
+	object->shadow = NULL;
+	object->shadow_offset = (vm_offset_t) 0;
+
+	simple_lock(&vm_object_list_lock);
+	TAILQ_INSERT_TAIL(&vm_object_list, object, object_list);
+	vm_object_count++;
+	cnt.v_nzfod += atop(size);
+	simple_unlock(&vm_object_list_lock);
+}
+
+/*
+ *	vm_object_reference:
+ *
+ *	Gets another reference to the given object.
+ */
+void
+vm_object_reference(object)
+	register vm_object_t	object;
+{
+	if (object == NULL)
+		return;
+
+	vm_object_lock(object);
+	object->ref_count++;
+	vm_object_unlock(object);
+}
+
+/*
+ *	vm_object_deallocate:
+ *
+ *	Release a reference to the specified object,
+ *	gained either through a vm_object_allocate
+ *	or a vm_object_reference call.  When all references
+ *	are gone, storage associated with this object
+ *	may be relinquished.
+ *
+ *	No object may be locked.
+ */
+void
+vm_object_deallocate(object)
+	register vm_object_t	object;
+{
+	vm_object_t	temp;
+
+	while (object != NULL) {
+
+		/*
+		 *	The cache holds a reference (uncounted) to
+		 *	the object; we must lock it before removing
+		 *	the object.
+		 */
+
+		vm_object_cache_lock();
+
+		/*
+		 *	Lose the reference
+		 */
+		vm_object_lock(object);
+		if (--(object->ref_count) != 0) {
+
+			/*
+			 *	If there are still references, then
+			 *	we are done.
+			 */
+			vm_object_unlock(object);
+			vm_object_cache_unlock();
+			return;
+		}
+
+		/*
+		 *	See if this object can persist.  If so, enter
+		 *	it in the cache, then deactivate all of its
+		 *	pages.
+		 */
+
+		if (object->flags & OBJ_CANPERSIST) {
+
+			TAILQ_INSERT_TAIL(&vm_object_cached_list, object,
+				cached_list);
+			vm_object_cached++;
+			vm_object_cache_unlock();
+
+			vm_object_deactivate_pages(object);
+			vm_object_unlock(object);
+
+			vm_object_cache_trim();
+			return;
+		}
+
+		/*
+		 *	Make sure no one can look us up now.
+		 */
+		vm_object_remove(object->pager);
+		vm_object_cache_unlock();
+
+		temp = object->shadow;
+		vm_object_terminate(object);
+			/* unlocks and deallocates object */
+		object = temp;
+	}
+}
+
+
+/*
+ *	vm_object_terminate actually destroys the specified object, freeing
+ *	up all previously used resources.
+ *
+ *	The object must be locked.
+ */
+void
+vm_object_terminate(object)
+	register vm_object_t	object;
+{
+	register vm_page_t	p;
+	vm_object_t		shadow_object;
+
+	/*
+	 *	Detach the object from its shadow if we are the shadow's
+	 *	copy.
+	 */
+	if ((shadow_object = object->shadow) != NULL) {
+		vm_object_lock(shadow_object);
+		if (shadow_object->copy == object)
+			shadow_object->copy = NULL;
+#if 0
+		else if (shadow_object->copy != NULL)
+			panic("vm_object_terminate: copy/shadow inconsistency");
+#endif
+		vm_object_unlock(shadow_object);
+	}
+
+	/*
+	 * Wait until the pageout daemon is through with the object.
+	 */
+	while (object->paging_in_progress) {
+		vm_object_sleep(object, object, FALSE);
+		vm_object_lock(object);
+	}
+
+	/*
+	 * If not an internal object clean all the pages, removing them
+	 * from paging queues as we go.
+	 *
+	 * XXX need to do something in the event of a cleaning error.
+	 */
+	if ((object->flags & OBJ_INTERNAL) == 0)
+		(void) vm_object_page_clean(object, 0, 0, TRUE, TRUE);
+
+	/*
+	 * Now free the pages.
+	 * For internal objects, this also removes them from paging queues.
+	 */
+	while ((p = object->memq.tqh_first) != NULL) {
+		VM_PAGE_CHECK(p);
+		vm_page_lock_queues();
+		vm_page_free(p);
+		cnt.v_pfree++;
+		vm_page_unlock_queues();
+	}
+	vm_object_unlock(object);
+
+	/*
+	 * Let the pager know object is dead.
+	 */
+	if (object->pager != NULL)
+		vm_pager_deallocate(object->pager);
+
+	simple_lock(&vm_object_list_lock);
+	TAILQ_REMOVE(&vm_object_list, object, object_list);
+	vm_object_count--;
+	simple_unlock(&vm_object_list_lock);
+
+	/*
+	 * Free the space for the object.
+	 */
+	free((caddr_t)object, M_VMOBJ);
+}
+
+/*
+ *	vm_object_page_clean
+ *
+ *	Clean all dirty pages in the specified range of object.
+ *	If syncio is TRUE, page cleaning is done synchronously.
+ *	If de_queue is TRUE, pages are removed from any paging queue
+ *	they were on, otherwise they are left on whatever queue they
+ *	were on before the cleaning operation began.
+ *
+ *	Odd semantics: if start == end, we clean everything.
+ *
+ *	The object must be locked.
+ *
+ *	Returns TRUE if all was well, FALSE if there was a pager error
+ *	somewhere.  We attempt to clean (and dequeue) all pages regardless
+ *	of where an error occurs.
+ */
+boolean_t
+vm_object_page_clean(object, start, end, syncio, de_queue)
+	register vm_object_t	object;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+	boolean_t		syncio;
+	boolean_t		de_queue;
+{
+	register vm_page_t	p;
+	int onqueue;
+	boolean_t noerror = TRUE;
+
+	if (object == NULL)
+		return (TRUE);
+
+	/*
+	 * If it is an internal object and there is no pager, attempt to
+	 * allocate one.  Note that vm_object_collapse may relocate one
+	 * from a collapsed object so we must recheck afterward.
+	 */
+	if ((object->flags & OBJ_INTERNAL) && object->pager == NULL) {
+		vm_object_collapse(object);
+		if (object->pager == NULL) {
+			vm_pager_t pager;
+
+			vm_object_unlock(object);
+			pager = vm_pager_allocate(PG_DFLT, (caddr_t)0,
+						  object->size, VM_PROT_ALL,
+						  (vm_offset_t)0);
+			if (pager)
+				vm_object_setpager(object, pager, 0, FALSE);
+			vm_object_lock(object);
+		}
+	}
+	if (object->pager == NULL)
+		return (FALSE);
+
+again:
+	/*
+	 * Wait until the pageout daemon is through with the object.
+	 */
+	while (object->paging_in_progress) {
+		vm_object_sleep(object, object, FALSE);
+		vm_object_lock(object);
+	}
+	/*
+	 * Loop through the object page list cleaning as necessary.
+	 */
+	for (p = object->memq.tqh_first; p != NULL; p = p->listq.tqe_next) {
+		if ((start == end || p->offset >= start && p->offset < end) &&
+		    !(p->flags & PG_FICTITIOUS)) {
+			if ((p->flags & PG_CLEAN) &&
+			    pmap_is_modified(VM_PAGE_TO_PHYS(p)))
+				p->flags &= ~PG_CLEAN;
+			/*
+			 * Remove the page from any paging queue.
+			 * This needs to be done if either we have been
+			 * explicitly asked to do so or it is about to
+			 * be cleaned (see comment below).
+			 */
+			if (de_queue || !(p->flags & PG_CLEAN)) {
+				vm_page_lock_queues();
+				if (p->flags & PG_ACTIVE) {
+					TAILQ_REMOVE(&vm_page_queue_active,
+						     p, pageq);
+					p->flags &= ~PG_ACTIVE;
+					cnt.v_active_count--;
+					onqueue = 1;
+				} else if (p->flags & PG_INACTIVE) {
+					TAILQ_REMOVE(&vm_page_queue_inactive,
+						     p, pageq);
+					p->flags &= ~PG_INACTIVE;
+					cnt.v_inactive_count--;
+					onqueue = -1;
+				} else
+					onqueue = 0;
+				vm_page_unlock_queues();
+			}
+			/*
+			 * To ensure the state of the page doesn't change
+			 * during the clean operation we do two things.
+			 * First we set the busy bit and write-protect all
+			 * mappings to ensure that write accesses to the
+			 * page block (in vm_fault).  Second, we remove
+			 * the page from any paging queue to foil the
+			 * pageout daemon (vm_pageout_scan).
+			 */
+			pmap_page_protect(VM_PAGE_TO_PHYS(p), VM_PROT_READ);
+			if (!(p->flags & PG_CLEAN)) {
+				p->flags |= PG_BUSY;
+				object->paging_in_progress++;
+				vm_object_unlock(object);
+				/*
+				 * XXX if put fails we mark the page as
+				 * clean to avoid an infinite loop.
+				 * Will loose changes to the page.
+				 */
+				if (vm_pager_put(object->pager, p, syncio)) {
+					printf("%s: pager_put error\n",
+					       "vm_object_page_clean");
+					p->flags |= PG_CLEAN;
+					noerror = FALSE;
+				}
+				vm_object_lock(object);
+				object->paging_in_progress--;
+				if (!de_queue && onqueue) {
+					vm_page_lock_queues();
+					if (onqueue > 0)
+						vm_page_activate(p);
+					else
+						vm_page_deactivate(p);
+					vm_page_unlock_queues();
+				}
+				p->flags &= ~PG_BUSY;
+				PAGE_WAKEUP(p);
+				goto again;
+			}
+		}
+	}
+	return (noerror);
+}
+
+/*
+ *	vm_object_deactivate_pages
+ *
+ *	Deactivate all pages in the specified object.  (Keep its pages
+ *	in memory even though it is no longer referenced.)
+ *
+ *	The object must be locked.
+ */
+void
+vm_object_deactivate_pages(object)
+	register vm_object_t	object;
+{
+	register vm_page_t	p, next;
+
+	for (p = object->memq.tqh_first; p != NULL; p = next) {
+		next = p->listq.tqe_next;
+		vm_page_lock_queues();
+		vm_page_deactivate(p);
+		vm_page_unlock_queues();
+	}
+}
+
+/*
+ *	Trim the object cache to size.
+ */
+void
+vm_object_cache_trim()
+{
+	register vm_object_t	object;
+
+	vm_object_cache_lock();
+	while (vm_object_cached > vm_cache_max) {
+		object = vm_object_cached_list.tqh_first;
+		vm_object_cache_unlock();
+
+		if (object != vm_object_lookup(object->pager))
+			panic("vm_object_deactivate: I'm sooo confused.");
+
+		pager_cache(object, FALSE);
+
+		vm_object_cache_lock();
+	}
+	vm_object_cache_unlock();
+}
+
+/*
+ *	vm_object_pmap_copy:
+ *
+ *	Makes all physical pages in the specified
+ *	object range copy-on-write.  No writeable
+ *	references to these pages should remain.
+ *
+ *	The object must *not* be locked.
+ */
+void
+vm_object_pmap_copy(object, start, end)
+	register vm_object_t	object;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+{
+	register vm_page_t	p;
+
+	if (object == NULL)
+		return;
+
+	vm_object_lock(object);
+	for (p = object->memq.tqh_first; p != NULL; p = p->listq.tqe_next) {
+		if ((start <= p->offset) && (p->offset < end)) {
+			pmap_page_protect(VM_PAGE_TO_PHYS(p), VM_PROT_READ);
+			p->flags |= PG_COPYONWRITE;
+		}
+	}
+	vm_object_unlock(object);
+}
+
+/*
+ *	vm_object_pmap_remove:
+ *
+ *	Removes all physical pages in the specified
+ *	object range from all physical maps.
+ *
+ *	The object must *not* be locked.
+ */
+void
+vm_object_pmap_remove(object, start, end)
+	register vm_object_t	object;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+{
+	register vm_page_t	p;
+
+	if (object == NULL)
+		return;
+
+	vm_object_lock(object);
+	for (p = object->memq.tqh_first; p != NULL; p = p->listq.tqe_next)
+		if ((start <= p->offset) && (p->offset < end))
+			pmap_page_protect(VM_PAGE_TO_PHYS(p), VM_PROT_NONE);
+	vm_object_unlock(object);
+}
+
+/*
+ *	vm_object_copy:
+ *
+ *	Create a new object which is a copy of an existing
+ *	object, and mark all of the pages in the existing
+ *	object 'copy-on-write'.  The new object has one reference.
+ *	Returns the new object.
+ *
+ *	May defer the copy until later if the object is not backed
+ *	up by a non-default pager.
+ */
+void
+vm_object_copy(src_object, src_offset, size,
+		    dst_object, dst_offset, src_needs_copy)
+	register vm_object_t	src_object;
+	vm_offset_t		src_offset;
+	vm_size_t		size;
+	vm_object_t		*dst_object;	/* OUT */
+	vm_offset_t		*dst_offset;	/* OUT */
+	boolean_t		*src_needs_copy;	/* OUT */
+{
+	register vm_object_t	new_copy;
+	register vm_object_t	old_copy;
+	vm_offset_t		new_start, new_end;
+
+	register vm_page_t	p;
+
+	if (src_object == NULL) {
+		/*
+		 *	Nothing to copy
+		 */
+		*dst_object = NULL;
+		*dst_offset = 0;
+		*src_needs_copy = FALSE;
+		return;
+	}
+
+	/*
+	 *	If the object's pager is null_pager or the
+	 *	default pager, we don't have to make a copy
+	 *	of it.  Instead, we set the needs copy flag and
+	 *	make a shadow later.
+	 */
+
+	vm_object_lock(src_object);
+	if (src_object->pager == NULL ||
+	    (src_object->flags & OBJ_INTERNAL)) {
+
+		/*
+		 *	Make another reference to the object
+		 */
+		src_object->ref_count++;
+
+		/*
+		 *	Mark all of the pages copy-on-write.
+		 */
+		for (p = src_object->memq.tqh_first; p; p = p->listq.tqe_next)
+			if (src_offset <= p->offset &&
+			    p->offset < src_offset + size)
+				p->flags |= PG_COPYONWRITE;
+		vm_object_unlock(src_object);
+
+		*dst_object = src_object;
+		*dst_offset = src_offset;
+		
+		/*
+		 *	Must make a shadow when write is desired
+		 */
+		*src_needs_copy = TRUE;
+		return;
+	}
+
+	/*
+	 *	Try to collapse the object before copying it.
+	 */
+	vm_object_collapse(src_object);
+
+	/*
+	 *	If the object has a pager, the pager wants to
+	 *	see all of the changes.  We need a copy-object
+	 *	for the changed pages.
+	 *
+	 *	If there is a copy-object, and it is empty,
+	 *	no changes have been made to the object since the
+	 *	copy-object was made.  We can use the same copy-
+	 *	object.
+	 */
+
+    Retry1:
+	old_copy = src_object->copy;
+	if (old_copy != NULL) {
+		/*
+		 *	Try to get the locks (out of order)
+		 */
+		if (!vm_object_lock_try(old_copy)) {
+			vm_object_unlock(src_object);
+
+			/* should spin a bit here... */
+			vm_object_lock(src_object);
+			goto Retry1;
+		}
+
+		if (old_copy->resident_page_count == 0 &&
+		    old_copy->pager == NULL) {
+			/*
+			 *	Return another reference to
+			 *	the existing copy-object.
+			 */
+			old_copy->ref_count++;
+			vm_object_unlock(old_copy);
+			vm_object_unlock(src_object);
+			*dst_object = old_copy;
+			*dst_offset = src_offset;
+			*src_needs_copy = FALSE;
+			return;
+		}
+		vm_object_unlock(old_copy);
+	}
+	vm_object_unlock(src_object);
+
+	/*
+	 *	If the object has a pager, the pager wants
+	 *	to see all of the changes.  We must make
+	 *	a copy-object and put the changed pages there.
+	 *
+	 *	The copy-object is always made large enough to
+	 *	completely shadow the original object, since
+	 *	it may have several users who want to shadow
+	 *	the original object at different points.
+	 */
+
+	new_copy = vm_object_allocate(src_object->size);
+
+    Retry2:
+	vm_object_lock(src_object);
+	/*
+	 *	Copy object may have changed while we were unlocked
+	 */
+	old_copy = src_object->copy;
+	if (old_copy != NULL) {
+		/*
+		 *	Try to get the locks (out of order)
+		 */
+		if (!vm_object_lock_try(old_copy)) {
+			vm_object_unlock(src_object);
+			goto Retry2;
+		}
+
+		/*
+		 *	Consistency check
+		 */
+		if (old_copy->shadow != src_object ||
+		    old_copy->shadow_offset != (vm_offset_t) 0)
+			panic("vm_object_copy: copy/shadow inconsistency");
+
+		/*
+		 *	Make the old copy-object shadow the new one.
+		 *	It will receive no more pages from the original
+		 *	object.
+		 */
+
+		src_object->ref_count--;	/* remove ref. from old_copy */
+		old_copy->shadow = new_copy;
+		new_copy->ref_count++;		/* locking not needed - we
+						   have the only pointer */
+		vm_object_unlock(old_copy);	/* done with old_copy */
+	}
+
+	new_start = (vm_offset_t) 0;	/* always shadow original at 0 */
+	new_end   = (vm_offset_t) new_copy->size; /* for the whole object */
+
+	/*
+	 *	Point the new copy at the existing object.
+	 */
+
+	new_copy->shadow = src_object;
+	new_copy->shadow_offset = new_start;
+	src_object->ref_count++;
+	src_object->copy = new_copy;
+
+	/*
+	 *	Mark all the affected pages of the existing object
+	 *	copy-on-write.
+	 */
+	for (p = src_object->memq.tqh_first; p != NULL; p = p->listq.tqe_next)
+		if ((new_start <= p->offset) && (p->offset < new_end))
+			p->flags |= PG_COPYONWRITE;
+
+	vm_object_unlock(src_object);
+
+	*dst_object = new_copy;
+	*dst_offset = src_offset - new_start;
+	*src_needs_copy = FALSE;
+}
+
+/*
+ *	vm_object_shadow:
+ *
+ *	Create a new object which is backed by the
+ *	specified existing object range.  The source
+ *	object reference is deallocated.
+ *
+ *	The new object and offset into that object
+ *	are returned in the source parameters.
+ */
+
+void
+vm_object_shadow(object, offset, length)
+	vm_object_t	*object;	/* IN/OUT */
+	vm_offset_t	*offset;	/* IN/OUT */
+	vm_size_t	length;
+{
+	register vm_object_t	source;
+	register vm_object_t	result;
+
+	source = *object;
+
+	/*
+	 *	Allocate a new object with the given length
+	 */
+
+	if ((result = vm_object_allocate(length)) == NULL)
+		panic("vm_object_shadow: no object for shadowing");
+
+	/*
+	 *	The new object shadows the source object, adding
+	 *	a reference to it.  Our caller changes his reference
+	 *	to point to the new object, removing a reference to
+	 *	the source object.  Net result: no change of reference
+	 *	count.
+	 */
+	result->shadow = source;
+	
+	/*
+	 *	Store the offset into the source object,
+	 *	and fix up the offset into the new object.
+	 */
+
+	result->shadow_offset = *offset;
+
+	/*
+	 *	Return the new things
+	 */
+
+	*offset = 0;
+	*object = result;
+}
+
+/*
+ *	Set the specified object's pager to the specified pager.
+ */
+
+void
+vm_object_setpager(object, pager, paging_offset,
+			read_only)
+	vm_object_t	object;
+	vm_pager_t	pager;
+	vm_offset_t	paging_offset;
+	boolean_t	read_only;
+{
+#ifdef	lint
+	read_only++;	/* No longer used */
+#endif
+
+	vm_object_lock(object);			/* XXX ? */
+	object->pager = pager;
+	object->paging_offset = paging_offset;
+	vm_object_unlock(object);			/* XXX ? */
+}
+
+/*
+ *	vm_object_hash hashes the pager/id pair.
+ */
+
+#define vm_object_hash(pager) \
+	(((unsigned long)pager)%VM_OBJECT_HASH_COUNT)
+
+/*
+ *	vm_object_lookup looks in the object cache for an object with the
+ *	specified pager and paging id.
+ */
+
+vm_object_t
+vm_object_lookup(pager)
+	vm_pager_t	pager;
+{
+	register vm_object_hash_entry_t	entry;
+	vm_object_t			object;
+
+	vm_object_cache_lock();
+
+	for (entry = vm_object_hashtable[vm_object_hash(pager)].tqh_first;
+	     entry != NULL;
+	     entry = entry->hash_links.tqe_next) {
+		object = entry->object;
+		if (object->pager == pager) {
+			vm_object_lock(object);
+			if (object->ref_count == 0) {
+				TAILQ_REMOVE(&vm_object_cached_list, object,
+					cached_list);
+				vm_object_cached--;
+			}
+			object->ref_count++;
+			vm_object_unlock(object);
+			vm_object_cache_unlock();
+			return(object);
+		}
+	}
+
+	vm_object_cache_unlock();
+	return(NULL);
+}
+
+/*
+ *	vm_object_enter enters the specified object/pager/id into
+ *	the hash table.
+ */
+
+void
+vm_object_enter(object, pager)
+	vm_object_t	object;
+	vm_pager_t	pager;
+{
+	struct vm_object_hash_head	*bucket;
+	register vm_object_hash_entry_t	entry;
+
+	/*
+	 *	We don't cache null objects, and we can't cache
+	 *	objects with the null pager.
+	 */
+
+	if (object == NULL)
+		return;
+	if (pager == NULL)
+		return;
+
+	bucket = &vm_object_hashtable[vm_object_hash(pager)];
+	entry = (vm_object_hash_entry_t)
+		malloc((u_long)sizeof *entry, M_VMOBJHASH, M_WAITOK);
+	entry->object = object;
+	object->flags |= OBJ_CANPERSIST;
+
+	vm_object_cache_lock();
+	TAILQ_INSERT_TAIL(bucket, entry, hash_links);
+	vm_object_cache_unlock();
+}
+
+/*
+ *	vm_object_remove:
+ *
+ *	Remove the pager from the hash table.
+ *	Note:  This assumes that the object cache
+ *	is locked.  XXX this should be fixed
+ *	by reorganizing vm_object_deallocate.
+ */
+void
+vm_object_remove(pager)
+	register vm_pager_t	pager;
+{
+	struct vm_object_hash_head	*bucket;
+	register vm_object_hash_entry_t	entry;
+	register vm_object_t		object;
+
+	bucket = &vm_object_hashtable[vm_object_hash(pager)];
+
+	for (entry = bucket->tqh_first;
+	     entry != NULL;
+	     entry = entry->hash_links.tqe_next) {
+		object = entry->object;
+		if (object->pager == pager) {
+			TAILQ_REMOVE(bucket, entry, hash_links);
+			free((caddr_t)entry, M_VMOBJHASH);
+			break;
+		}
+	}
+}
+
+/*
+ *	vm_object_cache_clear removes all objects from the cache.
+ *
+ */
+void
+vm_object_cache_clear()
+{
+	register vm_object_t	object;
+
+	/*
+	 *	Remove each object in the cache by scanning down the
+	 *	list of cached objects.
+	 */
+	vm_object_cache_lock();
+	while ((object = vm_object_cached_list.tqh_first) != NULL) {
+		vm_object_cache_unlock();
+
+		/* 
+		 * Note: it is important that we use vm_object_lookup
+		 * to gain a reference, and not vm_object_reference, because
+		 * the logic for removing an object from the cache lies in 
+		 * lookup.
+		 */
+		if (object != vm_object_lookup(object->pager))
+			panic("vm_object_cache_clear: I'm sooo confused.");
+		pager_cache(object, FALSE);
+
+		vm_object_cache_lock();
+	}
+	vm_object_cache_unlock();
+}
+
+boolean_t	vm_object_collapse_allowed = TRUE;
+/*
+ *	vm_object_collapse:
+ *
+ *	Collapse an object with the object backing it.
+ *	Pages in the backing object are moved into the
+ *	parent, and the backing object is deallocated.
+ *
+ *	Requires that the object be locked and the page
+ *	queues be unlocked.
+ *
+ */
+void
+vm_object_collapse(object)
+	register vm_object_t	object;
+
+{
+	register vm_object_t	backing_object;
+	register vm_offset_t	backing_offset;
+	register vm_size_t	size;
+	register vm_offset_t	new_offset;
+	register vm_page_t	p, pp;
+
+	if (!vm_object_collapse_allowed)
+		return;
+
+	while (TRUE) {
+		/*
+		 *	Verify that the conditions are right for collapse:
+		 *
+		 *	The object exists and no pages in it are currently
+		 *	being paged out (or have ever been paged out).
+		 */
+		if (object == NULL ||
+		    object->paging_in_progress != 0 ||
+		    object->pager != NULL)
+			return;
+
+		/*
+		 *		There is a backing object, and
+		 */
+	
+		if ((backing_object = object->shadow) == NULL)
+			return;
+	
+		vm_object_lock(backing_object);
+		/*
+		 *	...
+		 *		The backing object is not read_only,
+		 *		and no pages in the backing object are
+		 *		currently being paged out.
+		 *		The backing object is internal.
+		 */
+	
+		if ((backing_object->flags & OBJ_INTERNAL) == 0 ||
+		    backing_object->paging_in_progress != 0) {
+			vm_object_unlock(backing_object);
+			return;
+		}
+	
+		/*
+		 *	The backing object can't be a copy-object:
+		 *	the shadow_offset for the copy-object must stay
+		 *	as 0.  Furthermore (for the 'we have all the
+		 *	pages' case), if we bypass backing_object and
+		 *	just shadow the next object in the chain, old
+		 *	pages from that object would then have to be copied
+		 *	BOTH into the (former) backing_object and into the
+		 *	parent object.
+		 */
+		if (backing_object->shadow != NULL &&
+		    backing_object->shadow->copy != NULL) {
+			vm_object_unlock(backing_object);
+			return;
+		}
+
+		/*
+		 *	We know that we can either collapse the backing
+		 *	object (if the parent is the only reference to
+		 *	it) or (perhaps) remove the parent's reference
+		 *	to it.
+		 */
+
+		backing_offset = object->shadow_offset;
+		size = object->size;
+
+		/*
+		 *	If there is exactly one reference to the backing
+		 *	object, we can collapse it into the parent.
+		 */
+	
+		if (backing_object->ref_count == 1) {
+
+			/*
+			 *	We can collapse the backing object.
+			 *
+			 *	Move all in-memory pages from backing_object
+			 *	to the parent.  Pages that have been paged out
+			 *	will be overwritten by any of the parent's
+			 *	pages that shadow them.
+			 */
+
+			while ((p = backing_object->memq.tqh_first) != NULL) {
+				new_offset = (p->offset - backing_offset);
+
+				/*
+				 *	If the parent has a page here, or if
+				 *	this page falls outside the parent,
+				 *	dispose of it.
+				 *
+				 *	Otherwise, move it as planned.
+				 */
+
+				if (p->offset < backing_offset ||
+				    new_offset >= size) {
+					vm_page_lock_queues();
+					vm_page_free(p);
+					vm_page_unlock_queues();
+				} else {
+				    pp = vm_page_lookup(object, new_offset);
+				    if (pp != NULL && !(pp->flags & PG_FAKE)) {
+					vm_page_lock_queues();
+					vm_page_free(p);
+					vm_page_unlock_queues();
+				    }
+				    else {
+					if (pp) {
+					    /* may be someone waiting for it */
+					    PAGE_WAKEUP(pp);
+					    vm_page_lock_queues();
+					    vm_page_free(pp);
+					    vm_page_unlock_queues();
+					}
+					vm_page_rename(p, object, new_offset);
+				    }
+				}
+			}
+
+			/*
+			 *	Move the pager from backing_object to object.
+			 *
+			 *	XXX We're only using part of the paging space
+			 *	for keeps now... we ought to discard the
+			 *	unused portion.
+			 */
+
+			if (backing_object->pager) {
+				object->pager = backing_object->pager;
+				object->paging_offset = backing_offset +
+					backing_object->paging_offset;
+				backing_object->pager = NULL;
+			}
+
+			/*
+			 *	Object now shadows whatever backing_object did.
+			 *	Note that the reference to backing_object->shadow
+			 *	moves from within backing_object to within object.
+			 */
+
+			object->shadow = backing_object->shadow;
+			object->shadow_offset += backing_object->shadow_offset;
+			if (object->shadow != NULL &&
+			    object->shadow->copy != NULL) {
+				panic("vm_object_collapse: we collapsed a copy-object!");
+			}
+			/*
+			 *	Discard backing_object.
+			 *
+			 *	Since the backing object has no pages, no
+			 *	pager left, and no object references within it,
+			 *	all that is necessary is to dispose of it.
+			 */
+
+			vm_object_unlock(backing_object);
+
+			simple_lock(&vm_object_list_lock);
+			TAILQ_REMOVE(&vm_object_list, backing_object,
+			    object_list);
+			vm_object_count--;
+			simple_unlock(&vm_object_list_lock);
+
+			free((caddr_t)backing_object, M_VMOBJ);
+
+			object_collapses++;
+		}
+		else {
+			/*
+			 *	If all of the pages in the backing object are
+			 *	shadowed by the parent object, the parent
+			 *	object no longer has to shadow the backing
+			 *	object; it can shadow the next one in the
+			 *	chain.
+			 *
+			 *	The backing object must not be paged out - we'd
+			 *	have to check all of the paged-out pages, as
+			 *	well.
+			 */
+
+			if (backing_object->pager != NULL) {
+				vm_object_unlock(backing_object);
+				return;
+			}
+
+			/*
+			 *	Should have a check for a 'small' number
+			 *	of pages here.
+			 */
+
+			for (p = backing_object->memq.tqh_first;
+			     p != NULL;
+			     p = p->listq.tqe_next) {
+				new_offset = (p->offset - backing_offset);
+
+				/*
+				 *	If the parent has a page here, or if
+				 *	this page falls outside the parent,
+				 *	keep going.
+				 *
+				 *	Otherwise, the backing_object must be
+				 *	left in the chain.
+				 */
+
+				if (p->offset >= backing_offset &&
+				    new_offset < size &&
+				    ((pp = vm_page_lookup(object, new_offset))
+				      == NULL ||
+				     (pp->flags & PG_FAKE))) {
+					/*
+					 *	Page still needed.
+					 *	Can't go any further.
+					 */
+					vm_object_unlock(backing_object);
+					return;
+				}
+			}
+
+			/*
+			 *	Make the parent shadow the next object
+			 *	in the chain.  Deallocating backing_object
+			 *	will not remove it, since its reference
+			 *	count is at least 2.
+			 */
+
+			object->shadow = backing_object->shadow;
+			vm_object_reference(object->shadow);
+			object->shadow_offset += backing_object->shadow_offset;
+
+			/*
+			 *	Backing object might have had a copy pointer
+			 *	to us.  If it did, clear it. 
+			 */
+			if (backing_object->copy == object) {
+				backing_object->copy = NULL;
+			}
+	
+			/*	Drop the reference count on backing_object.
+			 *	Since its ref_count was at least 2, it
+			 *	will not vanish; so we don't need to call
+			 *	vm_object_deallocate.
+			 */
+			backing_object->ref_count--;
+			vm_object_unlock(backing_object);
+
+			object_bypasses ++;
+
+		}
+
+		/*
+		 *	Try again with this object's new backing object.
+		 */
+	}
+}
+
+/*
+ *	vm_object_page_remove: [internal]
+ *
+ *	Removes all physical pages in the specified
+ *	object range from the object's list of pages.
+ *
+ *	The object must be locked.
+ */
+void
+vm_object_page_remove(object, start, end)
+	register vm_object_t	object;
+	register vm_offset_t	start;
+	register vm_offset_t	end;
+{
+	register vm_page_t	p, next;
+
+	if (object == NULL)
+		return;
+
+	for (p = object->memq.tqh_first; p != NULL; p = next) {
+		next = p->listq.tqe_next;
+		if ((start <= p->offset) && (p->offset < end)) {
+			pmap_page_protect(VM_PAGE_TO_PHYS(p), VM_PROT_NONE);
+			vm_page_lock_queues();
+			vm_page_free(p);
+			vm_page_unlock_queues();
+		}
+	}
+}
+
+/*
+ *	Routine:	vm_object_coalesce
+ *	Function:	Coalesces two objects backing up adjoining
+ *			regions of memory into a single object.
+ *
+ *	returns TRUE if objects were combined.
+ *
+ *	NOTE:	Only works at the moment if the second object is NULL -
+ *		if it's not, which object do we lock first?
+ *
+ *	Parameters:
+ *		prev_object	First object to coalesce
+ *		prev_offset	Offset into prev_object
+ *		next_object	Second object into coalesce
+ *		next_offset	Offset into next_object
+ *
+ *		prev_size	Size of reference to prev_object
+ *		next_size	Size of reference to next_object
+ *
+ *	Conditions:
+ *	The object must *not* be locked.
+ */
+boolean_t
+vm_object_coalesce(prev_object, next_object,
+			prev_offset, next_offset,
+			prev_size, next_size)
+
+	register vm_object_t	prev_object;
+	vm_object_t	next_object;
+	vm_offset_t	prev_offset, next_offset;
+	vm_size_t	prev_size, next_size;
+{
+	vm_size_t	newsize;
+
+#ifdef	lint
+	next_offset++;
+#endif
+
+	if (next_object != NULL) {
+		return(FALSE);
+	}
+
+	if (prev_object == NULL) {
+		return(TRUE);
+	}
+
+	vm_object_lock(prev_object);
+
+	/*
+	 *	Try to collapse the object first
+	 */
+	vm_object_collapse(prev_object);
+
+	/*
+	 *	Can't coalesce if:
+	 *	. more than one reference
+	 *	. paged out
+	 *	. shadows another object
+	 *	. has a copy elsewhere
+	 *	(any of which mean that the pages not mapped to
+	 *	prev_entry may be in use anyway)
+	 */
+
+	if (prev_object->ref_count > 1 ||
+		prev_object->pager != NULL ||
+		prev_object->shadow != NULL ||
+		prev_object->copy != NULL) {
+		vm_object_unlock(prev_object);
+		return(FALSE);
+	}
+
+	/*
+	 *	Remove any pages that may still be in the object from
+	 *	a previous deallocation.
+	 */
+
+	vm_object_page_remove(prev_object,
+			prev_offset + prev_size,
+			prev_offset + prev_size + next_size);
+
+	/*
+	 *	Extend the object if necessary.
+	 */
+	newsize = prev_offset + prev_size + next_size;
+	if (newsize > prev_object->size)
+		prev_object->size = newsize;
+
+	vm_object_unlock(prev_object);
+	return(TRUE);
+}
+
+/*
+ *	vm_object_print:	[ debug ]
+ */
+void
+vm_object_print(object, full)
+	vm_object_t	object;
+	boolean_t	full;
+{
+	register vm_page_t	p;
+	extern indent;
+
+	register int count;
+
+	if (object == NULL)
+		return;
+
+	iprintf("Object 0x%x: size=0x%x, res=%d, ref=%d, ",
+		(int) object, (int) object->size,
+		object->resident_page_count, object->ref_count);
+	printf("pager=0x%x+0x%x, shadow=(0x%x)+0x%x\n",
+	       (int) object->pager, (int) object->paging_offset,
+	       (int) object->shadow, (int) object->shadow_offset);
+	printf("cache: next=0x%x, prev=0x%x\n",
+	       object->cached_list.tqe_next, object->cached_list.tqe_prev);
+
+	if (!full)
+		return;
+
+	indent += 2;
+	count = 0;
+	for (p = object->memq.tqh_first; p != NULL; p = p->listq.tqe_next) {
+		if (count == 0)
+			iprintf("memory:=");
+		else if (count == 6) {
+			printf("\n");
+			iprintf(" ...");
+			count = 0;
+		} else
+			printf(",");
+		count++;
+
+		printf("(off=0x%x,page=0x%x)", p->offset, VM_PAGE_TO_PHYS(p));
+	}
+	if (count != 0)
+		printf("\n");
+	indent -= 2;
+}

--- a/src-uland/libvm/vm_page.c
+++ b/src-uland/libvm/vm_page.c
@@ -1,0 +1,711 @@
+/* Copied from sys/vm/vm_page.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_page.c	8.4 (Berkeley) 1/9/95
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	Resident memory management module.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vm_map.h>
+#include <vm/vm_pageout.h>
+
+/*
+ *	Associated with page of user-allocatable memory is a
+ *	page structure.
+ */
+
+struct pglist	*vm_page_buckets;		/* Array of buckets */
+int		vm_page_bucket_count = 0;	/* How big is array? */
+int		vm_page_hash_mask;		/* Mask for hash function */
+simple_lock_data_t	bucket_lock;		/* lock for all buckets XXX */
+
+struct pglist	vm_page_queue_free;
+struct pglist	vm_page_queue_active;
+struct pglist	vm_page_queue_inactive;
+simple_lock_data_t	vm_page_queue_lock;
+simple_lock_data_t	vm_page_queue_free_lock;
+
+/* has physical page allocation been initialized? */
+boolean_t vm_page_startup_initialized;
+
+vm_page_t	vm_page_array;
+long		first_page;
+long		last_page;
+vm_offset_t	first_phys_addr;
+vm_offset_t	last_phys_addr;
+vm_size_t	page_mask;
+int		page_shift;
+
+/*
+ *	vm_set_page_size:
+ *
+ *	Sets the page size, perhaps based upon the memory
+ *	size.  Must be called before any use of page-size
+ *	dependent functions.
+ *
+ *	Sets page_shift and page_mask from cnt.v_page_size.
+ */
+void
+vm_set_page_size()
+{
+
+	if (cnt.v_page_size == 0)
+		cnt.v_page_size = DEFAULT_PAGE_SIZE;
+	page_mask = cnt.v_page_size - 1;
+	if ((page_mask & cnt.v_page_size) != 0)
+		panic("vm_set_page_size: page size not a power of two");
+	for (page_shift = 0; ; page_shift++)
+		if ((1 << page_shift) == cnt.v_page_size)
+			break;
+}
+
+
+/*
+ *	vm_page_startup:
+ *
+ *	Initializes the resident memory module.
+ *
+ *	Allocates memory for the page cells, and
+ *	for the object/offset-to-page hash table headers.
+ *	Each page cell is initialized and placed on the free list.
+ */
+void
+vm_page_startup(start, end)
+	vm_offset_t	*start;
+	vm_offset_t	*end;
+{
+	register vm_page_t	m;
+	register struct pglist	*bucket;
+	vm_size_t		npages;
+	int			i;
+	vm_offset_t		pa;
+	extern	vm_offset_t	kentry_data;
+	extern	vm_size_t	kentry_data_size;
+
+
+	/*
+	 *	Initialize the locks
+	 */
+
+	simple_lock_init(&vm_page_queue_free_lock);
+	simple_lock_init(&vm_page_queue_lock);
+
+	/*
+	 *	Initialize the queue headers for the free queue,
+	 *	the active queue and the inactive queue.
+	 */
+
+	TAILQ_INIT(&vm_page_queue_free);
+	TAILQ_INIT(&vm_page_queue_active);
+	TAILQ_INIT(&vm_page_queue_inactive);
+
+	/*
+	 *	Calculate the number of hash table buckets.
+	 *
+	 *	The number of buckets MUST BE a power of 2, and
+	 *	the actual value is the next power of 2 greater
+	 *	than the number of physical pages in the system.
+	 *
+	 *	Note:
+	 *		This computation can be tweaked if desired.
+	 */
+
+	if (vm_page_bucket_count == 0) {
+		vm_page_bucket_count = 1;
+		while (vm_page_bucket_count < atop(*end - *start))
+			vm_page_bucket_count <<= 1;
+	}
+
+	vm_page_hash_mask = vm_page_bucket_count - 1;
+
+	/*
+	 *	Allocate (and initialize) the hash table buckets.
+	 */
+	vm_page_buckets = (struct pglist *)
+	    pmap_bootstrap_alloc(vm_page_bucket_count * sizeof(struct pglist));
+	bucket = vm_page_buckets;
+
+	for (i = vm_page_bucket_count; i--;) {
+		TAILQ_INIT(bucket);
+		bucket++;
+	}
+
+	simple_lock_init(&bucket_lock);
+
+	/*
+	 *	Truncate the remainder of physical memory to our page size.
+	 */
+
+	*end = trunc_page(*end);
+
+	/*
+	 *	Pre-allocate maps and map entries that cannot be dynamically
+	 *	allocated via malloc().  The maps include the kernel_map and
+	 *	kmem_map which must be initialized before malloc() will
+	 *	work (obviously).  Also could include pager maps which would
+	 *	be allocated before kmeminit.
+	 *
+	 *	Allow some kernel map entries... this should be plenty
+	 *	since people shouldn't be cluttering up the kernel
+	 *	map (they should use their own maps).
+	 */
+
+	kentry_data_size = round_page(MAX_KMAP*sizeof(struct vm_map) +
+				      MAX_KMAPENT*sizeof(struct vm_map_entry));
+	kentry_data = (vm_offset_t) pmap_bootstrap_alloc(kentry_data_size);
+
+	/*
+ 	 *	Compute the number of pages of memory that will be
+	 *	available for use (taking into account the overhead
+	 *	of a page structure per page).
+	 */
+
+	cnt.v_free_count = npages = (*end - *start + sizeof(struct vm_page))
+		/ (PAGE_SIZE + sizeof(struct vm_page));
+
+	/*
+	 *	Record the extent of physical memory that the
+	 *	virtual memory system manages.
+	 */
+
+	first_page = *start;
+	first_page += npages*sizeof(struct vm_page);
+	first_page = atop(round_page(first_page));
+	last_page  = first_page + npages - 1;
+
+	first_phys_addr = ptoa(first_page);
+	last_phys_addr  = ptoa(last_page) + PAGE_MASK;
+
+
+	/*
+	 *	Allocate and clear the mem entry structures.
+	 */
+
+	m = vm_page_array = (vm_page_t)
+		pmap_bootstrap_alloc(npages * sizeof(struct vm_page));
+
+	/*
+	 *	Initialize the mem entry structures now, and
+	 *	put them in the free queue.
+	 */
+
+	pa = first_phys_addr;
+	while (npages--) {
+		m->flags = 0;
+		m->object = NULL;
+		m->phys_addr = pa;
+#ifdef i386
+		if (pmap_isvalidphys(m->phys_addr)) {
+			TAILQ_INSERT_TAIL(&vm_page_queue_free, m, pageq);
+		} else {
+			/* perhaps iomem needs it's own type, or dev pager? */
+			m->flags |= PG_FICTITIOUS | PG_BUSY;
+			cnt.v_free_count--;
+		}
+#else /* i386 */
+		TAILQ_INSERT_TAIL(&vm_page_queue_free, m, pageq);
+#endif /* i386 */
+		m++;
+		pa += PAGE_SIZE;
+	}
+
+	/*
+	 *	Initialize vm_pages_needed lock here - don't wait for pageout
+	 *	daemon	XXX
+	 */
+	simple_lock_init(&vm_pages_needed_lock);
+
+	/* from now on, pmap_bootstrap_alloc can't be used */
+	vm_page_startup_initialized = TRUE;
+}
+
+/*
+ *	vm_page_hash:
+ *
+ *	Distributes the object/offset key pair among hash buckets.
+ *
+ *	NOTE:  This macro depends on vm_page_bucket_count being a power of 2.
+ */
+#define vm_page_hash(object, offset) \
+	(((unsigned long)object+(unsigned long)atop(offset))&vm_page_hash_mask)
+
+/*
+ *	vm_page_insert:		[ internal use only ]
+ *
+ *	Inserts the given mem entry into the object/object-page
+ *	table and object list.
+ *
+ *	The object and page must be locked.
+ */
+
+void
+vm_page_insert(mem, object, offset)
+	register vm_page_t	mem;
+	register vm_object_t	object;
+	register vm_offset_t	offset;
+{
+	register struct pglist	*bucket;
+	int			spl;
+
+	VM_PAGE_CHECK(mem);
+
+	if (mem->flags & PG_TABLED)
+		panic("vm_page_insert: already inserted");
+
+	/*
+	 *	Record the object/offset pair in this page
+	 */
+
+	mem->object = object;
+	mem->offset = offset;
+
+	/*
+	 *	Insert it into the object_object/offset hash table
+	 */
+
+	bucket = &vm_page_buckets[vm_page_hash(object, offset)];
+	spl = splimp();
+	simple_lock(&bucket_lock);
+	TAILQ_INSERT_TAIL(bucket, mem, hashq);
+	simple_unlock(&bucket_lock);
+	(void) splx(spl);
+
+	/*
+	 *	Now link into the object's list of backed pages.
+	 */
+
+	TAILQ_INSERT_TAIL(&object->memq, mem, listq);
+	mem->flags |= PG_TABLED;
+
+	/*
+	 *	And show that the object has one more resident
+	 *	page.
+	 */
+
+	object->resident_page_count++;
+}
+
+/*
+ *	vm_page_remove:		[ internal use only ]
+ *				NOTE: used by device pager as well -wfj
+ *
+ *	Removes the given mem entry from the object/offset-page
+ *	table and the object page list.
+ *
+ *	The object and page must be locked.
+ */
+
+void
+vm_page_remove(mem)
+	register vm_page_t	mem;
+{
+	register struct pglist	*bucket;
+	int			spl;
+
+	VM_PAGE_CHECK(mem);
+
+	if (!(mem->flags & PG_TABLED))
+		return;
+
+	/*
+	 *	Remove from the object_object/offset hash table
+	 */
+
+	bucket = &vm_page_buckets[vm_page_hash(mem->object, mem->offset)];
+	spl = splimp();
+	simple_lock(&bucket_lock);
+	TAILQ_REMOVE(bucket, mem, hashq);
+	simple_unlock(&bucket_lock);
+	(void) splx(spl);
+
+	/*
+	 *	Now remove from the object's list of backed pages.
+	 */
+
+	TAILQ_REMOVE(&mem->object->memq, mem, listq);
+
+	/*
+	 *	And show that the object has one fewer resident
+	 *	page.
+	 */
+
+	mem->object->resident_page_count--;
+
+	mem->flags &= ~PG_TABLED;
+}
+
+/*
+ *	vm_page_lookup:
+ *
+ *	Returns the page associated with the object/offset
+ *	pair specified; if none is found, NULL is returned.
+ *
+ *	The object must be locked.  No side effects.
+ */
+
+vm_page_t
+vm_page_lookup(object, offset)
+	register vm_object_t	object;
+	register vm_offset_t	offset;
+{
+	register vm_page_t	mem;
+	register struct pglist	*bucket;
+	int			spl;
+
+	/*
+	 *	Search the hash table for this object/offset pair
+	 */
+
+	bucket = &vm_page_buckets[vm_page_hash(object, offset)];
+
+	spl = splimp();
+	simple_lock(&bucket_lock);
+	for (mem = bucket->tqh_first; mem != NULL; mem = mem->hashq.tqe_next) {
+		VM_PAGE_CHECK(mem);
+		if ((mem->object == object) && (mem->offset == offset)) {
+			simple_unlock(&bucket_lock);
+			splx(spl);
+			return(mem);
+		}
+	}
+
+	simple_unlock(&bucket_lock);
+	splx(spl);
+	return(NULL);
+}
+
+/*
+ *	vm_page_rename:
+ *
+ *	Move the given memory entry from its
+ *	current object to the specified target object/offset.
+ *
+ *	The object must be locked.
+ */
+void
+vm_page_rename(mem, new_object, new_offset)
+	register vm_page_t	mem;
+	register vm_object_t	new_object;
+	vm_offset_t		new_offset;
+{
+	if (mem->object == new_object)
+		return;
+
+	vm_page_lock_queues();	/* keep page from moving out from
+				   under pageout daemon */
+    	vm_page_remove(mem);
+	vm_page_insert(mem, new_object, new_offset);
+	vm_page_unlock_queues();
+}
+
+/*
+ *	vm_page_alloc:
+ *
+ *	Allocate and return a memory cell associated
+ *	with this VM object/offset pair.
+ *
+ *	Object must be locked.
+ */
+vm_page_t
+vm_page_alloc(object, offset)
+	vm_object_t	object;
+	vm_offset_t	offset;
+{
+	register vm_page_t	mem;
+	int		spl;
+
+	spl = splimp();				/* XXX */
+	simple_lock(&vm_page_queue_free_lock);
+	if (vm_page_queue_free.tqh_first == NULL) {
+		simple_unlock(&vm_page_queue_free_lock);
+		splx(spl);
+		return(NULL);
+	}
+
+	mem = vm_page_queue_free.tqh_first;
+	TAILQ_REMOVE(&vm_page_queue_free, mem, pageq);
+
+	cnt.v_free_count--;
+	simple_unlock(&vm_page_queue_free_lock);
+	splx(spl);
+
+	VM_PAGE_INIT(mem, object, offset);
+
+	/*
+	 *	Decide if we should poke the pageout daemon.
+	 *	We do this if the free count is less than the low
+	 *	water mark, or if the free count is less than the high
+	 *	water mark (but above the low water mark) and the inactive
+	 *	count is less than its target.
+	 *
+	 *	We don't have the counts locked ... if they change a little,
+	 *	it doesn't really matter.
+	 */
+
+	if (cnt.v_free_count < cnt.v_free_min ||
+	    (cnt.v_free_count < cnt.v_free_target &&
+	     cnt.v_inactive_count < cnt.v_inactive_target))
+		thread_wakeup(&vm_pages_needed);
+	return (mem);
+}
+
+/*
+ *	vm_page_free:
+ *
+ *	Returns the given page to the free list,
+ *	disassociating it with any VM object.
+ *
+ *	Object and page must be locked prior to entry.
+ */
+void
+vm_page_free(mem)
+	register vm_page_t	mem;
+{
+	vm_page_remove(mem);
+	if (mem->flags & PG_ACTIVE) {
+		TAILQ_REMOVE(&vm_page_queue_active, mem, pageq);
+		mem->flags &= ~PG_ACTIVE;
+		cnt.v_active_count--;
+	}
+
+	if (mem->flags & PG_INACTIVE) {
+		TAILQ_REMOVE(&vm_page_queue_inactive, mem, pageq);
+		mem->flags &= ~PG_INACTIVE;
+		cnt.v_inactive_count--;
+	}
+
+	if (!(mem->flags & PG_FICTITIOUS)) {
+		int	spl;
+
+		spl = splimp();
+		simple_lock(&vm_page_queue_free_lock);
+		TAILQ_INSERT_TAIL(&vm_page_queue_free, mem, pageq);
+
+		cnt.v_free_count++;
+		simple_unlock(&vm_page_queue_free_lock);
+		splx(spl);
+	}
+}
+
+/*
+ *	vm_page_wire:
+ *
+ *	Mark this page as wired down by yet
+ *	another map, removing it from paging queues
+ *	as necessary.
+ *
+ *	The page queues must be locked.
+ */
+void
+vm_page_wire(mem)
+	register vm_page_t	mem;
+{
+	VM_PAGE_CHECK(mem);
+
+	if (mem->wire_count == 0) {
+		if (mem->flags & PG_ACTIVE) {
+			TAILQ_REMOVE(&vm_page_queue_active, mem, pageq);
+			cnt.v_active_count--;
+			mem->flags &= ~PG_ACTIVE;
+		}
+		if (mem->flags & PG_INACTIVE) {
+			TAILQ_REMOVE(&vm_page_queue_inactive, mem, pageq);
+			cnt.v_inactive_count--;
+			mem->flags &= ~PG_INACTIVE;
+		}
+		cnt.v_wire_count++;
+	}
+	mem->wire_count++;
+}
+
+/*
+ *	vm_page_unwire:
+ *
+ *	Release one wiring of this page, potentially
+ *	enabling it to be paged again.
+ *
+ *	The page queues must be locked.
+ */
+void
+vm_page_unwire(mem)
+	register vm_page_t	mem;
+{
+	VM_PAGE_CHECK(mem);
+
+	mem->wire_count--;
+	if (mem->wire_count == 0) {
+		TAILQ_INSERT_TAIL(&vm_page_queue_active, mem, pageq);
+		cnt.v_active_count++;
+		mem->flags |= PG_ACTIVE;
+		cnt.v_wire_count--;
+	}
+}
+
+/*
+ *	vm_page_deactivate:
+ *
+ *	Returns the given page to the inactive list,
+ *	indicating that no physical maps have access
+ *	to this page.  [Used by the physical mapping system.]
+ *
+ *	The page queues must be locked.
+ */
+void
+vm_page_deactivate(m)
+	register vm_page_t	m;
+{
+	VM_PAGE_CHECK(m);
+
+	/*
+	 *	Only move active pages -- ignore locked or already
+	 *	inactive ones.
+	 */
+
+	if (m->flags & PG_ACTIVE) {
+		pmap_clear_reference(VM_PAGE_TO_PHYS(m));
+		TAILQ_REMOVE(&vm_page_queue_active, m, pageq);
+		TAILQ_INSERT_TAIL(&vm_page_queue_inactive, m, pageq);
+		m->flags &= ~PG_ACTIVE;
+		m->flags |= PG_INACTIVE;
+		cnt.v_active_count--;
+		cnt.v_inactive_count++;
+		if (pmap_is_modified(VM_PAGE_TO_PHYS(m)))
+			m->flags &= ~PG_CLEAN;
+		if (m->flags & PG_CLEAN)
+			m->flags &= ~PG_LAUNDRY;
+		else
+			m->flags |= PG_LAUNDRY;
+	}
+}
+
+/*
+ *	vm_page_activate:
+ *
+ *	Put the specified page on the active list (if appropriate).
+ *
+ *	The page queues must be locked.
+ */
+
+void
+vm_page_activate(m)
+	register vm_page_t	m;
+{
+	VM_PAGE_CHECK(m);
+
+	if (m->flags & PG_INACTIVE) {
+		TAILQ_REMOVE(&vm_page_queue_inactive, m, pageq);
+		cnt.v_inactive_count--;
+		m->flags &= ~PG_INACTIVE;
+	}
+	if (m->wire_count == 0) {
+		if (m->flags & PG_ACTIVE)
+			panic("vm_page_activate: already active");
+
+		TAILQ_INSERT_TAIL(&vm_page_queue_active, m, pageq);
+		m->flags |= PG_ACTIVE;
+		cnt.v_active_count++;
+	}
+}
+
+/*
+ *	vm_page_zero_fill:
+ *
+ *	Zero-fill the specified page.
+ *	Written as a standard pagein routine, to
+ *	be used by the zero-fill object.
+ */
+
+boolean_t
+vm_page_zero_fill(m)
+	vm_page_t	m;
+{
+	VM_PAGE_CHECK(m);
+
+	m->flags &= ~PG_CLEAN;
+	pmap_zero_page(VM_PAGE_TO_PHYS(m));
+	return(TRUE);
+}
+
+/*
+ *	vm_page_copy:
+ *
+ *	Copy one page to another
+ */
+
+void
+vm_page_copy(src_m, dest_m)
+	vm_page_t	src_m;
+	vm_page_t	dest_m;
+{
+	VM_PAGE_CHECK(src_m);
+	VM_PAGE_CHECK(dest_m);
+
+	dest_m->flags &= ~PG_CLEAN;
+	pmap_copy_page(VM_PAGE_TO_PHYS(src_m), VM_PAGE_TO_PHYS(dest_m));
+}

--- a/src-uland/libvm/vm_pageout.c
+++ b/src-uland/libvm/vm_pageout.c
@@ -1,0 +1,572 @@
+/* Copied from sys/vm/vm_pageout.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_pageout.c	8.7 (Berkeley) 6/19/95
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	The proverbial page-out daemon.
+ */
+
+#include <sys/param.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vm_pageout.h>
+
+#ifndef VM_PAGE_FREE_MIN
+#define VM_PAGE_FREE_MIN	(cnt.v_free_count / 20)
+#endif
+
+#ifndef VM_PAGE_FREE_TARGET
+#define VM_PAGE_FREE_TARGET	((cnt.v_free_min * 4) / 3)
+#endif
+
+int	vm_page_free_min_min = 16 * 1024;
+int	vm_page_free_min_max = 256 * 1024;
+
+int	vm_pages_needed;	/* Event on which pageout daemon sleeps */
+
+int	vm_page_max_wired = 0;	/* XXX max # of wired pages system-wide */
+
+#ifdef CLUSTERED_PAGEOUT
+#define MAXPOCLUSTER		(MAXPHYS/NBPG)	/* XXX */
+int doclustered_pageout = 1;
+#endif
+
+/*
+ *	vm_pageout_scan does the dirty work for the pageout daemon.
+ */
+void
+vm_pageout_scan()
+{
+	register vm_page_t	m, next;
+	register int		page_shortage;
+	register int		s;
+	register int		pages_freed;
+	int			free;
+	vm_object_t		object;
+
+	/*
+	 *	Only continue when we want more pages to be "free"
+	 */
+
+	cnt.v_rev++;
+
+	s = splimp();
+	simple_lock(&vm_page_queue_free_lock);
+	free = cnt.v_free_count;
+	simple_unlock(&vm_page_queue_free_lock);
+	splx(s);
+
+	if (free < cnt.v_free_target) {
+		swapout_threads();
+
+		/*
+		 *	Be sure the pmap system is updated so
+		 *	we can scan the inactive queue.
+		 */
+
+		pmap_update();
+	}
+
+	/*
+	 *	Acquire the resident page system lock,
+	 *	as we may be changing what's resident quite a bit.
+	 */
+	vm_page_lock_queues();
+
+	/*
+	 *	Start scanning the inactive queue for pages we can free.
+	 *	We keep scanning until we have enough free pages or
+	 *	we have scanned through the entire queue.  If we
+	 *	encounter dirty pages, we start cleaning them.
+	 */
+
+	pages_freed = 0;
+	for (m = vm_page_queue_inactive.tqh_first; m != NULL; m = next) {
+		s = splimp();
+		simple_lock(&vm_page_queue_free_lock);
+		free = cnt.v_free_count;
+		simple_unlock(&vm_page_queue_free_lock);
+		splx(s);
+		if (free >= cnt.v_free_target)
+			break;
+
+		cnt.v_scan++;
+		next = m->pageq.tqe_next;
+
+		/*
+		 * If the page has been referenced, move it back to the
+		 * active queue.
+		 */
+		if (pmap_is_referenced(VM_PAGE_TO_PHYS(m))) {
+			vm_page_activate(m);
+			cnt.v_reactivated++;
+			continue;
+		}
+
+		/*
+		 * If the page is clean, free it up.
+		 */
+		if (m->flags & PG_CLEAN) {
+			object = m->object;
+			if (vm_object_lock_try(object)) {
+				pmap_page_protect(VM_PAGE_TO_PHYS(m),
+						  VM_PROT_NONE);
+				vm_page_free(m);
+				pages_freed++;
+				cnt.v_dfree++;
+				vm_object_unlock(object);
+			}
+			continue;
+		}
+
+		/*
+		 * If the page is dirty but already being washed, skip it.
+		 */
+		if ((m->flags & PG_LAUNDRY) == 0)
+			continue;
+
+		/*
+		 * Otherwise the page is dirty and still in the laundry,
+		 * so we start the cleaning operation and remove it from
+		 * the laundry.
+		 */
+		object = m->object;
+		if (!vm_object_lock_try(object))
+			continue;
+		cnt.v_pageouts++;
+#ifdef CLUSTERED_PAGEOUT
+		if (object->pager &&
+		    vm_pager_cancluster(object->pager, PG_CLUSTERPUT))
+			vm_pageout_cluster(m, object);
+		else
+#endif
+		vm_pageout_page(m, object);
+		thread_wakeup(object);
+		vm_object_unlock(object);
+		/*
+		 * Former next page may no longer even be on the inactive
+		 * queue (due to potential blocking in the pager with the
+		 * queues unlocked).  If it isn't, we just start over.
+		 */
+		if (next && (next->flags & PG_INACTIVE) == 0)
+			next = vm_page_queue_inactive.tqh_first;
+	}
+	
+	/*
+	 *	Compute the page shortage.  If we are still very low on memory
+	 *	be sure that we will move a minimal amount of pages from active
+	 *	to inactive.
+	 */
+
+	page_shortage = cnt.v_inactive_target - cnt.v_inactive_count;
+	if (page_shortage <= 0 && pages_freed == 0)
+		page_shortage = 1;
+
+	while (page_shortage > 0) {
+		/*
+		 *	Move some more pages from active to inactive.
+		 */
+
+		if ((m = vm_page_queue_active.tqh_first) == NULL)
+			break;
+		vm_page_deactivate(m);
+		page_shortage--;
+	}
+
+	vm_page_unlock_queues();
+}
+
+/*
+ * Called with object and page queues locked.
+ * If reactivate is TRUE, a pager error causes the page to be
+ * put back on the active queue, ow it is left on the inactive queue.
+ */
+void
+vm_pageout_page(m, object)
+	vm_page_t m;
+	vm_object_t object;
+{
+	vm_pager_t pager;
+	int pageout_status;
+
+	/*
+	 * We set the busy bit to cause potential page faults on
+	 * this page to block.
+	 *
+	 * We also set pageout-in-progress to keep the object from
+	 * disappearing during pageout.  This guarantees that the
+	 * page won't move from the inactive queue.  (However, any
+	 * other page on the inactive queue may move!)
+	 */
+	pmap_page_protect(VM_PAGE_TO_PHYS(m), VM_PROT_NONE);
+	m->flags |= PG_BUSY;
+
+	/*
+	 * Try to collapse the object before making a pager for it.
+	 * We must unlock the page queues first.
+	 */
+	vm_page_unlock_queues();
+	if (object->pager == NULL)
+		vm_object_collapse(object);
+
+	object->paging_in_progress++;
+	vm_object_unlock(object);
+
+	/*
+	 * Do a wakeup here in case the following operations block.
+	 */
+	thread_wakeup(&cnt.v_free_count);
+
+	/*
+	 * If there is no pager for the page, use the default pager.
+	 * If there is no place to put the page at the moment,
+	 * leave it in the laundry and hope that there will be
+	 * paging space later.
+	 */
+	if ((pager = object->pager) == NULL) {
+		pager = vm_pager_allocate(PG_DFLT, (caddr_t)0, object->size,
+					  VM_PROT_ALL, (vm_offset_t)0);
+		if (pager != NULL)
+			vm_object_setpager(object, pager, 0, FALSE);
+	}
+	pageout_status = pager ? vm_pager_put(pager, m, FALSE) : VM_PAGER_FAIL;
+	vm_object_lock(object);
+	vm_page_lock_queues();
+
+	switch (pageout_status) {
+	case VM_PAGER_OK:
+	case VM_PAGER_PEND:
+		cnt.v_pgpgout++;
+		m->flags &= ~PG_LAUNDRY;
+		break;
+	case VM_PAGER_BAD:
+		/*
+		 * Page outside of range of object.  Right now we
+		 * essentially lose the changes by pretending it
+		 * worked.
+		 *
+		 * XXX dubious, what should we do?
+		 */
+		m->flags &= ~PG_LAUNDRY;
+		m->flags |= PG_CLEAN;
+		pmap_clear_modify(VM_PAGE_TO_PHYS(m));
+		break;
+	case VM_PAGER_AGAIN:
+	{
+		extern int lbolt;
+
+		/*
+		 * FAIL on a write is interpreted to mean a resource
+		 * shortage, so we put pause for awhile and try again.
+		 * XXX could get stuck here.
+		 */
+		vm_page_unlock_queues();
+		vm_object_unlock(object);
+		(void) tsleep((caddr_t)&lbolt, PZERO|PCATCH, "pageout", 0);
+		vm_object_lock(object);
+		vm_page_lock_queues();
+		break;
+	}
+	case VM_PAGER_FAIL:
+	case VM_PAGER_ERROR:
+		/*
+		 * If page couldn't be paged out, then reactivate
+		 * the page so it doesn't clog the inactive list.
+		 * (We will try paging out it again later).
+		 */
+		vm_page_activate(m);
+		cnt.v_reactivated++;
+		break;
+	}
+
+	pmap_clear_reference(VM_PAGE_TO_PHYS(m));
+
+	/*
+	 * If the operation is still going, leave the page busy
+	 * to block all other accesses.  Also, leave the paging
+	 * in progress indicator set so that we don't attempt an
+	 * object collapse.
+	 */
+	if (pageout_status != VM_PAGER_PEND) {
+		m->flags &= ~PG_BUSY;
+		PAGE_WAKEUP(m);
+		object->paging_in_progress--;
+	}
+}
+
+#ifdef CLUSTERED_PAGEOUT
+#define PAGEOUTABLE(p) \
+	((((p)->flags & (PG_INACTIVE|PG_CLEAN|PG_LAUNDRY)) == \
+	  (PG_INACTIVE|PG_LAUNDRY)) && !pmap_is_referenced(VM_PAGE_TO_PHYS(p)))
+
+/*
+ * Attempt to pageout as many contiguous (to ``m'') dirty pages as possible
+ * from ``object''.  Using information returned from the pager, we assemble
+ * a sorted list of contiguous dirty pages and feed them to the pager in one
+ * chunk.  Called with paging queues and object locked.  Also, object must
+ * already have a pager.
+ */
+void
+vm_pageout_cluster(m, object)
+	vm_page_t m;
+	vm_object_t object;
+{
+	vm_offset_t offset, loff, hoff;
+	vm_page_t plist[MAXPOCLUSTER], *plistp, p;
+	int postatus, ix, count;
+
+	/*
+	 * Determine the range of pages that can be part of a cluster
+	 * for this object/offset.  If it is only our single page, just
+	 * do it normally.
+	 */
+	vm_pager_cluster(object->pager, m->offset, &loff, &hoff);
+	if (hoff - loff == PAGE_SIZE) {
+		vm_pageout_page(m, object);
+		return;
+	}
+
+	plistp = plist;
+
+	/*
+	 * Target page is always part of the cluster.
+	 */
+	pmap_page_protect(VM_PAGE_TO_PHYS(m), VM_PROT_NONE);
+	m->flags |= PG_BUSY;
+	plistp[atop(m->offset - loff)] = m;
+	count = 1;
+
+	/*
+	 * Backup from the given page til we find one not fulfilling
+	 * the pageout criteria or we hit the lower bound for the
+	 * cluster.  For each page determined to be part of the
+	 * cluster, unmap it and busy it out so it won't change.
+	 */
+	ix = atop(m->offset - loff);
+	offset = m->offset;
+	while (offset > loff && count < MAXPOCLUSTER-1) {
+		p = vm_page_lookup(object, offset - PAGE_SIZE);
+		if (p == NULL || !PAGEOUTABLE(p))
+			break;
+		pmap_page_protect(VM_PAGE_TO_PHYS(p), VM_PROT_NONE);
+		p->flags |= PG_BUSY;
+		plistp[--ix] = p;
+		offset -= PAGE_SIZE;
+		count++;
+	}
+	plistp += atop(offset - loff);
+	loff = offset;
+
+	/*
+	 * Now do the same moving forward from the target.
+	 */
+	ix = atop(m->offset - loff) + 1;
+	offset = m->offset + PAGE_SIZE;
+	while (offset < hoff && count < MAXPOCLUSTER) {
+		p = vm_page_lookup(object, offset);
+		if (p == NULL || !PAGEOUTABLE(p))
+			break;
+		pmap_page_protect(VM_PAGE_TO_PHYS(p), VM_PROT_NONE);
+		p->flags |= PG_BUSY;
+		plistp[ix++] = p;
+		offset += PAGE_SIZE;
+		count++;
+	}
+	hoff = offset;
+
+	/*
+	 * Pageout the page.
+	 * Unlock everything and do a wakeup prior to the pager call
+	 * in case it blocks.
+	 */
+	vm_page_unlock_queues();
+	object->paging_in_progress++;
+	vm_object_unlock(object);
+again:
+	thread_wakeup(&cnt.v_free_count);
+	postatus = vm_pager_put_pages(object->pager, plistp, count, FALSE);
+	/*
+	 * XXX rethink this
+	 */
+	if (postatus == VM_PAGER_AGAIN) {
+		extern int lbolt;
+
+		(void) tsleep((caddr_t)&lbolt, PZERO|PCATCH, "pageout", 0);
+		goto again;
+	} else if (postatus == VM_PAGER_BAD)
+		panic("vm_pageout_cluster: VM_PAGER_BAD");
+	vm_object_lock(object);
+	vm_page_lock_queues();
+
+	/*
+	 * Loop through the affected pages, reflecting the outcome of
+	 * the operation.
+	 */
+	for (ix = 0; ix < count; ix++) {
+		p = *plistp++;
+		switch (postatus) {
+		case VM_PAGER_OK:
+		case VM_PAGER_PEND:
+			cnt.v_pgpgout++;
+			p->flags &= ~PG_LAUNDRY;
+			break;
+		case VM_PAGER_FAIL:
+		case VM_PAGER_ERROR:
+			/*
+			 * Pageout failed, reactivate the target page so it
+			 * doesn't clog the inactive list.  Other pages are
+			 * left as they are.
+			 */
+			if (p == m) {
+				vm_page_activate(p);
+				cnt.v_reactivated++;
+			}
+			break;
+		}
+		pmap_clear_reference(VM_PAGE_TO_PHYS(p));
+		/*
+		 * If the operation is still going, leave the page busy
+		 * to block all other accesses.
+		 */
+		if (postatus != VM_PAGER_PEND) {
+			p->flags &= ~PG_BUSY;
+			PAGE_WAKEUP(p);
+
+		}
+	}
+	/*
+	 * If the operation is still going, leave the paging in progress
+	 * indicator set so that we don't attempt an object collapse.
+	 */
+	if (postatus != VM_PAGER_PEND)
+		object->paging_in_progress--;
+
+}
+#endif
+
+/*
+ *	vm_pageout is the high level pageout daemon.
+ */
+
+void
+vm_pageout()
+{
+	(void) spl0();
+
+	/*
+	 *	Initialize some paging parameters.
+	 */
+
+	if (cnt.v_free_min == 0) {
+		cnt.v_free_min = VM_PAGE_FREE_MIN;
+		vm_page_free_min_min /= cnt.v_page_size;
+		vm_page_free_min_max /= cnt.v_page_size;
+		if (cnt.v_free_min < vm_page_free_min_min)
+			cnt.v_free_min = vm_page_free_min_min;
+		if (cnt.v_free_min > vm_page_free_min_max)
+			cnt.v_free_min = vm_page_free_min_max;
+	}
+
+	if (cnt.v_free_target == 0)
+		cnt.v_free_target = VM_PAGE_FREE_TARGET;
+
+	if (cnt.v_free_target <= cnt.v_free_min)
+		cnt.v_free_target = cnt.v_free_min + 1;
+
+	/* XXX does not really belong here */
+	if (vm_page_max_wired == 0)
+		vm_page_max_wired = cnt.v_free_count / 3;
+
+	/*
+	 *	The pageout daemon is never done, so loop
+	 *	forever.
+	 */
+
+	simple_lock(&vm_pages_needed_lock);
+	while (TRUE) {
+		thread_sleep(&vm_pages_needed, &vm_pages_needed_lock, FALSE);
+		/*
+		 * Compute the inactive target for this scan.
+		 * We need to keep a reasonable amount of memory in the
+		 * inactive list to better simulate LRU behavior.
+		 */
+		cnt.v_inactive_target =
+			(cnt.v_active_count + cnt.v_inactive_count) / 3;
+		if (cnt.v_inactive_target <= cnt.v_free_target)
+			cnt.v_inactive_target = cnt.v_free_target + 1;
+
+		/*
+		 * Only make a scan if we are likely to do something.
+		 * Otherwise we might have been awakened by a pager
+		 * to clean up async pageouts.
+		 */
+		if (cnt.v_free_count < cnt.v_free_target ||
+		    cnt.v_inactive_count < cnt.v_inactive_target)
+			vm_pageout_scan();
+		vm_pager_sync();
+		simple_lock(&vm_pages_needed_lock);
+		thread_wakeup(&cnt.v_free_count);
+	}
+}

--- a/src-uland/libvm/vm_pager.c
+++ b/src-uland/libvm/vm_pager.c
@@ -1,0 +1,402 @@
+/* Copied from sys/vm/vm_pager.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_pager.c	8.7 (Berkeley) 7/7/94
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	Paging space routine stubs.  Emulates a matchmaker-like interface
+ *	for builtin pagers.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/malloc.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vm_kern.h>
+
+#ifdef SWAPPAGER
+extern struct pagerops swappagerops;
+#endif
+
+#ifdef VNODEPAGER
+extern struct pagerops vnodepagerops;
+#endif
+
+#ifdef DEVPAGER
+extern struct pagerops devicepagerops;
+#endif
+
+struct pagerops *pagertab[] = {
+#ifdef SWAPPAGER
+	&swappagerops,		/* PG_SWAP */
+#else
+	NULL,
+#endif
+#ifdef VNODEPAGER
+	&vnodepagerops,		/* PG_VNODE */
+#else
+	NULL,
+#endif
+#ifdef DEVPAGER
+	&devicepagerops,	/* PG_DEV */
+#else
+	NULL,
+#endif
+};
+int npagers = sizeof (pagertab) / sizeof (pagertab[0]);
+
+struct pagerops *dfltpagerops = NULL;	/* default pager */
+
+/*
+ * Kernel address space for mapping pages.
+ * Used by pagers where KVAs are needed for IO.
+ *
+ * XXX needs to be large enough to support the number of pending async
+ * cleaning requests (NPENDINGIO == 64) * the maximum swap cluster size
+ * (MAXPHYS == 64k) if you want to get the most efficiency.
+ */
+#define PAGER_MAP_SIZE	(4 * 1024 * 1024)
+
+vm_map_t pager_map;
+boolean_t pager_map_wanted;
+vm_offset_t pager_sva, pager_eva;
+
+void
+vm_pager_init()
+{
+	struct pagerops **pgops;
+
+	/*
+	 * Allocate a kernel submap for tracking get/put page mappings
+	 */
+	pager_map = kmem_suballoc(kernel_map, &pager_sva, &pager_eva,
+				  PAGER_MAP_SIZE, FALSE);
+	/*
+	 * Initialize known pagers
+	 */
+	for (pgops = pagertab; pgops < &pagertab[npagers]; pgops++)
+		if (pgops)
+			(*(*pgops)->pgo_init)();
+	if (dfltpagerops == NULL)
+		panic("no default pager");
+}
+
+/*
+ * Allocate an instance of a pager of the given type.
+ * Size, protection and offset parameters are passed in for pagers that
+ * need to perform page-level validation (e.g. the device pager).
+ */
+vm_pager_t
+vm_pager_allocate(type, handle, size, prot, off)
+	int type;
+	caddr_t handle;
+	vm_size_t size;
+	vm_prot_t prot;
+	vm_offset_t off;
+{
+	struct pagerops *ops;
+
+	ops = (type == PG_DFLT) ? dfltpagerops : pagertab[type];
+	if (ops)
+		return ((*ops->pgo_alloc)(handle, size, prot, off));
+	return (NULL);
+}
+
+void
+vm_pager_deallocate(pager)
+	vm_pager_t	pager;
+{
+	if (pager == NULL)
+		panic("vm_pager_deallocate: null pager");
+
+	(*pager->pg_ops->pgo_dealloc)(pager);
+}
+
+int
+vm_pager_get_pages(pager, mlist, npages, sync)
+	vm_pager_t	pager;
+	vm_page_t	*mlist;
+	int		npages;
+	boolean_t	sync;
+{
+	int rv;
+
+	if (pager == NULL) {
+		rv = VM_PAGER_OK;
+		while (npages--)
+			if (!vm_page_zero_fill(*mlist)) {
+				rv = VM_PAGER_FAIL;
+				break;
+			} else
+				mlist++;
+		return (rv);
+	}
+	return ((*pager->pg_ops->pgo_getpages)(pager, mlist, npages, sync));
+}
+
+int
+vm_pager_put_pages(pager, mlist, npages, sync)
+	vm_pager_t	pager;
+	vm_page_t	*mlist;
+	int		npages;
+	boolean_t	sync;
+{
+	if (pager == NULL)
+		panic("vm_pager_put_pages: null pager");
+	return ((*pager->pg_ops->pgo_putpages)(pager, mlist, npages, sync));
+}
+
+/* XXX compatibility*/
+int
+vm_pager_get(pager, m, sync)
+	vm_pager_t	pager;
+	vm_page_t	m;
+	boolean_t	sync;
+{
+	return vm_pager_get_pages(pager, &m, 1, sync);
+}
+
+/* XXX compatibility*/
+int
+vm_pager_put(pager, m, sync)
+	vm_pager_t	pager;
+	vm_page_t	m;
+	boolean_t	sync;
+{
+	return vm_pager_put_pages(pager, &m, 1, sync);
+}
+
+boolean_t
+vm_pager_has_page(pager, offset)
+	vm_pager_t	pager;
+	vm_offset_t	offset;
+{
+	if (pager == NULL)
+		panic("vm_pager_has_page: null pager");
+	return ((*pager->pg_ops->pgo_haspage)(pager, offset));
+}
+
+/*
+ * Called by pageout daemon before going back to sleep.
+ * Gives pagers a chance to clean up any completed async pageing operations.
+ */
+void
+vm_pager_sync()
+{
+	struct pagerops **pgops;
+
+	for (pgops = pagertab; pgops < &pagertab[npagers]; pgops++)
+		if (pgops)
+			(*(*pgops)->pgo_putpages)(NULL, NULL, 0, FALSE);
+}
+
+void
+vm_pager_cluster(pager, offset, loff, hoff)
+	vm_pager_t	pager;
+	vm_offset_t	offset;
+	vm_offset_t	*loff;
+	vm_offset_t	*hoff;
+{
+	if (pager == NULL)
+		panic("vm_pager_cluster: null pager");
+	((*pager->pg_ops->pgo_cluster)(pager, offset, loff, hoff));
+}
+
+void
+vm_pager_clusternull(pager, offset, loff, hoff)
+	vm_pager_t	pager;
+	vm_offset_t	offset;
+	vm_offset_t	*loff;
+	vm_offset_t	*hoff;
+{
+	panic("vm_pager_nullcluster called");
+}
+
+vm_offset_t
+vm_pager_map_pages(mlist, npages, canwait)
+	vm_page_t	*mlist;
+	int		npages;
+	boolean_t	canwait;
+{
+	vm_offset_t kva, va;
+	vm_size_t size;
+	vm_page_t m;
+
+	/*
+	 * Allocate space in the pager map, if none available return 0.
+	 * This is basically an expansion of kmem_alloc_wait with optional
+	 * blocking on no space.
+	 */
+	size = npages * PAGE_SIZE;
+	vm_map_lock(pager_map);
+	while (vm_map_findspace(pager_map, 0, size, &kva)) {
+		if (!canwait) {
+			vm_map_unlock(pager_map);
+			return (0);
+		}
+		pager_map_wanted = TRUE;
+		vm_map_unlock(pager_map);
+		(void) tsleep(pager_map, PVM, "pager_map", 0);
+		vm_map_lock(pager_map);
+	}
+	vm_map_insert(pager_map, NULL, 0, kva, kva + size);
+	vm_map_unlock(pager_map);
+
+	for (va = kva; npages--; va += PAGE_SIZE) {
+		m = *mlist++;
+#ifdef DEBUG
+		if ((m->flags & PG_BUSY) == 0)
+			panic("vm_pager_map_pages: page not busy");
+		if (m->flags & PG_PAGEROWNED)
+			panic("vm_pager_map_pages: page already in pager");
+#endif
+#ifdef DEBUG
+		m->flags |= PG_PAGEROWNED;
+#endif
+		pmap_enter(vm_map_pmap(pager_map), va, VM_PAGE_TO_PHYS(m),
+			   VM_PROT_DEFAULT, TRUE);
+	}
+	return (kva);
+}
+
+void
+vm_pager_unmap_pages(kva, npages)
+	vm_offset_t	kva;
+	int		npages;
+{
+	vm_size_t size = npages * PAGE_SIZE;
+
+#ifdef DEBUG
+	vm_offset_t va;
+	vm_page_t m;
+	int np = npages;
+
+	for (va = kva; np--; va += PAGE_SIZE) {
+		m = vm_pager_atop(va);
+		if (m->flags & PG_PAGEROWNED)
+			m->flags &= ~PG_PAGEROWNED;
+		else
+			printf("vm_pager_unmap_pages: %x(%x/%x) not owned\n",
+			       m, va, VM_PAGE_TO_PHYS(m));
+	}
+#endif
+	pmap_remove(vm_map_pmap(pager_map), kva, kva + size);
+	vm_map_lock(pager_map);
+	(void) vm_map_delete(pager_map, kva, kva + size);
+	if (pager_map_wanted)
+		wakeup(pager_map);
+	vm_map_unlock(pager_map);
+}
+
+vm_page_t
+vm_pager_atop(kva)
+	vm_offset_t	kva;
+{
+	vm_offset_t pa;
+
+	pa = pmap_extract(vm_map_pmap(pager_map), kva);
+	if (pa == 0)
+		panic("vm_pager_atop");
+	return (PHYS_TO_VM_PAGE(pa));
+}
+
+vm_pager_t
+vm_pager_lookup(pglist, handle)
+	register struct pagerlst *pglist;
+	caddr_t handle;
+{
+	register vm_pager_t pager;
+
+	for (pager = pglist->tqh_first; pager; pager = pager->pg_list.tqe_next)
+		if (pager->pg_handle == handle)
+			return (pager);
+	return (NULL);
+}
+
+/*
+ * This routine gains a reference to the object.
+ * Explicit deallocation is necessary.
+ */
+int
+pager_cache(object, should_cache)
+	vm_object_t	object;
+	boolean_t	should_cache;
+{
+	if (object == NULL)
+		return (KERN_INVALID_ARGUMENT);
+
+	vm_object_cache_lock();
+	vm_object_lock(object);
+	if (should_cache)
+		object->flags |= OBJ_CANPERSIST;
+	else
+		object->flags &= ~OBJ_CANPERSIST;
+	vm_object_unlock(object);
+	vm_object_cache_unlock();
+
+	vm_object_deallocate(object);
+
+	return (KERN_SUCCESS);
+}

--- a/src-uland/libvm/vm_swap.c
+++ b/src-uland/libvm/vm_swap.c
@@ -1,0 +1,428 @@
+/* Copied from sys/vm/vm_swap.c */
+/*
+ * Copyright (c) 1982, 1986, 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_swap.c	8.5 (Berkeley) 2/17/94
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/buf.h>
+#include <sys/conf.h>
+#include <sys/proc.h>
+#include <sys/namei.h>
+#include <sys/dmap.h>		/* XXX */
+#include <sys/vnode.h>
+#include <sys/map.h>
+#include <sys/file.h>
+
+#include <miscfs/specfs/specdev.h>
+
+/*
+ * Indirect driver for multi-controller paging.
+ */
+
+int	nswap, nswdev;
+#ifdef SEQSWAP
+int	niswdev;		/* number of interleaved swap devices */
+int	niswap;			/* size of interleaved swap area */
+#endif
+
+/*
+ * Set up swap devices.
+ * Initialize linked list of free swap
+ * headers. These do not actually point
+ * to buffers, but rather to pages that
+ * are being swapped in and out.
+ */
+void
+swapinit()
+{
+	register int i;
+	register struct buf *sp = swbuf;
+	register struct proc *p = &proc0;	/* XXX */
+	struct swdevt *swp;
+	int error;
+
+	/*
+	 * Count swap devices, and adjust total swap space available.
+	 * Some of the space will not be countable until later (dynamically
+	 * configurable devices) and some of the counted space will not be
+	 * available until a swapon() system call is issued, both usually
+	 * happen when the system goes multi-user.
+	 *
+	 * If using NFS for swap, swdevt[0] will already be bdevvp'd.	XXX
+	 */
+#ifdef SEQSWAP
+	nswdev = niswdev = 0;
+	nswap = niswap = 0;
+	/*
+	 * All interleaved devices must come first
+	 */
+	for (swp = swdevt; swp->sw_dev != NODEV || swp->sw_vp != NULL; swp++) {
+		if (swp->sw_flags & SW_SEQUENTIAL)
+			break;
+		niswdev++;
+		if (swp->sw_nblks > niswap)
+			niswap = swp->sw_nblks;
+	}
+	niswap = roundup(niswap, dmmax);
+	niswap *= niswdev;
+	if (swdevt[0].sw_vp == NULL &&
+	    bdevvp(swdevt[0].sw_dev, &swdevt[0].sw_vp))
+		panic("swapvp");
+	/*
+	 * The remainder must be sequential
+	 */
+	for ( ; swp->sw_dev != NODEV; swp++) {
+		if ((swp->sw_flags & SW_SEQUENTIAL) == 0)
+			panic("binit: mis-ordered swap devices");
+		nswdev++;
+		if (swp->sw_nblks > 0) {
+			if (swp->sw_nblks % dmmax)
+				swp->sw_nblks -= (swp->sw_nblks % dmmax);
+			nswap += swp->sw_nblks;
+		}
+	}
+	nswdev += niswdev;
+	if (nswdev == 0)
+		panic("swapinit");
+	nswap += niswap;
+#else
+	nswdev = 0;
+	nswap = 0;
+	for (swp = swdevt; swp->sw_dev != NODEV || swp->sw_vp != NULL; swp++) {
+		nswdev++;
+		if (swp->sw_nblks > nswap)
+			nswap = swp->sw_nblks;
+	}
+	if (nswdev == 0)
+		panic("swapinit");
+	if (nswdev > 1)
+		nswap = ((nswap + dmmax - 1) / dmmax) * dmmax;
+	nswap *= nswdev;
+	if (swdevt[0].sw_vp == NULL &&
+	    bdevvp(swdevt[0].sw_dev, &swdevt[0].sw_vp))
+		panic("swapvp");
+#endif
+	if (nswap == 0)
+		printf("WARNING: no swap space found\n");
+	else if (error = swfree(p, 0)) {
+		printf("swfree errno %d\n", error);	/* XXX */
+		panic("swapinit swfree 0");
+	}
+
+	/*
+	 * Now set up swap buffer headers.
+	 */
+	bswlist.b_actf = sp;
+	for (i = 0; i < nswbuf - 1; i++, sp++) {
+		sp->b_actf = sp + 1;
+		sp->b_rcred = sp->b_wcred = p->p_ucred;
+		sp->b_vnbufs.le_next = NOLIST;
+	}
+	sp->b_rcred = sp->b_wcred = p->p_ucred;
+	sp->b_vnbufs.le_next = NOLIST;
+	sp->b_actf = NULL;
+}
+
+void
+swstrategy(bp)
+	register struct buf *bp;
+{
+	int sz, off, seg, index;
+	register struct swdevt *sp;
+	struct vnode *vp;
+
+#ifdef GENERIC
+	/*
+	 * A mini-root gets copied into the front of the swap
+	 * and we run over top of the swap area just long
+	 * enough for us to do a mkfs and restor of the real
+	 * root (sure beats rewriting standalone restor).
+	 */
+#define	MINIROOTSIZE	4096
+	if (rootdev == dumpdev)
+		bp->b_blkno += MINIROOTSIZE;
+#endif
+	sz = howmany(bp->b_bcount, DEV_BSIZE);
+	if (bp->b_blkno + sz > nswap) {
+		bp->b_error = EINVAL;
+		bp->b_flags |= B_ERROR;
+		biodone(bp);
+		return;
+	}
+	if (nswdev > 1) {
+#ifdef SEQSWAP
+		if (bp->b_blkno < niswap) {
+			if (niswdev > 1) {
+				off = bp->b_blkno % dmmax;
+				if (off+sz > dmmax) {
+					bp->b_error = EINVAL;
+					bp->b_flags |= B_ERROR;
+					biodone(bp);
+					return;
+				}
+				seg = bp->b_blkno / dmmax;
+				index = seg % niswdev;
+				seg /= niswdev;
+				bp->b_blkno = seg*dmmax + off;
+			} else
+				index = 0;
+		} else {
+			register struct swdevt *swp;
+
+			bp->b_blkno -= niswap;
+			for (index = niswdev, swp = &swdevt[niswdev];
+			     swp->sw_dev != NODEV;
+			     swp++, index++) {
+				if (bp->b_blkno < swp->sw_nblks)
+					break;
+				bp->b_blkno -= swp->sw_nblks;
+			}
+			if (swp->sw_dev == NODEV ||
+			    bp->b_blkno+sz > swp->sw_nblks) {
+				bp->b_error = swp->sw_dev == NODEV ?
+					ENODEV : EINVAL;
+				bp->b_flags |= B_ERROR;
+				biodone(bp);
+				return;
+			}
+		}
+#else
+		off = bp->b_blkno % dmmax;
+		if (off+sz > dmmax) {
+			bp->b_error = EINVAL;
+			bp->b_flags |= B_ERROR;
+			biodone(bp);
+			return;
+		}
+		seg = bp->b_blkno / dmmax;
+		index = seg % nswdev;
+		seg /= nswdev;
+		bp->b_blkno = seg*dmmax + off;
+#endif
+	} else
+		index = 0;
+	sp = &swdevt[index];
+	if ((bp->b_dev = sp->sw_dev) == NODEV)
+		panic("swstrategy");
+	if (sp->sw_vp == NULL) {
+		bp->b_error = ENODEV;
+		bp->b_flags |= B_ERROR;
+		biodone(bp);
+		return;
+	}
+	VHOLD(sp->sw_vp);
+	if ((bp->b_flags & B_READ) == 0) {
+		if (vp = bp->b_vp) {
+			vp->v_numoutput--;
+			if ((vp->v_flag & VBWAIT) && vp->v_numoutput <= 0) {
+				vp->v_flag &= ~VBWAIT;
+				wakeup((caddr_t)&vp->v_numoutput);
+			}
+		}
+		sp->sw_vp->v_numoutput++;
+	}
+	if (bp->b_vp != NULL)
+		brelvp(bp);
+	bp->b_vp = sp->sw_vp;
+	VOP_STRATEGY(bp);
+}
+
+/*
+ * System call swapon(name) enables swapping on device name,
+ * which must be in the swdevsw.  Return EBUSY
+ * if already swapping on this device.
+ */
+struct swapon_args {
+	char	*name;
+};
+/* ARGSUSED */
+int
+swapon(p, uap, retval)
+	struct proc *p;
+	struct swapon_args *uap;
+	int *retval;
+{
+	register struct vnode *vp;
+	register struct swdevt *sp;
+	dev_t dev;
+	int error;
+	struct nameidata nd;
+
+	if (error = suser(p->p_ucred, &p->p_acflag))
+		return (error);
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, uap->name, p);
+	if (error = namei(&nd))
+		return (error);
+	vp = nd.ni_vp;
+	if (vp->v_type != VBLK) {
+		vrele(vp);
+		return (ENOTBLK);
+	}
+	dev = (dev_t)vp->v_rdev;
+	if (major(dev) >= nblkdev) {
+		vrele(vp);
+		return (ENXIO);
+	}
+	for (sp = &swdevt[0]; sp->sw_dev != NODEV; sp++) {
+		if (sp->sw_dev == dev) {
+			if (sp->sw_flags & SW_FREED) {
+				vrele(vp);
+				return (EBUSY);
+			}
+			sp->sw_vp = vp;
+			if (error = swfree(p, sp - swdevt)) {
+				vrele(vp);
+				return (error);
+			}
+			return (0);
+		}
+#ifdef SEQSWAP
+		/*
+		 * If we have reached a non-freed sequential device without
+		 * finding what we are looking for, it is an error.
+		 * That is because all interleaved devices must come first
+		 * and sequential devices must be freed in order.
+		 */
+		if ((sp->sw_flags & (SW_SEQUENTIAL|SW_FREED)) == SW_SEQUENTIAL)
+			break;
+#endif
+	}
+	vrele(vp);
+	return (EINVAL);
+}
+
+/*
+ * Swfree(index) frees the index'th portion of the swap map.
+ * Each of the nswdev devices provides 1/nswdev'th of the swap
+ * space, which is laid out with blocks of dmmax pages circularly
+ * among the devices.
+ */
+int
+swfree(p, index)
+	struct proc *p;
+	int index;
+{
+	register struct swdevt *sp;
+	register swblk_t vsbase;
+	register long blk;
+	struct vnode *vp;
+	register swblk_t dvbase;
+	register int nblks;
+	int error;
+
+	sp = &swdevt[index];
+	vp = sp->sw_vp;
+	if (error = VOP_OPEN(vp, FREAD|FWRITE, p->p_ucred, p))
+		return (error);
+	sp->sw_flags |= SW_FREED;
+	nblks = sp->sw_nblks;
+	/*
+	 * Some devices may not exist til after boot time.
+	 * If so, their nblk count will be 0.
+	 */
+	if (nblks <= 0) {
+		int perdev;
+		dev_t dev = sp->sw_dev;
+
+		if (bdevsw[major(dev)].d_psize == 0 ||
+		    (nblks = (*bdevsw[major(dev)].d_psize)(dev)) == -1) {
+			(void) VOP_CLOSE(vp, FREAD|FWRITE, p->p_ucred, p);
+			sp->sw_flags &= ~SW_FREED;
+			return (ENXIO);
+		}
+#ifdef SEQSWAP
+		if (index < niswdev) {
+			perdev = niswap / niswdev;
+			if (nblks > perdev)
+				nblks = perdev;
+		} else {
+			if (nblks % dmmax)
+				nblks -= (nblks % dmmax);
+			nswap += nblks;
+		}
+#else
+		perdev = nswap / nswdev;
+		if (nblks > perdev)
+			nblks = perdev;
+#endif
+		sp->sw_nblks = nblks;
+	}
+	if (nblks == 0) {
+		(void) VOP_CLOSE(vp, FREAD|FWRITE, p->p_ucred, p);
+		sp->sw_flags &= ~SW_FREED;
+		return (0);	/* XXX error? */
+	}
+#ifdef SEQSWAP
+	if (sp->sw_flags & SW_SEQUENTIAL) {
+		register struct swdevt *swp;
+
+		blk = niswap;
+		for (swp = &swdevt[niswdev]; swp != sp; swp++)
+			blk += swp->sw_nblks;
+		rmfree(swapmap, nblks, blk);
+		return (0);
+	}
+#endif
+	for (dvbase = 0; dvbase < nblks; dvbase += dmmax) {
+		blk = nblks - dvbase;
+#ifdef SEQSWAP
+		if ((vsbase = index*dmmax + dvbase*niswdev) >= niswap)
+			panic("swfree");
+#else
+		if ((vsbase = index*dmmax + dvbase*nswdev) >= nswap)
+			panic("swfree");
+#endif
+		if (blk > dmmax)
+			blk = dmmax;
+		if (vsbase == 0) {
+			/*
+			 * First of all chunks... initialize the swapmap.
+			 * Don't use the first cluster of the device
+			 * in case it starts with a label or boot block.
+			 */
+			rminit(swapmap, blk - ctod(CLSIZE),
+			    vsbase + ctod(CLSIZE), "swap", nswapmap);
+		} else if (dvbase == 0) {
+			/*
+			 * Don't use the first cluster of the device
+			 * in case it starts with a label or boot block.
+			 */
+			rmfree(swapmap, blk - ctod(CLSIZE),
+			    vsbase + ctod(CLSIZE));
+		} else
+			rmfree(swapmap, blk, vsbase);
+	}
+	return (0);
+}

--- a/src-uland/libvm/vm_unix.c
+++ b/src-uland/libvm/vm_unix.c
@@ -1,0 +1,138 @@
+/* Copied from sys/vm/vm_unix.c */
+/*
+ * Copyright (c) 1988 University of Utah.
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * the Systems Programming Group of the University of Utah Computer
+ * Science Department.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * from: Utah $Hdr: vm_unix.c 1.1 89/11/07$
+ *
+ *	@(#)vm_unix.c	8.2 (Berkeley) 1/9/95
+ */
+
+/*
+ * Traditional sbrk/grow interface to VM
+ */
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/resourcevar.h>
+
+#include <vm/vm.h>
+
+struct obreak_args {
+	char	*nsiz;
+};
+/* ARGSUSED */
+int
+obreak(p, uap, retval)
+	struct proc *p;
+	struct obreak_args *uap;
+	int *retval;
+{
+	register struct vmspace *vm = p->p_vmspace;
+	vm_offset_t new, old;
+	int rv;
+	register int diff;
+
+	old = (vm_offset_t)vm->vm_daddr;
+	new = round_page(uap->nsiz);
+	if ((int)(new - old) > p->p_rlimit[RLIMIT_DATA].rlim_cur)
+		return(ENOMEM);
+	old = round_page(old + ctob(vm->vm_dsize));
+	diff = new - old;
+	if (diff > 0) {
+		rv = vm_allocate(&vm->vm_map, &old, diff, FALSE);
+		if (rv != KERN_SUCCESS) {
+			uprintf("sbrk: grow failed, return = %d\n", rv);
+			return(ENOMEM);
+		}
+		vm->vm_dsize += btoc(diff);
+	} else if (diff < 0) {
+		diff = -diff;
+		rv = vm_deallocate(&vm->vm_map, new, diff);
+		if (rv != KERN_SUCCESS) {
+			uprintf("sbrk: shrink failed, return = %d\n", rv);
+			return(ENOMEM);
+		}
+		vm->vm_dsize -= btoc(diff);
+	}
+	return(0);
+}
+
+/*
+ * Enlarge the "stack segment" to include the specified
+ * stack pointer for the process.
+ */
+int
+grow(p, sp)
+	struct proc *p;
+	vm_offset_t sp;
+{
+	register struct vmspace *vm = p->p_vmspace;
+	register int si;
+
+	/*
+	 * For user defined stacks (from sendsig).
+	 */
+	if (sp < (vm_offset_t)vm->vm_maxsaddr)
+		return (0);
+	/*
+	 * For common case of already allocated (from trap).
+	 */
+	if (sp >= USRSTACK - ctob(vm->vm_ssize))
+		return (1);
+	/*
+	 * Really need to check vs limit and increment stack size if ok.
+	 */
+	si = clrnd(btoc(USRSTACK-sp) - vm->vm_ssize);
+	if (vm->vm_ssize + si > btoc(p->p_rlimit[RLIMIT_STACK].rlim_cur))
+		return (0);
+	vm->vm_ssize += si;
+	return (1);
+}
+
+struct ovadvise_args {
+	int	anom;
+};
+/* ARGSUSED */
+int
+ovadvise(p, uap, retval)
+	struct proc *p;
+	struct ovadvise_args *uap;
+	int *retval;
+{
+
+	return (EINVAL);
+}

--- a/src-uland/libvm/vm_user.c
+++ b/src-uland/libvm/vm_user.c
@@ -1,0 +1,313 @@
+/* Copied from sys/vm/vm_user.c */
+/* 
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * The Mach Operating System project at Carnegie-Mellon University.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vm_user.c	8.2 (Berkeley) 1/12/94
+ *
+ *
+ * Copyright (c) 1987, 1990 Carnegie-Mellon University.
+ * All rights reserved.
+ *
+ * Authors: Avadis Tevanian, Jr., Michael Wayne Young
+ * 
+ * Permission to use, copy, modify and distribute this software and
+ * its documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" 
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND 
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie the
+ * rights to redistribute these changes.
+ */
+
+/*
+ *	User-exported virtual memory functions.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+
+#include <vm/vm.h>
+
+simple_lock_data_t	vm_alloc_lock;	/* XXX */
+
+#ifdef MACHVMCOMPAT
+/*
+ * BSD style syscall interfaces to MACH calls
+ * All return MACH return values.
+ */
+struct svm_allocate_args {
+	vm_map_t map;
+	vm_offset_t *addr;
+	vm_size_t size;
+	boolean_t anywhere;
+};
+/* ARGSUSED */
+int
+svm_allocate(p, uap, retval)
+	struct proc *p;
+	struct svm_allocate_args *uap;
+	int *retval;
+{
+	vm_offset_t addr;
+	int rv;
+
+	uap->map = p->p_map;		/* XXX */
+
+	if (copyin((caddr_t)uap->addr, (caddr_t)&addr, sizeof (addr)))
+		rv = KERN_INVALID_ARGUMENT;
+	else
+		rv = vm_allocate(uap->map, &addr, uap->size, uap->anywhere);
+	if (rv == KERN_SUCCESS) {
+		if (copyout((caddr_t)&addr, (caddr_t)uap->addr, sizeof(addr)))
+			rv = KERN_INVALID_ARGUMENT;
+	}
+	return((int)rv);
+}
+
+struct svm_deallocate_args {
+	vm_map_t map;
+	vm_offset_t addr;
+	vm_size_t size;
+};
+/* ARGSUSED */
+int
+svm_deallocate(p, uap, retval)
+	struct proc *p;
+	struct svm_deallocate_args *uap;
+	int *retval;
+{
+	int rv;
+
+	uap->map = p->p_map;		/* XXX */
+	rv = vm_deallocate(uap->map, uap->addr, uap->size);
+	return((int)rv);
+}
+
+struct svm_inherit_args {
+	vm_map_t map;
+	vm_offset_t addr;
+	vm_size_t size;
+	vm_inherit_t inherit;
+};
+/* ARGSUSED */
+int
+svm_inherit(p, uap, retval)
+	struct proc *p;
+	struct svm_inherit_args *uap;
+	int *retval;
+{
+	int rv;
+
+	uap->map = p->p_map;		/* XXX */
+	rv = vm_inherit(uap->map, uap->addr, uap->size, uap->inherit);
+	return((int)rv);
+}
+
+struct svm_protect_args {
+	vm_map_t map;
+	vm_offset_t addr;
+	vm_size_t size;
+	boolean_t setmax;
+	vm_prot_t prot;
+};
+/* ARGSUSED */
+int
+svm_protect(p, uap, retval)
+	struct proc *p;
+	struct svm_protect_args *uap;
+	int *retval;
+{
+	int rv;
+
+	uap->map = p->p_map;		/* XXX */
+	rv = vm_protect(uap->map, uap->addr, uap->size, uap->setmax, uap->prot);
+	return((int)rv);
+}
+
+/*
+ *	vm_inherit sets the inheritence of the specified range in the
+ *	specified map.
+ */
+int
+vm_inherit(map, start, size, new_inheritance)
+	register vm_map_t	map;
+	vm_offset_t		start;
+	vm_size_t		size;
+	vm_inherit_t		new_inheritance;
+{
+	if (map == NULL)
+		return(KERN_INVALID_ARGUMENT);
+
+	return(vm_map_inherit(map, trunc_page(start), round_page(start+size), new_inheritance));
+}
+
+/*
+ *	vm_protect sets the protection of the specified range in the
+ *	specified map.
+ */
+
+int
+vm_protect(map, start, size, set_maximum, new_protection)
+	register vm_map_t	map;
+	vm_offset_t		start;
+	vm_size_t		size;
+	boolean_t		set_maximum;
+	vm_prot_t		new_protection;
+{
+	if (map == NULL)
+		return(KERN_INVALID_ARGUMENT);
+
+	return(vm_map_protect(map, trunc_page(start), round_page(start+size), new_protection, set_maximum));
+}
+#endif
+
+/*
+ *	vm_allocate allocates "zero fill" memory in the specfied
+ *	map.
+ */
+int
+vm_allocate(map, addr, size, anywhere)
+	register vm_map_t	map;
+	register vm_offset_t	*addr;
+	register vm_size_t	size;
+	boolean_t		anywhere;
+{
+	int	result;
+
+	if (map == NULL)
+		return(KERN_INVALID_ARGUMENT);
+	if (size == 0) {
+		*addr = 0;
+		return(KERN_SUCCESS);
+	}
+
+	if (anywhere)
+		*addr = vm_map_min(map);
+	else
+		*addr = trunc_page(*addr);
+	size = round_page(size);
+
+	result = vm_map_find(map, NULL, (vm_offset_t) 0, addr, size, anywhere);
+
+	return(result);
+}
+
+/*
+ *	vm_deallocate deallocates the specified range of addresses in the
+ *	specified address map.
+ */
+int
+vm_deallocate(map, start, size)
+	register vm_map_t	map;
+	vm_offset_t		start;
+	vm_size_t		size;
+{
+	if (map == NULL)
+		return(KERN_INVALID_ARGUMENT);
+
+	if (size == (vm_offset_t) 0)
+		return(KERN_SUCCESS);
+
+	return(vm_map_remove(map, trunc_page(start), round_page(start+size)));
+}
+
+/*
+ * Similar to vm_allocate but assigns an explicit pager.
+ */
+int
+vm_allocate_with_pager(map, addr, size, anywhere, pager, poffset, internal)
+	register vm_map_t	map;
+	register vm_offset_t	*addr;
+	register vm_size_t	size;
+	boolean_t		anywhere;
+	vm_pager_t		pager;
+	vm_offset_t		poffset;
+	boolean_t		internal;
+{
+	register vm_object_t	object;
+	register int		result;
+
+	if (map == NULL)
+		return(KERN_INVALID_ARGUMENT);
+
+	*addr = trunc_page(*addr);
+	size = round_page(size);
+
+	/*
+	 *	Lookup the pager/paging-space in the object cache.
+	 *	If it's not there, then create a new object and cache
+	 *	it.
+	 */
+	object = vm_object_lookup(pager);
+	cnt.v_lookups++;
+	if (object == NULL) {
+		object = vm_object_allocate(size);
+		/*
+		 * From Mike Hibler: "unnamed anonymous objects should never
+		 * be on the hash list ... For now you can just change
+		 * vm_allocate_with_pager to not do vm_object_enter if this
+		 * is an internal object ..."
+		 */
+		if (!internal)
+			vm_object_enter(object, pager);
+	} else
+		cnt.v_hits++;
+	if (internal)
+		object->flags |= OBJ_INTERNAL;
+	else {
+		object->flags &= ~OBJ_INTERNAL;
+		cnt.v_nzfod -= atop(size);
+	}
+
+	result = vm_map_find(map, object, poffset, addr, size, anywhere);
+	if (result != KERN_SUCCESS)
+		vm_object_deallocate(object);
+	else if (pager != NULL)
+		vm_object_setpager(object, pager, (vm_offset_t) 0, TRUE);
+	return(result);
+}

--- a/src-uland/libvm/vnode_pager.c
+++ b/src-uland/libvm/vnode_pager.c
@@ -1,0 +1,583 @@
+/* Copied from sys/vm/vnode_pager.c */
+/*
+ * Copyright (c) 1990 University of Utah.
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * the Systems Programming Group of the University of Utah Computer
+ * Science Department.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vnode_pager.c	8.10 (Berkeley) 5/14/95
+ */
+
+/*
+ * Page to/from files (vnodes).
+ *
+ * TODO:
+ *	pageouts
+ *	fix credential use (uses current process credentials now)
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/malloc.h>
+#include <sys/vnode.h>
+#include <sys/uio.h>
+#include <sys/mount.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+#include <vm/vnode_pager.h>
+
+struct pagerlst	vnode_pager_list;	/* list of managed vnodes */
+
+#ifdef DEBUG
+int	vpagerdebug = 0x00;
+#define	VDB_FOLLOW	0x01
+#define VDB_INIT	0x02
+#define VDB_IO		0x04
+#define VDB_FAIL	0x08
+#define VDB_ALLOC	0x10
+#define VDB_SIZE	0x20
+#endif
+
+static vm_pager_t	 vnode_pager_alloc
+			    __P((caddr_t, vm_size_t, vm_prot_t, vm_offset_t));
+static void		 vnode_pager_cluster
+			    __P((vm_pager_t, vm_offset_t,
+				 vm_offset_t *, vm_offset_t *));
+static void		 vnode_pager_dealloc __P((vm_pager_t));
+static int		 vnode_pager_getpage
+			    __P((vm_pager_t, vm_page_t *, int, boolean_t));
+static boolean_t	 vnode_pager_haspage __P((vm_pager_t, vm_offset_t));
+static void		 vnode_pager_init __P((void));
+static int		 vnode_pager_io
+			    __P((vn_pager_t, vm_page_t *, int,
+				 boolean_t, enum uio_rw));
+static boolean_t	 vnode_pager_putpage
+			    __P((vm_pager_t, vm_page_t *, int, boolean_t));
+
+struct pagerops vnodepagerops = {
+	vnode_pager_init,
+	vnode_pager_alloc,
+	vnode_pager_dealloc,
+	vnode_pager_getpage,
+	vnode_pager_putpage,
+	vnode_pager_haspage,
+	vnode_pager_cluster
+};
+
+static void
+vnode_pager_init()
+{
+#ifdef DEBUG
+	if (vpagerdebug & VDB_FOLLOW)
+		printf("vnode_pager_init()\n");
+#endif
+	TAILQ_INIT(&vnode_pager_list);
+}
+
+/*
+ * Allocate (or lookup) pager for a vnode.
+ * Handle is a vnode pointer.
+ */
+static vm_pager_t
+vnode_pager_alloc(handle, size, prot, foff)
+	caddr_t handle;
+	vm_size_t size;
+	vm_prot_t prot;
+	vm_offset_t foff;
+{
+	register vm_pager_t pager;
+	register vn_pager_t vnp;
+	vm_object_t object;
+	struct vattr vattr;
+	struct vnode *vp;
+	struct proc *p = curproc;	/* XXX */
+
+#ifdef DEBUG
+	if (vpagerdebug & (VDB_FOLLOW|VDB_ALLOC))
+		printf("vnode_pager_alloc(%x, %x, %x)\n", handle, size, prot);
+#endif
+	/*
+	 * Pageout to vnode, no can do yet.
+	 */
+	if (handle == NULL)
+		return(NULL);
+
+	/*
+	 * Vnodes keep a pointer to any associated pager so no need to
+	 * lookup with vm_pager_lookup.
+	 */
+	vp = (struct vnode *)handle;
+	pager = (vm_pager_t)vp->v_vmdata;
+	if (pager == NULL) {
+		/*
+		 * Allocate pager structures
+		 */
+		pager = (vm_pager_t)malloc(sizeof *pager, M_VMPAGER, M_WAITOK);
+		if (pager == NULL)
+			return(NULL);
+		vnp = (vn_pager_t)malloc(sizeof *vnp, M_VMPGDATA, M_WAITOK);
+		if (vnp == NULL) {
+			free((caddr_t)pager, M_VMPAGER);
+			return(NULL);
+		}
+		/*
+		 * And an object of the appropriate size
+		 */
+		if (VOP_GETATTR(vp, &vattr, p->p_ucred, p) == 0) {
+			object = vm_object_allocate(round_page(vattr.va_size));
+			vm_object_enter(object, pager);
+			vm_object_setpager(object, pager, 0, TRUE);
+		} else {
+			free((caddr_t)vnp, M_VMPGDATA);
+			free((caddr_t)pager, M_VMPAGER);
+			return(NULL);
+		}
+		/*
+		 * Hold a reference to the vnode and initialize pager data.
+		 */
+		VREF(vp);
+		vnp->vnp_flags = 0;
+		vnp->vnp_vp = vp;
+		vnp->vnp_size = vattr.va_size;
+		TAILQ_INSERT_TAIL(&vnode_pager_list, pager, pg_list);
+		pager->pg_handle = handle;
+		pager->pg_type = PG_VNODE;
+		pager->pg_flags = 0;
+		pager->pg_ops = &vnodepagerops;
+		pager->pg_data = vnp;
+		vp->v_vmdata = (caddr_t)pager;
+	} else {
+		/*
+		 * vm_object_lookup() will remove the object from the
+		 * cache if found and also gain a reference to the object.
+		 */
+		object = vm_object_lookup(pager);
+#ifdef DEBUG
+		vnp = (vn_pager_t)pager->pg_data;
+#endif
+	}
+#ifdef DEBUG
+	if (vpagerdebug & VDB_ALLOC)
+		printf("vnode_pager_setup: vp %x sz %x pager %x object %x\n",
+		       vp, vnp->vnp_size, pager, object);
+#endif
+	return(pager);
+}
+
+static void
+vnode_pager_dealloc(pager)
+	vm_pager_t pager;
+{
+	register vn_pager_t vnp = (vn_pager_t)pager->pg_data;
+	register struct vnode *vp;
+#ifdef NOTDEF
+	struct proc *p = curproc;		/* XXX */
+#endif
+
+#ifdef DEBUG
+	if (vpagerdebug & VDB_FOLLOW)
+		printf("vnode_pager_dealloc(%x)\n", pager);
+#endif
+	if (vp = vnp->vnp_vp) {
+		vp->v_vmdata = NULL;
+		vp->v_flag &= ~VTEXT;
+#if NOTDEF
+		/* can hang if done at reboot on NFS FS */
+		(void) VOP_FSYNC(vp, p->p_ucred, p);
+#endif
+		vrele(vp);
+	}
+	TAILQ_REMOVE(&vnode_pager_list, pager, pg_list);
+	free((caddr_t)vnp, M_VMPGDATA);
+	free((caddr_t)pager, M_VMPAGER);
+}
+
+static int
+vnode_pager_getpage(pager, mlist, npages, sync)
+	vm_pager_t pager;
+	vm_page_t *mlist;
+	int npages;
+	boolean_t sync;
+{
+
+#ifdef DEBUG
+	if (vpagerdebug & VDB_FOLLOW)
+		printf("vnode_pager_getpage(%x, %x, %x, %x)\n",
+		       pager, mlist, npages, sync);
+#endif
+	return(vnode_pager_io((vn_pager_t)pager->pg_data,
+			      mlist, npages, sync, UIO_READ));
+}
+
+static boolean_t
+vnode_pager_putpage(pager, mlist, npages, sync)
+	vm_pager_t pager;
+	vm_page_t *mlist;
+	int npages;
+	boolean_t sync;
+{
+	int err;
+
+#ifdef DEBUG
+	if (vpagerdebug & VDB_FOLLOW)
+		printf("vnode_pager_putpage(%x, %x, %x, %x)\n",
+		       pager, mlist, npages, sync);
+#endif
+	if (pager == NULL)
+		return (FALSE);			/* ??? */
+	err = vnode_pager_io((vn_pager_t)pager->pg_data,
+			     mlist, npages, sync, UIO_WRITE);
+	/*
+	 * If the operation was successful, mark the pages clean.
+	 */
+	if (err == VM_PAGER_OK) {
+		while (npages--) {
+			(*mlist)->flags |= PG_CLEAN;
+			pmap_clear_modify(VM_PAGE_TO_PHYS(*mlist));
+			mlist++;
+		}
+	}
+	return(err);
+}
+
+static boolean_t
+vnode_pager_haspage(pager, offset)
+	vm_pager_t pager;
+	vm_offset_t offset;
+{
+	struct proc *p = curproc;	/* XXX */
+	vn_pager_t vnp = (vn_pager_t)pager->pg_data;
+	daddr_t bn;
+	int err;
+
+#ifdef DEBUG
+	if (vpagerdebug & VDB_FOLLOW)
+		printf("vnode_pager_haspage(%x, %x)\n", pager, offset);
+#endif
+
+	/*
+	 * Offset beyond end of file, do not have the page
+	 * Lock the vnode first to make sure we have the most recent
+	 * version of the size.
+	 */
+	vn_lock(vnp->vnp_vp, LK_EXCLUSIVE | LK_RETRY, p);
+	if (offset >= vnp->vnp_size) {
+		VOP_UNLOCK(vnp->vnp_vp, 0, p);
+#ifdef DEBUG
+		if (vpagerdebug & (VDB_FAIL|VDB_SIZE))
+			printf("vnode_pager_haspage: pg %x, off %x, size %x\n",
+			       pager, offset, vnp->vnp_size);
+#endif
+		return(FALSE);
+	}
+
+	/*
+	 * Read the index to find the disk block to read
+	 * from.  If there is no block, report that we don't
+	 * have this data.
+	 *
+	 * Assumes that the vnode has whole page or nothing.
+	 */
+	err = VOP_BMAP(vnp->vnp_vp,
+		       offset / vnp->vnp_vp->v_mount->mnt_stat.f_iosize,
+		       (struct vnode **)0, &bn, NULL);
+	VOP_UNLOCK(vnp->vnp_vp, 0, p);
+	if (err) {
+#ifdef DEBUG
+		if (vpagerdebug & VDB_FAIL)
+			printf("vnode_pager_haspage: BMAP err %d, pg %x, off %x\n",
+			       err, pager, offset);
+#endif
+		return(TRUE);
+	}
+	return((long)bn < 0 ? FALSE : TRUE);
+}
+
+static void
+vnode_pager_cluster(pager, offset, loffset, hoffset)
+	vm_pager_t	pager;
+	vm_offset_t	offset;
+	vm_offset_t	*loffset;
+	vm_offset_t	*hoffset;
+{
+	vn_pager_t vnp = (vn_pager_t)pager->pg_data;
+	vm_offset_t loff, hoff;
+
+#ifdef DEBUG
+	if (vpagerdebug & VDB_FOLLOW)
+		printf("vnode_pager_cluster(%x, %x) ", pager, offset);
+#endif
+	loff = offset;
+	if (loff >= vnp->vnp_size)
+		panic("vnode_pager_cluster: bad offset");
+	/*
+	 * XXX could use VOP_BMAP to get maxcontig value
+	 */
+	hoff = loff + MAXBSIZE;
+	if (hoff > round_page(vnp->vnp_size))
+		hoff = round_page(vnp->vnp_size);
+
+	*loffset = loff;
+	*hoffset = hoff;
+#ifdef DEBUG
+	if (vpagerdebug & VDB_FOLLOW)
+		printf("returns [%x-%x]\n", loff, hoff);
+#endif
+}
+
+/*
+ * (XXX)
+ * Lets the VM system know about a change in size for a file.
+ * If this vnode is mapped into some address space (i.e. we have a pager
+ * for it) we adjust our own internal size and flush any cached pages in
+ * the associated object that are affected by the size change.
+ *
+ * Note: this routine may be invoked as a result of a pager put
+ * operation (possibly at object termination time), so we must be careful.
+ */
+void
+vnode_pager_setsize(vp, nsize)
+	struct vnode *vp;
+	u_long nsize;
+{
+	register vn_pager_t vnp;
+	register vm_object_t object;
+	vm_pager_t pager;
+
+	/*
+	 * Not a mapped vnode
+	 */
+	if (vp == NULL || vp->v_type != VREG || vp->v_vmdata == NULL)
+		return;
+	/*
+	 * Hasn't changed size
+	 */
+	pager = (vm_pager_t)vp->v_vmdata;
+	vnp = (vn_pager_t)pager->pg_data;
+	if (nsize == vnp->vnp_size)
+		return;
+	/*
+	 * No object.
+	 * This can happen during object termination since
+	 * vm_object_page_clean is called after the object
+	 * has been removed from the hash table, and clean
+	 * may cause vnode write operations which can wind
+	 * up back here.
+	 */
+	object = vm_object_lookup(pager);
+	if (object == NULL)
+		return;
+
+#ifdef DEBUG
+	if (vpagerdebug & (VDB_FOLLOW|VDB_SIZE))
+		printf("vnode_pager_setsize: vp %x obj %x osz %d nsz %d\n",
+		       vp, object, vnp->vnp_size, nsize);
+#endif
+	/*
+	 * File has shrunk.
+	 * Toss any cached pages beyond the new EOF.
+	 */
+	if (nsize < vnp->vnp_size) {
+		vm_object_lock(object);
+		vm_object_page_remove(object,
+				      (vm_offset_t)nsize, vnp->vnp_size);
+		vm_object_unlock(object);
+	}
+	vnp->vnp_size = (vm_offset_t)nsize;
+	vm_object_deallocate(object);
+}
+
+void
+vnode_pager_umount(mp)
+	register struct mount *mp;
+{
+	struct proc *p = curproc;	/* XXX */
+	vm_pager_t pager, npager;
+	struct vnode *vp;
+
+	for (pager = vnode_pager_list.tqh_first; pager != NULL; pager = npager){
+		/*
+		 * Save the next pointer now since uncaching may
+		 * terminate the object and render pager invalid
+		 */
+		npager = pager->pg_list.tqe_next;
+		vp = ((vn_pager_t)pager->pg_data)->vnp_vp;
+		if (mp == (struct mount *)0 || vp->v_mount == mp) {
+			vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+			(void) vnode_pager_uncache(vp);
+			VOP_UNLOCK(vp, 0, p);
+		}
+	}
+}
+
+/*
+ * Remove vnode associated object from the object cache.
+ *
+ * XXX unlock the vnode if it is currently locked.
+ * We must do this since uncaching the object may result in its
+ * destruction which may initiate paging activity which may necessitate
+ * re-locking the vnode.
+ */
+boolean_t
+vnode_pager_uncache(vp)
+	register struct vnode *vp;
+{
+	struct proc *p = curproc;	/* XXX */
+	vm_object_t object;
+	boolean_t uncached;
+	vm_pager_t pager;
+
+	/*
+	 * Not a mapped vnode
+	 */
+	if (vp->v_type != VREG || (pager = (vm_pager_t)vp->v_vmdata) == NULL)
+		return (TRUE);
+#ifdef DEBUG
+	if (!VOP_ISLOCKED(vp)) {
+		extern int (**nfsv2_vnodeop_p)();
+
+		if (vp->v_op != nfsv2_vnodeop_p)
+			panic("vnode_pager_uncache: vnode not locked!");
+	}
+#endif
+	/*
+	 * Must use vm_object_lookup() as it actually removes
+	 * the object from the cache list.
+	 */
+	object = vm_object_lookup(pager);
+	if (object) {
+		uncached = (object->ref_count <= 1);
+		VOP_UNLOCK(vp, 0, p);
+		pager_cache(object, FALSE);
+		vn_lock(vp, LK_EXCLUSIVE | LK_RETRY, p);
+	} else
+		uncached = TRUE;
+	return(uncached);
+}
+
+static int
+vnode_pager_io(vnp, mlist, npages, sync, rw)
+	register vn_pager_t vnp;
+	vm_page_t *mlist;
+	int npages;
+	boolean_t sync;
+	enum uio_rw rw;
+{
+	struct uio auio;
+	struct iovec aiov;
+	vm_offset_t kva, foff;
+	int error, size;
+	struct proc *p = curproc;		/* XXX */
+
+	/* XXX */
+	vm_page_t m;
+	if (npages != 1)
+		panic("vnode_pager_io: cannot handle multiple pages");
+	m = *mlist;
+	/* XXX */
+
+#ifdef DEBUG
+	if (vpagerdebug & VDB_FOLLOW)
+		printf("vnode_pager_io(%x, %x, %c): vnode %x\n",
+		       vnp, m, rw == UIO_READ ? 'R' : 'W', vnp->vnp_vp);
+#endif
+	foff = m->offset + m->object->paging_offset;
+	/*
+	 * Allocate a kernel virtual address and initialize so that
+	 * we can use VOP_READ/WRITE routines.
+	 */
+	kva = vm_pager_map_pages(mlist, npages, sync);
+	if (kva == NULL)
+		return(VM_PAGER_AGAIN);
+	/*
+	 * After all of the potentially blocking operations have been
+	 * performed, we can do the size checks:
+	 *	read beyond EOF (returns error)
+	 *	short read
+	 */
+	vn_lock(vnp->vnp_vp, LK_EXCLUSIVE | LK_RETRY, p);
+	if (foff >= vnp->vnp_size) {
+		VOP_UNLOCK(vnp->vnp_vp, 0, p);
+		vm_pager_unmap_pages(kva, npages);
+#ifdef DEBUG
+		if (vpagerdebug & VDB_SIZE)
+			printf("vnode_pager_io: vp %x, off %d size %d\n",
+			       vnp->vnp_vp, foff, vnp->vnp_size);
+#endif
+		return(VM_PAGER_BAD);
+	}
+	if (foff + PAGE_SIZE > vnp->vnp_size)
+		size = vnp->vnp_size - foff;
+	else
+		size = PAGE_SIZE;
+	aiov.iov_base = (caddr_t)kva;
+	aiov.iov_len = size;
+	auio.uio_iov = &aiov;
+	auio.uio_iovcnt = 1;
+	auio.uio_offset = foff;
+	auio.uio_segflg = UIO_SYSSPACE;
+	auio.uio_rw = rw;
+	auio.uio_resid = size;
+	auio.uio_procp = (struct proc *)0;
+#ifdef DEBUG
+	if (vpagerdebug & VDB_IO)
+		printf("vnode_pager_io: vp %x kva %x foff %x size %x",
+		       vnp->vnp_vp, kva, foff, size);
+#endif
+	if (rw == UIO_READ)
+		error = VOP_READ(vnp->vnp_vp, &auio, 0, p->p_ucred);
+	else
+		error = VOP_WRITE(vnp->vnp_vp, &auio, 0, p->p_ucred);
+	VOP_UNLOCK(vnp->vnp_vp, 0, p);
+#ifdef DEBUG
+	if (vpagerdebug & VDB_IO) {
+		if (error || auio.uio_resid)
+			printf(" returns error %x, resid %x",
+			       error, auio.uio_resid);
+		printf("\n");
+	}
+#endif
+	if (!error) {
+		register int count = size - auio.uio_resid;
+
+		if (count == 0)
+			error = EINVAL;
+		else if (count != PAGE_SIZE && rw == UIO_READ)
+			bzero((void *)(kva + count), PAGE_SIZE - count);
+	}
+	vm_pager_unmap_pages(kva, npages);
+	return (error ? VM_PAGER_ERROR : VM_PAGER_OK);
+}


### PR DESCRIPTION
## Summary
- add new `src-kernel` directory with syscall stubs delegating to user libraries
- create `src-uland` with copies of scheduler, virtual memory, and VFS sources
- provide simple makefiles for building these components
- document new directories in `SOURCE_TREE_OVERVIEW.md`

## Testing
- `make -C usr/src/usr.sbin/config` *(fails: yacc missing)*
- `make -C src-kernel` *(builds libkern_stubs.a)*
- `make -C src-uland/libkern_sched` *(fails: no rule to make target)*
- `make -C src-uland/fs-server` *(fails: no rule to make target)*
- `make -C src-uland/libvm` *(fails: no rule to make target)*