### PR TITLE
Add exokernel testing instructions

### DIFF
--- a/docs/exokernel_plan.md
+++ b/docs/exokernel_plan.md
@@ -38,7 +38,7 @@ Steps from `tools/migrate_to_fhs.sh` still place these directories under `/usr` 
    - Continue following the FHS migration guide to ensure files end up under `/usr/src-kernel` and `/usr/src-uland`.
 5. **Testing**
    - Compile the exokernel following the steps in [building_kernel.md](building_kernel.md).
-   - Boot with minimal services to validate that user-level managers can start and allocate resources correctly.
+   - Boot with minimal services to validate that user-level managers can start and allocate resources correctly. See [exokernel_testing.md](exokernel_testing.md) for a detailed walkthrough.
 
 ## Mapping FHS Tasks
 

--- a/docs/exokernel_testing.md
+++ b/docs/exokernel_testing.md
@@ -1,0 +1,42 @@
+# Booting the Exokernel with Minimal Managers
+
+This guide explains how to start the exokernel with only the essential user-level managers and verify that low-level resource allocation works. It assumes the exokernel and user managers have been built as described in [building_kernel.md](building_kernel.md).
+
+## Requirements
+
+- `qemu-system-i386` or another x86 emulator
+- The exokernel binary built under `src-kernel`
+- User-level managers (scheduler, memory manager, file server) built under `src-uland`
+- A bootable disk image containing the managers in `/bin` or `/usr/bin`
+
+## Booting in QEMU
+
+1. Create a disk image with the managers installed.
+2. Launch QEMU using the exokernel as the kernel image:
+   ```sh
+   qemu-system-i386 -kernel path/to/exokernel \
+     -hda hdd.img -nographic -serial mon:stdio
+   ```
+3. QEMU displays the kernel and manager initialization. A minimal boot shows lines similar to:
+   ```
+   Booting exokernel...
+   loading memmgr
+   loading sched
+   loading fs_mgr
+   Managers ready. Launching shell.
+   ```
+
+## Verifying Resource Allocation APIs
+
+1. At the shell prompt run the provided allocation test:
+   ```sh
+   /usr/tests/alloc_test
+   ```
+2. The program should request a page and an I/O port. Expected output:
+   ```
+   request_page: success
+   request_io_port: success
+   ```
+3. Check the console or log messages from the managers to confirm that each request reached the corresponding manager and was granted.
+
+If these steps complete without errors the basic resource allocation APIs are functioning under the minimal boot environment.


### PR DESCRIPTION
## Summary
- document how to boot the exokernel with minimal user-space managers
- link the testing plan from the exokernel migration plan

## Testing
- `git status --short`
