### PR TITLE
Add script to locate or build yacc and update build docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential gcc-multilib
       - name: Build with GCC C23 x86_64
         run: make -C usr/src CC=gcc CSTD=-std=c2x CFLAGS_EXTRA='-m64'
+      - name: Generate file inventory
+        run: make inventory
+      - name: Upload inventory
+        uses: actions/upload-artifact@v3
+        with:
+          name: file-inventory-${{ github.job }}
+          path: docs/file_inventory.txt
 
   gcc-i686:
     runs-on: ubuntu-latest
@@ -22,6 +29,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential gcc-multilib
       - name: Build with GCC C23 i686
         run: make -C usr/src CC=gcc CSTD=-std=c2x CFLAGS_EXTRA='-m32'
+      - name: Generate file inventory
+        run: make inventory
+      - name: Upload inventory
+        uses: actions/upload-artifact@v3
+        with:
+          name: file-inventory-${{ github.job }}
+          path: docs/file_inventory.txt
 
   clang-amd64:
     runs-on: ubuntu-latest
@@ -31,6 +45,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang make gcc-multilib
       - name: Build with Clang C23 x86_64
         run: make -C usr/src CC=clang CSTD=-std=c2x CFLAGS_EXTRA='-m64'
+      - name: Generate file inventory
+        run: make inventory
+      - name: Upload inventory
+        uses: actions/upload-artifact@v3
+        with:
+          name: file-inventory-${{ github.job }}
+          path: docs/file_inventory.txt
 
   clang-i686:
     runs-on: ubuntu-latest
@@ -40,3 +61,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang make gcc-multilib
       - name: Build with Clang C23 i686
         run: make -C usr/src CC=clang CSTD=-std=c2x CFLAGS_EXTRA='-m32'
+      - name: Generate file inventory
+        run: make inventory
+      - name: Upload inventory
+        uses: actions/upload-artifact@v3
+        with:
+          name: file-inventory-${{ github.job }}
+          path: docs/file_inventory.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+# Top-level convenience targets
+
+.PHONY: inventory
+
+inventory:
+	python3 tools/create_inventory.py

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -1,11 +1,10 @@
 # Building the 4.4BSD-Lite2 kernel
 
 This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `make`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
-If your host lacks `yacc` or `bison`, build the repository's bundled version first:
+If your host lacks `yacc` or `bison`, run the helper script which locates or
+builds the bundled version automatically:
 ```sh
-cd usr/src/usr.bin/yacc
-make clean && make
-export YACC=$(pwd)/yacc
+export YACC=$(./tools/find_or_build_yacc.sh)
 ```
 Then proceed with the steps below.
 

--- a/docs/exokernel_plan.md
+++ b/docs/exokernel_plan.md
@@ -27,6 +27,7 @@ Steps from `tools/migrate_to_fhs.sh` still place these directories under `/usr` 
 
 1. **Inventory**
    - Use `tools/create_inventory.py` as described in [building_kernel.md](building_kernel.md) to capture the current tree.
+   - The CI workflow runs `make inventory` and uploads `docs/file_inventory.txt` so each branch records its file list.
 2. **Kernel Minimization**
    - Strip existing kernel files to a bare allocator, context switch code and interrupt handlers.
    - Provide system calls for safe access to hardware resources (CPU time slices, memory pages, I/O ports).
@@ -36,6 +37,7 @@ Steps from `tools/migrate_to_fhs.sh` still place these directories under `/usr` 
 4. **Build System Updates**
    - Update makefiles so the exokernel and user managers build separately but link during installation.
    - Continue following the FHS migration guide to ensure files end up under `/usr/src-kernel` and `/usr/src-uland`.
+   - Use `tools/find_or_build_yacc.sh` to ensure a working `yacc` is available during the build.
 5. **Testing**
    - Compile the exokernel following the steps in [building_kernel.md](building_kernel.md).
    - Boot with minimal services to validate that user-level managers can start and allocate resources correctly.

--- a/docs/file_inventory.txt
+++ b/docs/file_inventory.txt
@@ -127,6 +127,7 @@ Foreign/src/telnetd/state.c
 Foreign/src/telnetd/telnetd.c
 Foreign/src/telnetd/termstat.c
 Foreign/src/telnetd/utility.c
+Makefile
 README.md
 SOURCE_TREE_OVERVIEW.md
 dependency_graph.dot
@@ -137,6 +138,7 @@ dev/MAKEDEV.local
 docs/AGENTS.md
 docs/building_kernel.md
 docs/ci_workflows.md
+docs/exokernel_plan.md
 docs/fhs_migration.md
 docs/file_inventory.txt
 docs/file_tree.txt
@@ -210,10 +212,12 @@ tools/AGENTS.md
 tools/analyze_codebase.py
 tools/build_collect_warnings.sh
 tools/create_inventory.py
+tools/find_or_build_yacc.sh
 tools/generate_cscope.sh
 tools/generate_ctags.sh
 tools/generate_dependency_graph.py
 tools/migrate_to_fhs.sh
+tools/organize_sources.sh
 usr/AGENTS.md
 usr/X11
 usr/bin/X11
@@ -19779,6 +19783,7 @@ usr/src/usr.bin/xstr/tags
 usr/src/usr.bin/xstr/xstr.1
 usr/src/usr.bin/xstr/xstr.c
 usr/src/usr.bin/yacc/ACKNOWLEDGEMENTS
+usr/src/usr.bin/yacc/CMakeLists.txt
 usr/src/usr.bin/yacc/Makefile
 usr/src/usr.bin/yacc/NEW_FEATURES
 usr/src/usr.bin/yacc/NOTES

--- a/tools/find_or_build_yacc.sh
+++ b/tools/find_or_build_yacc.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Locate an available yacc implementation or build the bundled one via CMake.
+set -e
+if command -v yacc >/dev/null 2>&1; then
+  command -v yacc
+  exit 0
+fi
+if command -v bison >/dev/null 2>&1; then
+  echo "$(command -v bison) -y"
+  exit 0
+fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+YACC_SRC="$ROOT_DIR/usr/src/usr.bin/yacc"
+BUILD_DIR="$YACC_SRC/build"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+if [ ! -f yacc ]; then
+  cmake .. >/dev/null && make >/dev/null
+fi
+echo "$BUILD_DIR/yacc"

--- a/usr/src/usr.bin/yacc/CMakeLists.txt
+++ b/usr/src/usr.bin/yacc/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+project(yacc C)
+add_executable(yacc
+    closure.c error.c lalr.c lr0.c main.c mkpar.c
+    output.c reader.c skeleton.c symtab.c verbose.c warshall.c)
+install(TARGETS yacc DESTINATION bin)

--- a/usr/src/usr.sbin/config/Makefile
+++ b/usr/src/usr.sbin/config/Makefile
@@ -1,6 +1,11 @@
 # Simplified GNU makefile for the config utility
 PROG = config
 CFLAGS += -I. -I$(CURDIR)
+
+# Allow overriding yacc and lex implementations
+YACC ?= yacc
+LEX ?= lex
+
 SRCS = config.c main.c lang.c mkioconf.c mkmakefile.c mkglue.c mkheaders.c \
        mkswapconf.c
 LDADD = -ll
@@ -12,6 +17,14 @@ all: $(PROG)
 
 $(PROG): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LDADD) -o $@
+
+config.c y.tab.h: config.y
+	$(YACC) -d $<
+	mv y.tab.c config.c
+
+lang.c: lang.l
+	$(LEX) $<
+	mv lex.yy.c lang.c
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
## Summary
- provide `tools/find_or_build_yacc.sh` to build or locate yacc
- add simple `CMakeLists.txt` for building yacc with CMake
- document the helper script in the kernel build guide and exokernel plan
- teach `config` Makefile to generate parser files via YACC/LEX
- refresh `docs/file_inventory.txt`

## Testing
- `./tools/find_or_build_yacc.sh` (builds yacc with CMake)
- `make -C usr/src/usr.sbin/config` (fails: `lex` missing)
- `make inventory`
