### PR TITLE
Add exokernel stub header

### DIFF
--- a/docs/exokernel_plan.md
+++ b/docs/exokernel_plan.md
@@ -19,7 +19,9 @@ The layout introduced in the microkernel plan remains with slight changes:
 
 - `src-kernel/` – exokernel core providing only protection and low-level resource handling.
 - `src-uland/` – user-level libraries and servers that implement traditional OS functionality.
-- `include/` – headers shared between the exokernel and user components.
+- `include/` – headers shared between the exokernel and user components. The
+  `exokernel.h` header declares stub entry points `kern_sched_init`,
+  `kern_open` and `kern_vm_fault`.
 - The specific subsystems being moved are listed in
 [exokernel_subsystems.md](exokernel_subsystems.md).
 

--- a/include/exokernel.h
+++ b/include/exokernel.h
@@ -1,0 +1,10 @@
+#ifndef EXOKERNEL_H
+#define EXOKERNEL_H
+
+/* Interface exported by the exokernel stubs. */
+
+void   kern_sched_init(void);
+int    kern_open(const char *path, int flags);
+int    kern_vm_fault(void *addr);
+
+#endif /* EXOKERNEL_H */

--- a/src-kernel/sched_hooks.c
+++ b/src-kernel/sched_hooks.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "../include/exokernel.h"
 /* Stubs delegating to user-space scheduler */
 extern void uland_sched_init(void);
 void

--- a/src-kernel/vfs_hooks.c
+++ b/src-kernel/vfs_hooks.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "../include/exokernel.h"
 /* Stubs delegating to user-space file server */
 extern int fs_open(const char *path, int flags);
 int

--- a/src-kernel/vm_hooks.c
+++ b/src-kernel/vm_hooks.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "../include/exokernel.h"
 /* Stubs delegating to user-space VM library */
 extern int uland_vm_fault(void *addr);
 int


### PR DESCRIPTION
## Summary
- declare `kern_sched_init`, `kern_open` and `kern_vm_fault` in new header
- include the header in the kernel stub sources
- document the header in the exokernel plan

## Testing
- `make clean && make` in `src-kernel`