### PR TITLE
Add proc_manager server from kern_proc.c

### DIFF
--- a/docs/exokernel_subsystems.md
+++ b/docs/exokernel_subsystems.md
@@ -6,7 +6,7 @@ This reference records where each kernel component from the microkernel plan wil
 |-----------|------------------|-----------------|----------------|
 | Console driver | `sys/dev/cons*` | `src-uland/servers/` | no new name defined |
 | File server | `sys/kern/vfs*` | `src-uland/servers/` | no new name defined |
-| Process manager | `sys/kern/kern_proc.c` | `src-uland/servers/` | no new name defined |
+| Process manager | `sys/kern/kern_proc.c` | `src-uland/servers/proc_manager/` | no new name defined |
 | Scheduler | `sys/kern/kern_sched.c` | `src-uland/servers/` | no new name defined |
 | Virtual memory manager | `sys/vm/` | `src-uland/servers/` | no new name defined |
 | Device drivers | `sys/dev/*` | `src-uland/servers/` | drivers compiled as separate tasks |

--- a/src-headers/AGENTS.md
+++ b/src-headers/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Headers
+
+This directory collects header files needed for building user-space
+servers derived from the kernel sources. Files here are copied from
+`sys/` with comments preserved.

--- a/src-headers/machine/ansi.h
+++ b/src-headers/machine/ansi.h
@@ -1,0 +1,72 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ansi.h	8.2 (Berkeley) 1/4/94
+ */
+
+#ifndef	_ANSI_H_
+#define	_ANSI_H_
+
+/*
+ * Types which are fundamental to the implementation and may appear in
+ * more than one standard header are defined here.  Standard headers
+ * then use:
+ *	#ifdef	_BSD_SIZE_T_
+ *	typedef	_BSD_SIZE_T_ size_t;
+ *	#undef	_BSD_SIZE_T_
+ *	#endif
+ */
+#define	_BSD_CLOCK_T_	unsigned long		/* clock() */
+#define	_BSD_PTRDIFF_T_	int			/* ptr1 - ptr2 */
+#define	_BSD_SIZE_T_	unsigned int		/* sizeof() */
+#define	_BSD_SSIZE_T_	int			/* byte count or error */
+#define	_BSD_TIME_T_	long			/* time() */
+#define	_BSD_VA_LIST_	char *			/* va_list */
+
+/*
+ * Runes (wchar_t) is declared to be an ``int'' instead of the more natural
+ * ``unsigned long'' or ``long''.  Two things are happening here.  It is not
+ * unsigned so that EOF (-1) can be naturally assigned to it and used.  Also,
+ * it looks like 10646 will be a 31 bit standard.  This means that if your
+ * ints cannot hold 32 bits, you will be in trouble.  The reason an int was
+ * chosen over a long is that the is*() and to*() routines take ints (says
+ * ANSI C), but they use _RUNE_T_ instead of int.  By changing it here, you
+ * lose a bit of ANSI conformance, but your programs will still work.
+ *    
+ * Note that _WCHAR_T_ and _RUNE_T_ must be of the same type.  When wchar_t
+ * and rune_t are typedef'd, _WCHAR_T_ will be undef'd, but _RUNE_T remains
+ * defined for ctype.h.
+ */
+#define	_BSD_WCHAR_T_	int			/* wchar_t */
+#define	_BSD_RUNE_T_	int			/* rune_t */
+
+#endif	/* _ANSI_H_ */

--- a/src-headers/machine/endian.h
+++ b/src-headers/machine/endian.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 1987, 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)endian.h	8.1 (Berkeley) 6/11/93
+ */
+
+#ifndef _ENDIAN_H_
+#define	_ENDIAN_H_
+
+/*
+ * Define _NOQUAD if the compiler does NOT support 64-bit integers.
+ */
+/* #define _NOQUAD */
+
+/*
+ * Define the order of 32-bit words in 64-bit words.
+ */
+#define _QUAD_HIGHWORD 1
+#define _QUAD_LOWWORD 0
+
+#ifndef _POSIX_SOURCE
+/*
+ * Definitions for byte order, according to byte significance from low
+ * address to high.
+ */
+#define	LITTLE_ENDIAN	1234	/* LSB first: i386, vax */
+#define	BIG_ENDIAN	4321	/* MSB first: 68000, ibm, net */
+#define	PDP_ENDIAN	3412	/* LSB first in word, MSW first in long */
+
+#define	BYTE_ORDER	LITTLE_ENDIAN
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+unsigned long	htonl __P((unsigned long));
+unsigned short	htons __P((unsigned short));
+unsigned long	ntohl __P((unsigned long));
+unsigned short	ntohs __P((unsigned short));
+__END_DECLS
+
+/*
+ * Macros for network/external number representation conversion.
+ */
+#if BYTE_ORDER == BIG_ENDIAN && !defined(lint)
+#define	ntohl(x)	(x)
+#define	ntohs(x)	(x)
+#define	htonl(x)	(x)
+#define	htons(x)	(x)
+
+#define	NTOHL(x)	(x)
+#define	NTOHS(x)	(x)
+#define	HTONL(x)	(x)
+#define	HTONS(x)	(x)
+
+#else
+
+#define	NTOHL(x)	(x) = ntohl((u_long)x)
+#define	NTOHS(x)	(x) = ntohs((u_short)x)
+#define	HTONL(x)	(x) = htonl((u_long)x)
+#define	HTONS(x)	(x) = htons((u_short)x)
+#endif
+#endif /* ! _POSIX_SOURCE */
+#endif /* !_ENDIAN_H_ */

--- a/src-headers/machine/types.h
+++ b/src-headers/machine/types.h
@@ -1,0 +1,65 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)types.h	8.3 (Berkeley) 1/5/94
+ */
+
+#ifndef	_MACHTYPES_H_
+#define	_MACHTYPES_H_
+
+#if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
+typedef struct _physadr {
+	int r[1];
+} *physadr;
+
+typedef struct label_t {
+	int val[6];
+} label_t;
+#endif
+
+typedef	unsigned long	vm_offset_t;
+typedef	unsigned long	vm_size_t;
+
+/*
+ * Basic integral types.  Omit the typedef if
+ * not possible for a machine/compiler combination.
+ */
+typedef	__signed char		   int8_t;
+typedef	unsigned char		 u_int8_t;
+typedef	short			  int16_t;
+typedef	unsigned short		u_int16_t;
+typedef	int			  int32_t;
+typedef	unsigned int		u_int32_t;
+typedef	long long		  int64_t;
+typedef	unsigned long long	u_int64_t;
+
+#endif	/* _MACHTYPES_H_ */

--- a/src-headers/proc_manager.h
+++ b/src-headers/proc_manager.h
@@ -1,0 +1,20 @@
+#ifndef PROC_MANAGER_H
+#define PROC_MANAGER_H
+
+/* Derived from sys/kern/kern_proc.c */
+
+#include <sys/types.h>
+#include <sys/proc.h>
+
+void procinit(void);
+int chgproccnt(uid_t uid, int diff);
+int inferior(struct proc *p);
+struct proc *pfind(pid_t pid);
+struct pgrp *pgfind(pid_t pgid);
+int enterpgrp(struct proc *p, pid_t pgid, int mksess);
+int leavepgrp(struct proc *p);
+void pgdelete(struct pgrp *pgrp);
+void fixjobc(struct proc *p, struct pgrp *pgrp, int entering);
+void pgrpdump(void);
+
+#endif /* PROC_MANAGER_H */

--- a/src-uland/servers/AGENTS.md
+++ b/src-uland/servers/AGENTS.md
@@ -1,0 +1,4 @@
+# Userland Servers
+
+This directory collects user-space managers derived from kernel sources.
+Build each server using its local Makefile.

--- a/src-uland/servers/proc_manager/Makefile
+++ b/src-uland/servers/proc_manager/Makefile
@@ -1,0 +1,17 @@
+OBJS = kern_proc.o
+PROG = proc_manager
+CC ?= cc
+CFLAGS ?= -O2
+CPPFLAGS ?= -I../../../src-headers -I../../../sys -I../../../sys/i386/include
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(OBJS) -o $@
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(PROG)
+

--- a/src-uland/servers/proc_manager/kern_proc.c
+++ b/src-uland/servers/proc_manager/kern_proc.c
@@ -1,0 +1,376 @@
+/* Copied from sys/kern/kern_proc.c */
+/*
+ * Copyright (c) 1982, 1986, 1989, 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)kern_proc.c	8.7 (Berkeley) 2/14/95
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/map.h>
+#include <sys/kernel.h>
+#include <sys/proc.h>
+#include <sys/buf.h>
+#include <sys/acct.h>
+#include <sys/wait.h>
+#include <sys/file.h>
+#include <ufs/ufs/quota.h>
+#include <sys/uio.h>
+#include <sys/malloc.h>
+#include "proc_manager.h"
+#include <sys/mbuf.h>
+#include <sys/ioctl.h>
+#include <sys/tty.h>
+
+/*
+ * Structure associated with user cacheing.
+ */
+struct uidinfo {
+	LIST_ENTRY(uidinfo) ui_hash;
+	uid_t	ui_uid;
+	long	ui_proccnt;
+};
+#define	UIHASH(uid)	(&uihashtbl[(uid) & uihash])
+LIST_HEAD(uihashhead, uidinfo) *uihashtbl;
+u_long uihash;		/* size of hash table - 1 */
+
+/*
+ * Other process lists
+ */
+struct pidhashhead *pidhashtbl;
+u_long pidhash;
+struct pgrphashhead *pgrphashtbl;
+u_long pgrphash;
+struct proclist allproc;
+struct proclist zombproc;
+
+/*
+ * Initialize global process hashing structures.
+ */
+void
+procinit()
+{
+
+	LIST_INIT(&allproc);
+	LIST_INIT(&zombproc);
+	pidhashtbl = hashinit(maxproc / 4, M_PROC, &pidhash);
+	pgrphashtbl = hashinit(maxproc / 4, M_PROC, &pgrphash);
+	uihashtbl = hashinit(maxproc / 16, M_PROC, &uihash);
+}
+
+/*
+ * Change the count associated with number of processes
+ * a given user is using.
+ */
+int
+chgproccnt(uid, diff)
+	uid_t	uid;
+	int	diff;
+{
+	register struct uidinfo *uip;
+	register struct uihashhead *uipp;
+
+	uipp = UIHASH(uid);
+	for (uip = uipp->lh_first; uip != 0; uip = uip->ui_hash.le_next)
+		if (uip->ui_uid == uid)
+			break;
+	if (uip) {
+		uip->ui_proccnt += diff;
+		if (uip->ui_proccnt > 0)
+			return (uip->ui_proccnt);
+		if (uip->ui_proccnt < 0)
+			panic("chgproccnt: procs < 0");
+		LIST_REMOVE(uip, ui_hash);
+		FREE(uip, M_PROC);
+		return (0);
+	}
+	if (diff <= 0) {
+		if (diff == 0)
+			return(0);
+		panic("chgproccnt: lost user");
+	}
+	MALLOC(uip, struct uidinfo *, sizeof(*uip), M_PROC, M_WAITOK);
+	LIST_INSERT_HEAD(uipp, uip, ui_hash);
+	uip->ui_uid = uid;
+	uip->ui_proccnt = diff;
+	return (diff);
+}
+
+/*
+ * Is p an inferior of the current process?
+ */
+inferior(p)
+	register struct proc *p;
+{
+
+	for (; p != curproc; p = p->p_pptr)
+		if (p->p_pid == 0)
+			return (0);
+	return (1);
+}
+
+/*
+ * Locate a process by number
+ */
+struct proc *
+pfind(pid)
+	register pid_t pid;
+{
+	register struct proc *p;
+
+	for (p = PIDHASH(pid)->lh_first; p != 0; p = p->p_hash.le_next)
+		if (p->p_pid == pid)
+			return (p);
+	return (NULL);
+}
+
+/*
+ * Locate a process group by number
+ */
+struct pgrp *
+pgfind(pgid)
+	register pid_t pgid;
+{
+	register struct pgrp *pgrp;
+
+	for (pgrp = PGRPHASH(pgid)->lh_first; pgrp != 0;
+	     pgrp = pgrp->pg_hash.le_next)
+		if (pgrp->pg_id == pgid)
+			return (pgrp);
+	return (NULL);
+}
+
+/*
+ * Move p to a new or existing process group (and session)
+ */
+int
+enterpgrp(p, pgid, mksess)
+	register struct proc *p;
+	pid_t pgid;
+	int mksess;
+{
+	register struct pgrp *pgrp = pgfind(pgid);
+
+#ifdef DIAGNOSTIC
+	if (pgrp != NULL && mksess)	/* firewalls */
+		panic("enterpgrp: setsid into non-empty pgrp");
+	if (SESS_LEADER(p))
+		panic("enterpgrp: session leader attempted setpgrp");
+#endif
+	if (pgrp == NULL) {
+		pid_t savepid = p->p_pid;
+		struct proc *np;
+		/*
+		 * new process group
+		 */
+#ifdef DIAGNOSTIC
+		if (p->p_pid != pgid)
+			panic("enterpgrp: new pgrp and pid != pgid");
+#endif
+		MALLOC(pgrp, struct pgrp *, sizeof(struct pgrp), M_PGRP,
+		    M_WAITOK);
+		if ((np = pfind(savepid)) == NULL || np != p)
+			return (ESRCH);
+		if (mksess) {
+			register struct session *sess;
+
+			/*
+			 * new session
+			 */
+			MALLOC(sess, struct session *, sizeof(struct session),
+			    M_SESSION, M_WAITOK);
+			sess->s_leader = p;
+			sess->s_count = 1;
+			sess->s_ttyvp = NULL;
+			sess->s_ttyp = NULL;
+			bcopy(p->p_session->s_login, sess->s_login,
+			    sizeof(sess->s_login));
+			p->p_flag &= ~P_CONTROLT;
+			pgrp->pg_session = sess;
+#ifdef DIAGNOSTIC
+			if (p != curproc)
+				panic("enterpgrp: mksession and p != curproc");
+#endif
+		} else {
+			pgrp->pg_session = p->p_session;
+			pgrp->pg_session->s_count++;
+		}
+		pgrp->pg_id = pgid;
+		LIST_INIT(&pgrp->pg_members);
+		LIST_INSERT_HEAD(PGRPHASH(pgid), pgrp, pg_hash);
+		pgrp->pg_jobc = 0;
+	} else if (pgrp == p->p_pgrp)
+		return (0);
+
+	/*
+	 * Adjust eligibility of affected pgrps to participate in job control.
+	 * Increment eligibility counts before decrementing, otherwise we
+	 * could reach 0 spuriously during the first call.
+	 */
+	fixjobc(p, pgrp, 1);
+	fixjobc(p, p->p_pgrp, 0);
+
+	LIST_REMOVE(p, p_pglist);
+	if (p->p_pgrp->pg_members.lh_first == 0)
+		pgdelete(p->p_pgrp);
+	p->p_pgrp = pgrp;
+	LIST_INSERT_HEAD(&pgrp->pg_members, p, p_pglist);
+	return (0);
+}
+
+/*
+ * remove process from process group
+ */
+int
+leavepgrp(p)
+	register struct proc *p;
+{
+
+	LIST_REMOVE(p, p_pglist);
+	if (p->p_pgrp->pg_members.lh_first == 0)
+		pgdelete(p->p_pgrp);
+	p->p_pgrp = 0;
+	return (0);
+}
+
+/*
+ * delete a process group
+ */
+void
+pgdelete(pgrp)
+	register struct pgrp *pgrp;
+{
+
+	if (pgrp->pg_session->s_ttyp != NULL && 
+	    pgrp->pg_session->s_ttyp->t_pgrp == pgrp)
+		pgrp->pg_session->s_ttyp->t_pgrp = NULL;
+	LIST_REMOVE(pgrp, pg_hash);
+	if (--pgrp->pg_session->s_count == 0)
+		FREE(pgrp->pg_session, M_SESSION);
+	FREE(pgrp, M_PGRP);
+}
+
+static void orphanpg();
+
+/*
+ * Adjust pgrp jobc counters when specified process changes process group.
+ * We count the number of processes in each process group that "qualify"
+ * the group for terminal job control (those with a parent in a different
+ * process group of the same session).  If that count reaches zero, the
+ * process group becomes orphaned.  Check both the specified process'
+ * process group and that of its children.
+ * entering == 0 => p is leaving specified group.
+ * entering == 1 => p is entering specified group.
+ */
+void
+fixjobc(p, pgrp, entering)
+	register struct proc *p;
+	register struct pgrp *pgrp;
+	int entering;
+{
+	register struct pgrp *hispgrp;
+	register struct session *mysession = pgrp->pg_session;
+
+	/*
+	 * Check p's parent to see whether p qualifies its own process
+	 * group; if so, adjust count for p's process group.
+	 */
+	if ((hispgrp = p->p_pptr->p_pgrp) != pgrp &&
+	    hispgrp->pg_session == mysession)
+		if (entering)
+			pgrp->pg_jobc++;
+		else if (--pgrp->pg_jobc == 0)
+			orphanpg(pgrp);
+
+	/*
+	 * Check this process' children to see whether they qualify
+	 * their process groups; if so, adjust counts for children's
+	 * process groups.
+	 */
+	for (p = p->p_children.lh_first; p != 0; p = p->p_sibling.le_next)
+		if ((hispgrp = p->p_pgrp) != pgrp &&
+		    hispgrp->pg_session == mysession &&
+		    p->p_stat != SZOMB)
+			if (entering)
+				hispgrp->pg_jobc++;
+			else if (--hispgrp->pg_jobc == 0)
+				orphanpg(hispgrp);
+}
+
+/* 
+ * A process group has become orphaned;
+ * if there are any stopped processes in the group,
+ * hang-up all process in that group.
+ */
+static void
+orphanpg(pg)
+	struct pgrp *pg;
+{
+	register struct proc *p;
+
+	for (p = pg->pg_members.lh_first; p != 0; p = p->p_pglist.le_next) {
+		if (p->p_stat == SSTOP) {
+			for (p = pg->pg_members.lh_first; p != 0;
+			    p = p->p_pglist.le_next) {
+				psignal(p, SIGHUP);
+				psignal(p, SIGCONT);
+			}
+			return;
+		}
+	}
+}
+
+#ifdef DEBUG
+pgrpdump()
+{
+	register struct pgrp *pgrp;
+	register struct proc *p;
+	register i;
+
+	for (i = 0; i <= pgrphash; i++) {
+		if (pgrp = pgrphashtbl[i].lh_first) {
+			printf("\tindx %d\n", i);
+			for (; pgrp != 0; pgrp = pgrp->pg_hash.le_next) {
+				printf("\tpgrp %x, pgid %d, sess %x, sesscnt %d, mem %x\n",
+				    pgrp, pgrp->pg_id, pgrp->pg_session,
+				    pgrp->pg_session->s_count,
+				    pgrp->pg_members.lh_first);
+				for (p = pgrp->pg_members.lh_first; p != 0;
+				    p = p->p_pglist.le_next) {
+					printf("\t\tpid %d addr %x pgrp %x\n", 
+					    p->p_pid, p, p->p_pgrp);
+				}
+			}
+		}
+	}
+}
+#endif /* DEBUG */


### PR DESCRIPTION
## Summary
- copy `kern_proc.c` to a new `proc_manager` server
- create Makefile for building `proc_manager`
- document the new server path in `exokernel_subsystems.md`
- introduce `src-headers` with headers needed by `proc_manager`

## Testing
- `make clean && make` in `src-uland/servers/proc_manager` *(fails: machine/signal.h: No such file or directory)*