### PR TITLE
Add migrate_to_src_layout script

### DIFF
--- a/docs/fhs_migration.md
+++ b/docs/fhs_migration.md
@@ -61,9 +61,11 @@ when modernizing historic BSD trees.
    `tools/migrate_to_fhs.sh --dry-run` to review the planned actions.
 3. Execute `tools/migrate_to_fhs.sh` without `--dry-run` to copy directories
    under `/usr` and replace the originals with symlinks.
-4. Run `tools/post_fhs_cleanup.sh --dry-run` to preview how the source tree
-   will be reorganized.
-5. Execute `tools/post_fhs_cleanup.sh` (add `--force` when outside the chroot)
+4. Run `tools/migrate_to_src_layout.sh --dry-run` to preview how the source tree
+   will be reorganized. The script performs the same moves as
+   `tools/organize_sources.sh` and supersedes the old
+   `tools/post_fhs_cleanup.sh` helper.
+5. Execute `tools/migrate_to_src_layout.sh` (add `--force` when outside the chroot)
    to relocate the sources. The script moves the kernel into `src-kernel`, user
    programs into `src-uland`, headers into `src-headers` and library objects
    into `src-lib`.
@@ -81,7 +83,7 @@ Following these steps alongside the broader plan in `reorg_plan.md` helps turn
 the BSD distribution into a structure that is familiar to modern systems.
 ## Remaining Manual Symlinks
 Some directories are not handled by `migrate_to_fhs.sh` and must be linked manually.
-After running `tools/post_fhs_cleanup.sh` the kernel sources live in `src-kernel`.
+After running `tools/migrate_to_src_layout.sh` the kernel sources live in `src-kernel`.
 Directories that still require manual handling include:
 - `Domestic` - U.S. cryptography sources
 - `Foreign` - externally maintained utilities

--- a/docs/reorg_plan.md
+++ b/docs/reorg_plan.md
@@ -19,4 +19,7 @@ This document outlines tasks for flattening the 4.4BSD-Lite2 source tree and mod
 5. Document all changes and keep references to original paths for traceability.
 6. Convert the historic directory layout using `tools/migrate_to_fhs.sh` and
    maintain compatibility symlinks during the transition.
+7. Reorganize kernel and userland sources with
+   `tools/migrate_to_src_layout.sh` (or the older `tools/organize_sources.sh`)
+   to move them into `src-kernel`, `src-uland`, `src-headers` and `src-lib`.
 

--- a/tools/migrate_to_src_layout.sh
+++ b/tools/migrate_to_src_layout.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Source layout migration helper
+# Moves kernel and userland sources into consolidated directories
+# similar to organize_sources.sh.
+# Usage: migrate_to_src_layout.sh [--force] [--dry-run]
+
+set -e
+
+usage() {
+    echo "Usage: $0 [--force] [--dry-run]" >&2
+    exit 1
+}
+
+# Detect if running inside a chroot
+in_chroot() {
+    if [ "$(stat -c %d:%i / 2>/dev/null)" != "$(stat -c %d:%i /proc/1/root 2>/dev/null)" ]; then
+        return 0
+    fi
+    return 1
+}
+
+FORCE=0
+DRYRUN=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force)
+            FORCE=1
+            ;;
+        --dry-run)
+            DRYRUN=1
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+run_cmd() {
+    if [ "$DRYRUN" -eq 1 ]; then
+        echo "$*"
+    else
+        eval "$*"
+    fi
+}
+
+move_and_link() {
+    src="$1"
+    dst="$2"
+    [ -e "$src" ] || return 0
+    if [ -L "$src" ] && [ "$(readlink "$src")" = "$dst" ]; then
+        return 0
+    fi
+    run_cmd "mkdir -p \"$(dirname \"$dst\")\""
+    run_cmd "rsync -a \"$src/\" \"$dst/\""
+    run_cmd "rm -rf \"$src\""
+    run_cmd "ln -snf \"$dst\" \"$src\""
+}
+
+move_artifacts() {
+    base="$1"
+    [ -d "$base" ] || return 0
+    find "$base" -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.so.*' \) | while read f; do
+        rel="${f#$base/}"
+        dest="src-lib/$rel"
+        run_cmd "mkdir -p \"$(dirname \"$dest\")\""
+        run_cmd "mv \"$f\" \"$dest\""
+    done
+}
+
+if ! in_chroot && [ "$FORCE" -ne 1 ]; then
+    echo "Error: not running inside a chroot. Use --force to override." >&2
+    exit 1
+fi
+
+move_and_link sys src-kernel
+move_and_link usr/src src-uland
+move_and_link src-uland/include src-headers
+
+move_artifacts src-uland
+move_artifacts src-kernel
+
+echo "Source layout migration complete."


### PR DESCRIPTION
## Summary
- migrate kernel and userland sources with `migrate_to_src_layout.sh`
- document new script in the migration docs and reorg plan

## Testing
- `tools/migrate_to_src_layout.sh --dry-run`