### PR TITLE
Add microkernel functional model documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Downloaded from: ftp://alge.anart.no/pub/BSD/4.4BSD-Lite/4.4BSD-Lite2.tar.gz
 For kernel build instructions see [docs/building_kernel.md](docs/building_kernel.md).
 For GitHub CI examples see [docs/ci_workflows.md](docs/ci_workflows.md).
 For FHS migration steps see [docs/fhs_migration.md](docs/fhs_migration.md).
+For microkernel tasks see [docs/microkernel_plan.md](docs/microkernel_plan.md)
+and the functional overview in
+[docs/microkernel_functional_model.md](docs/microkernel_functional_model.md).
 For exokernel tasks see [docs/exokernel_plan.md](docs/exokernel_plan.md).
 
 ### User's Supplementary Documents

--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -1,0 +1,59 @@
+# Microkernel Functional Model
+
+This document summarizes how the evolving microkernel and its user-space
+components interact.  It complements `microkernel_plan.md` by describing
+expected responsibilities and message flows.
+
+## Core Microkernel Responsibilities
+
+The microkernel contains only the minimal mechanisms needed to run the
+system safely.  These include:
+
+- **Thread scheduling hooks** – the kernel delegates policy decisions to the
+  user-space scheduler library.  It starts execution in `kern_sched_init()`
+  and performs context switches on request.
+- **Virtual memory hooks** – page faults call `kern_vm_fault()` which forwards
+  to a user-space memory manager for allocation and paging decisions.
+- **System call gate** – simple wrappers like `kern_open()` pass file
+  operations to the file server running in user space.
+- **IPC primitives** – the kernel exposes message queues for servers and
+  drivers to communicate.  Messages are fixed-size structures shared via
+  a ring buffer.
+
+The microkernel itself remains small and largely architecture independent.
+Device drivers, filesystems and process management are all provided by
+servers outside the kernel.
+
+## User-space Servers
+
+User-space components implement nearly all traditional BSD services:
+
+- The **process manager** handles fork, exec and signal delivery.  It runs as
+  `proc_manager` in `src-uland/servers`.
+- The **file server** (`fs_server`) maintains vnodes and dispatches file
+  requests from the `kern_open()` hook.
+- The **scheduler library** and **VM library** in `src-uland/libkern_sched`
+  and `src-uland/libvm` make policy decisions for scheduling and memory
+  management.
+- Additional drivers will appear under `src-uland/servers` as standalone
+  tasks communicating with the kernel via the IPC layer.
+
+Each server starts at boot time via init scripts and registers with the
+microkernel.  Crashes can be detected by a simple watchdog process so that
+failed components are restarted automatically.
+
+## Message Flow Example
+
+1. A user program calls `open("/etc/passwd", O_RDONLY)`.
+2. The kernel trap handler invokes `kern_open()`.
+3. `kern_open()` packages the request into an IPC message and sends it to
+   the file server.
+4. The file server translates the path, checks permissions and returns a file
+   descriptor.
+5. The kernel relays this descriptor back to the user program.
+
+Other operations follow the same pattern: the kernel validates basic
+parameters, packages the request and relies on a user-space server to
+perform the real work.  This separation keeps the kernel small and easier
+to reason about.
+

--- a/docs/microkernel_plan.md
+++ b/docs/microkernel_plan.md
@@ -4,7 +4,10 @@ This document sketches out an incremental approach for isolating select subsyste
 
 ## Overview
 This plan transitions the monolithic BSD kernel into a minimal microkernel and moves device drivers and system servers into user space. Steps reference the FHS migration guide and the roles listed in reorg_plan.md.
-For background on MINIX 3 features influencing this roadmap, see [minix3_concepts.md](minix3_concepts.md).
+For background on MINIX 3 features influencing this roadmap, see
+[minix3_concepts.md](minix3_concepts.md).  A complementary overview of how
+the microkernel and user-space servers interact is provided in
+[microkernel_functional_model.md](microkernel_functional_model.md).
 
 
 ## Candidate subsystems


### PR DESCRIPTION
## Summary
- document microkernel functional model
- link to the new documentation from the microkernel plan and README

## Testing
- `git status --short`