### PR TITLE
Fix builds by adding kernel headers

### DIFF
--- a/docs/microkernel_plan.md
+++ b/docs/microkernel_plan.md
@@ -56,6 +56,8 @@ The steps in `tools/migrate_to_fhs.sh` will be updated so these directories map 
 2. **Build System Updates**
    - The **Build System Engineer** drafts makefiles for `src-kernel` and `src-uland` so they build independently.
    - Update `tools/migrate_to_fhs.sh` to place these directories under `/usr` during migration.
+   - Collect required kernel headers in `src-headers/` so user-space
+     servers compile without referencing the entire `sys/` tree.
    - Existing FHS tasks such as verifying symlinks and updating scripts continue to apply, but now reference the new directories.
 
 3. **Microkernel Extraction**

--- a/src-headers/machine/cpu.h
+++ b/src-headers/machine/cpu.h
@@ -1,0 +1,115 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * William Jolitz.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)cpu.h	8.5 (Berkeley) 5/17/95
+ */
+
+/*
+ * Definitions unique to i386 cpu support.
+ */
+#include <machine/frame.h>
+#include <machine/segments.h>
+
+/*
+ * definitions of cpu-dependent requirements
+ * referenced in generic code
+ */
+#undef	COPY_SIGCODE	/* don't copy sigcode above user stack in exec */
+
+#define	cpu_exec(p)			/* nothing */
+#define	cpu_swapin(p)			/* nothing */
+#define cpu_setstack(p, ap)		(p)->p_md.md_regs[SP] = ap
+#define cpu_set_init_frame(p, fp)	(p)->p_md.md_regs = fp
+#define	BACKTRACE(p)			/* not implemented */
+
+/*
+ * Arguments to hardclock, softclock and gatherstats
+ * encapsulate the previous machine state in an opaque
+ * clockframe; for now, use generic intrframe.
+ */
+struct clockframe {
+	struct intrframe	cf_if;
+};
+
+#define	CLKF_USERMODE(framep)	(ISPL((framep)->cf_if.if_cs) == SEL_UPL)
+#define	CLKF_BASEPRI(framep)	((framep)->cf_if.if_ppl == 0)
+#define	CLKF_PC(framep)		((framep)->cf_if.if_eip)
+
+#define	resettodr()	/* no todr to set */
+
+/*
+ * Preempt the current process if in interrupt from user mode,
+ * or after the current trap/syscall if in system mode.
+ */
+#define	need_resched()	{ want_resched++; aston(); }
+
+/*
+ * Give a profiling tick to the current process from the softclock
+ * interrupt.  On tahoe, request an ast to send us through trap(),
+ * marking the proc as needing a profiling tick.
+ */
+#define	profile_tick(p, framep)	{ (p)->p_flag |= P_OWEUPC; aston(); }
+
+/*
+ * Notify the current process (p) that it has a signal pending,
+ * process as soon as possible.
+ */
+#define	signotify(p)	aston()
+
+#define aston() (astpending++)
+
+int	astpending;		/* need to trap before returning to user mode */
+int	want_resched;		/* resched() was called */
+
+/*
+ * Kinds of processor
+ */
+
+#define	CPU_386SX	0
+#define	CPU_386		1
+#define	CPU_486SX	2
+#define	CPU_486		3
+#define	CPU_586		4
+
+/*
+ * CTL_MACHDEP definitions.
+ */
+#define	CPU_CONSDEV		1	/* dev_t: console terminal device */
+#define	CPU_MAXID		2	/* number of valid machdep ids */
+
+#define CTL_MACHDEP_NAMES { \
+	{ 0, 0 }, \
+	{ "console_device", CTLTYPE_STRUCT }, \
+}

--- a/src-headers/machine/limits.h
+++ b/src-headers/machine/limits.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 1988, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)limits.h	8.4 (Berkeley) 4/28/95
+ */
+
+#define	CHAR_BIT	8		/* number of bits in a char */
+#define	MB_LEN_MAX	6		/* Allow 31 bit UTF2 */
+
+
+#define	CLK_TCK		60		/* ticks per second */
+
+/*
+ * According to ANSI (section 2.2.4.2), the values below must be usable by
+ * #if preprocessing directives.  Additionally, the expression must have the
+ * same type as would an expression that is an object of the corresponding
+ * type converted according to the integral promotions.  The subtraction for
+ * INT_MIN and LONG_MIN is so the value is not unsigned; 2147483648 is an
+ * unsigned int for 32-bit two's complement ANSI compilers (section 3.1.3.2).
+ * These numbers work for pcc as well.  The UINT_MAX and ULONG_MAX values
+ * are written as hex so that GCC will be quiet about large integer constants.
+ */
+#define	SCHAR_MAX	127		/* min value for a signed char */
+#define	SCHAR_MIN	(-128)		/* max value for a signed char */
+
+#define	UCHAR_MAX	255		/* max value for an unsigned char */
+#define	CHAR_MAX	127		/* max value for a char */
+#define	CHAR_MIN	(-128)		/* min value for a char */
+
+#define	USHRT_MAX	65535		/* max value for an unsigned short */
+#define	SHRT_MAX	32767		/* max value for a short */
+#define	SHRT_MIN	(-32768)	/* min value for a short */
+
+#define	UINT_MAX	0xffffffff	/* max value for an unsigned int */
+#define	INT_MAX		2147483647	/* max value for an int */
+#define	INT_MIN		(-2147483647-1)	/* min value for an int */
+
+#define	ULONG_MAX	0xffffffffL	/* max value for an unsigned long */
+#define	LONG_MAX	2147483647L	/* max value for a long */
+					/* min value for a long */
+#define	LONG_MIN	(-2147483647L-1L)
+
+#if !defined(_ANSI_SOURCE)
+#define	SSIZE_MAX	INT_MAX		/* max value for a ssize_t */
+
+#if !defined(_POSIX_SOURCE)
+#define	SIZE_T_MAX	UINT_MAX	/* max value for a size_t */
+
+/* GCC requires that quad constants be written as expressions. */
+#define	UQUAD_MAX	((u_quad_t)0-1)	/* max value for a uquad_t */
+					/* max value for a quad_t */
+#define	QUAD_MAX	((quad_t)(UQUAD_MAX >> 1))
+#define	QUAD_MIN	(-QUAD_MAX-1)	/* min value for a quad_t */
+
+#endif /* !_POSIX_SOURCE */
+#endif /* !_ANSI_SOURCE */

--- a/src-headers/machine/param.h
+++ b/src-headers/machine/param.h
@@ -1,0 +1,210 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * William Jolitz.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)param.h	8.3 (Berkeley) 5/14/95
+ */
+
+/*
+ * Machine dependent constants for Intel 386.
+ */
+
+#define MACHINE "i386"
+#define NCPUS 1
+
+/*
+ * Round p (pointer or byte index) up to a correctly-aligned value for all
+ * data types (int, long, ...).   The result is u_int and must be cast to
+ * any desired pointer type.
+ */
+#define	ALIGNBYTES	3
+#define	ALIGN(p)	(((u_int)(p) + ALIGNBYTES) &~ ALIGNBYTES)
+
+#define	NBPG		4096		/* bytes/page */
+#define	PGOFSET		(NBPG-1)	/* byte offset into page */
+#define	PGSHIFT		12		/* LOG2(NBPG) */
+#define	NPTEPG		(NBPG/(sizeof (struct pte)))
+
+#define NBPDR		(1024*NBPG)	/* bytes/page dir */
+#define	PDROFSET	(NBPDR-1)	/* byte offset into page dir */
+#define	PDRSHIFT	22		/* LOG2(NBPDR) */
+
+#define	KERNBASE	0xFE000000	/* start of kernel virtual */
+#define	BTOPKERNBASE	((u_long)KERNBASE >> PGSHIFT)
+
+#define	DEV_BSIZE	512
+#define	DEV_BSHIFT	9		/* log2(DEV_BSIZE) */
+#define BLKDEV_IOSIZE	2048
+#define	MAXPHYS		(64 * 1024)	/* max raw I/O transfer size */
+
+#define	CLSIZE		1
+#define	CLSIZELOG2	0
+
+/* NOTE: SSIZE, SINCR and UPAGES must be multiples of CLSIZE */
+#define	SSIZE	1		/* initial stack size/NBPG */
+#define	SINCR	1		/* increment of stack/NBPG */
+
+#define	UPAGES	2		/* pages of u-area */
+
+/*
+ * Constants related to network buffer management.
+ * MCLBYTES must be no larger than CLBYTES (the software page size), and,
+ * on machines that exchange pages of input or output buffers with mbuf
+ * clusters (MAPPED_MBUFS), MCLBYTES must also be an integral multiple
+ * of the hardware page size.
+ */
+#define	MSIZE		128		/* size of an mbuf */
+#define	MCLBYTES	1024
+#define	MCLSHIFT	10
+#define	MCLOFSET	(MCLBYTES - 1)
+#ifndef NMBCLUSTERS
+#ifdef GATEWAY
+#define	NMBCLUSTERS	512		/* map size, max cluster allocation */
+#else
+#define	NMBCLUSTERS	256		/* map size, max cluster allocation */
+#endif
+#endif
+
+/*
+ * Size of kernel malloc arena in CLBYTES-sized logical pages
+ */ 
+#ifndef NKMEMCLUSTERS
+#define	NKMEMCLUSTERS	(2048*1024/CLBYTES)
+#endif
+/*
+ * Some macros for units conversion
+ */
+/* Core clicks (4096 bytes) to segments and vice versa */
+#define	ctos(x)	(x)
+#define	stoc(x)	(x)
+
+/* Core clicks (4096 bytes) to disk blocks */
+#define	ctod(x)	((x)<<(PGSHIFT-DEV_BSHIFT))
+#define	dtoc(x)	((x)>>(PGSHIFT-DEV_BSHIFT))
+#define	dtob(x)	((x)<<DEV_BSHIFT)
+
+/* clicks to bytes */
+#define	ctob(x)	((x)<<PGSHIFT)
+
+/* bytes to clicks */
+#define	btoc(x)	(((unsigned)(x)+(NBPG-1))>>PGSHIFT)
+
+#define	btodb(bytes)	 		/* calculates (bytes / DEV_BSIZE) */ \
+	((bytes) >> DEV_BSHIFT)
+#define	dbtob(db)			/* calculates (db * DEV_BSIZE) */ \
+	((db) << DEV_BSHIFT)
+
+/*
+ * Map a ``block device block'' to a file system block.
+ * This should be device dependent, and will be if we
+ * add an entry to cdevsw/bdevsw for that purpose.
+ * For now though just use DEV_BSIZE.
+ */
+#define	bdbtofsb(bn)	((bn) / (BLKDEV_IOSIZE/DEV_BSIZE))
+
+/*
+ * Mach derived conversion macros
+ */
+#define i386_round_pdr(x)	((((unsigned)(x)) + NBPDR - 1) & ~(NBPDR-1))
+#define i386_trunc_pdr(x)	((unsigned)(x) & ~(NBPDR-1))
+#define i386_round_page(x)	((((unsigned)(x)) + NBPG - 1) & ~(NBPG-1))
+#define i386_trunc_page(x)	((unsigned)(x) & ~(NBPG-1))
+#define i386_btod(x)		((unsigned)(x) >> PDRSHIFT)
+#define i386_dtob(x)		((unsigned)(x) << PDRSHIFT)
+#define i386_btop(x)		((unsigned)(x) >> PGSHIFT)
+#define i386_ptob(x)		((unsigned)(x) << PGSHIFT)
+
+#ifndef KERNEL
+/* DELAY is in locore.s for the kernel */
+#define	DELAY(n)	{ register int N = (n); while (--N > 0); }
+#endif
+
+#ifndef _SIMPLELOCK_H_
+#define _SIMPLELOCK_H_
+/*
+ * A simple spin lock.
+ *
+ * This structure only sets one bit of data, but is sized based on the
+ * minimum word size that can be operated on by the hardware test-and-set
+ * instruction. It is only needed for multiprocessors, as uniprocessors
+ * will always run to completion or a sleep. It is an error to hold one
+ * of these locks while a process is sleeping.
+ */
+struct simplelock {
+	int	lock_data;
+};
+
+#if !defined(DEBUG) && NCPUS > 1
+/*
+ * The simple-lock routines are the primitives out of which the lock
+ * package is built. The machine-dependent code must implement an
+ * atomic test_and_set operation that indivisibly sets the simple lock
+ * to non-zero and returns its old value. It also assumes that the
+ * setting of the lock to zero below is indivisible. Simple locks may
+ * only be used for exclusive locks.
+ */
+static __inline void
+simple_lock_init(lkp)
+	struct simplelock *lkp;
+{
+
+	lkp->lock_data = 0;
+}
+
+static __inline void
+simple_lock(lkp)
+	__volatile struct simplelock *lkp;
+{
+
+	while (test_and_set(&lkp->lock_data))
+		continue;
+}
+
+static __inline int
+simple_lock_try(lkp)
+	__volatile struct simplelock *lkp;
+{
+
+	return (!test_and_set(&lkp->lock_data))
+}
+
+static __inline void
+simple_unlock(lkp)
+	__volatile struct simplelock *lkp;
+{
+
+	lkp->lock_data = 0;
+}
+#endif /* NCPUS > 1 */
+#endif /* !_SIMPLELOCK_H_ */

--- a/src-headers/machine/proc.h
+++ b/src-headers/machine/proc.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 1992, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)proc.h	8.1 (Berkeley) 6/11/93
+ */
+
+/*
+ * Machine-dependent part of the proc structure for hp300.
+ */
+struct mdproc {
+	int	md_flags;		/* machine-dependent flags */
+	int	*md_regs;		/* registers on current frame */
+};
+
+/* md_flags */
+#define	MDP_AST		0x0001	/* async trap pending */

--- a/src-headers/machine/signal.h
+++ b/src-headers/machine/signal.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 1986, 1989, 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)signal.h	8.2 (Berkeley) 5/3/95
+ */
+
+/*
+ * Machine-dependent signal definitions
+ */
+
+typedef int sig_atomic_t;
+
+#if !defined(_POSIX_SOURCE) && !defined(_ANSI_SOURCE)
+#include <machine/trap.h>	/* codes for SIGILL, SIGFPE */
+
+/*
+ * Information pushed on stack when a signal is delivered.
+ * This is used by the kernel to restore state following
+ * execution of the signal handler.  It is also made available
+ * to the handler to allow it to restore state properly if
+ * a non-standard exit is performed.
+ */
+struct	sigcontext {
+	int	sc_onstack;	/* sigstack state to restore */
+	int	sc_mask;	/* signal mask to restore */
+	int	sc_sp;		/* sp to restore */
+	int	sc_fp;		/* fp to restore */
+	int	sc_ap;		/* ap to restore */
+	int	sc_pc;		/* pc to restore */
+	int	sc_ps;		/* psl to restore */
+};
+#endif

--- a/src-headers/machine/trap.h
+++ b/src-headers/machine/trap.h
@@ -1,0 +1,96 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * William Jolitz.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)trap.h	8.1 (Berkeley) 6/11/93
+ */
+
+/*
+ * Trap type values
+ * also known in trap.c for name strings
+ */
+
+#define	T_RESADFLT	0	/* reserved addressing */
+#define	T_PRIVINFLT	1	/* privileged instruction */
+#define	T_RESOPFLT	2	/* reserved operand */
+#define	T_BPTFLT	3	/* breakpoint instruction */
+#define	T_SYSCALL	5	/* system call (kcall) */
+#define	T_ARITHTRAP	6	/* arithmetic trap */
+#define	T_ASTFLT	7	/* system forced exception */
+#define	T_SEGFLT	8	/* segmentation (limit) fault */
+#define	T_PROTFLT	9	/* protection fault */
+#define	T_TRCTRAP	10	/* trace trap */
+#define	T_PAGEFLT	12	/* page fault */
+#define	T_TABLEFLT	13	/* page table fault */
+#define	T_ALIGNFLT	14	/* alignment fault */
+#define	T_KSPNOTVAL	15	/* kernel stack pointer not valid */
+#define	T_BUSERR	16	/* bus error */
+#define	T_KDBTRAP	17	/* kernel debugger trap */
+
+#define	T_DIVIDE	18	/* integer divide fault */
+#define	T_NMI		19	/* non-maskable trap */
+#define	T_OFLOW		20	/* overflow trap */
+#define	T_BOUND		21	/* bound instruction fault */
+#define	T_DNA		22	/* device not available fault */
+#define	T_DOUBLEFLT	23	/* double fault */
+#define	T_FPOPFLT	24	/* fp coprocessor operand fetch fault */
+#define	T_TSSFLT	25	/* invalid tss fault */
+#define	T_SEGNPFLT	26	/* segment not present fault */
+#define	T_STKFLT	27	/* stack fault */
+#define	T_RESERVED	28	/* reserved fault base */
+
+/* definitions for <sys/signal.h> */
+#define	    ILL_RESAD_FAULT	T_RESADFLT
+#define	    ILL_PRIVIN_FAULT	T_PRIVINFLT
+#define	    ILL_RESOP_FAULT	T_RESOPFLT
+#define	    ILL_ALIGN_FAULT	T_ALIGNFLT
+#define	    ILL_FPOP_FAULT	T_FPOPFLT	/* coprocessor operand fault */
+
+/* codes for SIGFPE/ARITHTRAP */
+#define	    FPE_INTOVF_TRAP	0x1	/* integer overflow */
+#define	    FPE_INTDIV_TRAP	0x2	/* integer divide by zero */
+#define	    FPE_FLTDIV_TRAP	0x3	/* floating/decimal divide by zero */
+#define	    FPE_FLTOVF_TRAP	0x4	/* floating overflow */
+#define	    FPE_FLTUND_TRAP	0x5	/* floating underflow */
+#define	    FPE_FPU_NP_TRAP	0x6	/* floating point unit not present */
+#define	    FPE_SUBRNG_TRAP	0x7	/* subrange out of bounds */
+
+/* codes for SIGBUS */
+#define	    BUS_PAGE_FAULT	T_PAGEFLT	/* page fault protection base */
+#define	    BUS_SEGNP_FAULT	T_SEGNPFLT	/* segment not present */
+#define	    BUS_STK_FAULT	T_STKFLT	/* stack segment */
+#define	    BUS_SEGM_FAULT	T_RESERVED	/* segment protection base */
+
+/* Trap's coming from user mode */
+#define	T_USER	0x100

--- a/src-headers/sys/systm.h
+++ b/src-headers/sys/systm.h
@@ -1,0 +1,170 @@
+/*-
+ * Copyright (c) 1982, 1988, 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)systm.h	8.7 (Berkeley) 3/29/95
+ */
+
+/*
+ * The `securelevel' variable controls the security level of the system.
+ * It can only be decreased by process 1 (/sbin/init).
+ *
+ * Security levels are as follows:
+ *   -1	permannently insecure mode - always run system in level 0 mode.
+ *    0	insecure mode - immutable and append-only flags make be turned off.
+ *	All devices may be read or written subject to permission modes.
+ *    1	secure mode - immutable and append-only flags may not be changed;
+ *	raw disks of mounted filesystems, /dev/mem, and /dev/kmem are
+ *	read-only.
+ *    2	highly secure mode - same as (1) plus raw disks are always
+ *	read-only whether mounted or not. This level precludes tampering 
+ *	with filesystems by unmounting them, but also inhibits running
+ *	newfs while the system is secured.
+ *
+ * In normal operation, the system runs in level 0 mode while single user
+ * and in level 1 mode while multiuser. If level 2 mode is desired while
+ * running multiuser, it can be set in the multiuser startup script
+ * (/etc/rc.local) using sysctl(1). If it is desired to run the system
+ * in level 0 mode while multiuser, initialize the variable securelevel
+ * in /sys/kern/kern_sysctl.c to -1. Note that it is NOT initialized to
+ * zero as that would allow the vmunix binary to be patched to -1.
+ * Without initialization, securelevel loads in the BSS area which only
+ * comes into existence when the kernel is loaded and hence cannot be
+ * patched by a stalking hacker.
+ */
+extern int securelevel;		/* system security level */
+extern const char *panicstr;	/* panic message */
+extern char version[];		/* system version */
+extern char copyright[];	/* system copyright */
+
+extern int nblkdev;		/* number of entries in bdevsw */
+extern int nchrdev;		/* number of entries in cdevsw */
+extern int nswdev;		/* number of swap devices */
+extern int nswap;		/* size of swap space */
+
+extern int selwait;		/* select timeout address */
+
+extern u_char curpriority;	/* priority of current process */
+
+extern int maxmem;		/* max memory per process */
+extern int physmem;		/* physical memory */
+
+extern dev_t dumpdev;		/* dump device */
+extern long dumplo;		/* offset into dumpdev */
+
+extern dev_t rootdev;		/* root device */
+extern struct vnode *rootvp;	/* vnode equivalent to above */
+
+extern dev_t swapdev;		/* swapping device */
+extern struct vnode *swapdev_vp;/* vnode equivalent to above */
+
+extern struct sysent {		/* system call table */
+	short	sy_narg;	/* number of args */
+	short	sy_argsize;	/* total size of arguments */
+	int	(*sy_call)();	/* implementing function */
+} sysent[];
+extern int nsysent;
+#define	SCARG(p,k)	((p)->k.datum)	/* get arg from args pointer */
+
+extern int boothowto;		/* reboot flags, from console subsystem */
+
+/* casts to keep lint happy */
+#define	insque(q,p)	_insque((caddr_t)q,(caddr_t)p)
+#define	remque(q)	_remque((caddr_t)q)
+
+/*
+ * General function declarations.
+ */
+int	nullop __P((void));
+int	enodev __P((void));
+int	enoioctl __P((void));
+int	enxio __P((void));
+int	eopnotsupp __P((void));
+int	einval __P((void));
+int	seltrue __P((dev_t dev, int which, struct proc *p));
+void	*hashinit __P((int count, int type, u_long *hashmask));
+int	nosys __P((struct proc *, void *, register_t *));
+
+#ifdef __GNUC__
+volatile void	panic __P((const char *, ...));
+#else
+void	panic __P((const char *, ...));
+#endif
+void	tablefull __P((const char *));
+void	addlog __P((const char *, ...));
+void	log __P((int, const char *, ...));
+void	printf __P((const char *, ...));
+int	sprintf __P((char *buf, const char *, ...));
+void	ttyprintf __P((struct tty *, const char *, ...));
+
+void	bcopy __P((const void *from, void *to, u_int len));
+void	ovbcopy __P((const void *from, void *to, u_int len));
+void	bzero __P((void *buf, u_int len));
+
+int	copystr __P((void *kfaddr, void *kdaddr, u_int len, u_int *done));
+int	copyinstr __P((void *udaddr, void *kaddr, u_int len, u_int *done));
+int	copyoutstr __P((void *kaddr, void *udaddr, u_int len, u_int *done));
+int	copyin __P((void *udaddr, void *kaddr, u_int len));
+int	copyout __P((void *kaddr, void *udaddr, u_int len));
+
+int	fubyte __P((void *base));
+#ifdef notdef
+int	fuibyte __P((void *base));
+#endif
+int	subyte __P((void *base, int byte));
+int	suibyte __P((void *base, int byte));
+int	fuword __P((void *base));
+int	fuiword __P((void *base));
+int	suword __P((void *base, int word));
+int	suiword __P((void *base, int word));
+
+int	hzto __P((struct timeval *tv));
+void	timeout __P((void (*func)(void *), void *arg, int ticks));
+void	untimeout __P((void (*func)(void *), void *arg));
+void	realitexpire __P((void *));
+
+struct clockframe;
+void	hardclock __P((struct clockframe *frame));
+void	softclock __P((void));
+void	statclock __P((struct clockframe *frame));
+
+void	initclocks __P((void));
+
+void	startprofclock __P((struct proc *));
+void	stopprofclock __P((struct proc *));
+void	setstatclockrate __P((int hzrate));
+
+#include <libkern/libkern.h>

--- a/src-uland/fs-server/Makefile
+++ b/src-uland/fs-server/Makefile
@@ -4,11 +4,17 @@ PROG = fs_server
 
 CC ?= cc
 CFLAGS ?= -O2
+CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
+            -I../../include -I../../sys -I../../sys/sys \
+            -I../../sys/i386/include
 
 all: $(PROG)
 
 $(PROG): $(OBJS)
-	$(CC) $(CFLAGS) $(OBJS) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(OBJS) -o $@
+
+%.o: %.c
+	        $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(OBJS) $(PROG)

--- a/src-uland/libkern_sched/Makefile
+++ b/src-uland/libkern_sched/Makefile
@@ -4,6 +4,9 @@ LIB  = libkern_sched.a
 CC ?= cc
 AR ?= ar
 CFLAGS ?= -O2
+CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
+            -I../../include -I../../sys -I../../sys/sys \
+            -I../../sys/i386/include
 
 all: $(LIB)
 
@@ -11,7 +14,7 @@ $(LIB): $(OBJS)
 	$(AR) rcs $@ $(OBJS)
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(OBJS) $(LIB)

--- a/src-uland/libvm/Makefile
+++ b/src-uland/libvm/Makefile
@@ -5,11 +5,17 @@ LIB  = libvm.a
 CC ?= cc
 AR ?= ar
 CFLAGS ?= -O2
+CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
+            -I../../include -I../../sys -I../../sys/sys \
+            -I../../sys/i386/include
 
 all: $(LIB)
 
 $(LIB): $(OBJS)
-	$(AR) rcs $@ $(OBJS)
+        $(AR) rcs $@ $(OBJS)
+
+%.o: %.c
+        $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(OBJS) $(LIB)

--- a/src-uland/servers/proc_manager/Makefile
+++ b/src-uland/servers/proc_manager/Makefile
@@ -2,7 +2,9 @@ OBJS = kern_proc.o
 PROG = proc_manager
 CC ?= cc
 CFLAGS ?= -O2
-CPPFLAGS ?= -I../../../src-headers -I../../../sys -I../../../sys/i386/include
+CPPFLAGS ?= -I../../../src-headers -I../../../src-headers/machine \
+            -I../../../include -I../../../sys -I../../../sys/sys \
+            -I../../../sys/i386/include
 
 all: $(PROG)
 


### PR DESCRIPTION
## Summary
- copy missing machine headers into src-headers
- copy systm.h for user-space libraries
- propagate CPPFLAGS in microkernel/userland Makefiles
- document the new header collection step in microkernel plan

## Testing
- `make -C src-kernel clean all`
- `make -C src-uland/libkern_sched clean all` *(fails: machine/frame.h missing)*
- `make -C src-uland/fs-server clean all` *(fails: incomplete types in headers)*