### PR TITLE
Improve userland build headers

### DIFF
--- a/src-headers/machine/types.h
+++ b/src-headers/machine/types.h
@@ -61,5 +61,6 @@ typedef	int			  int32_t;
 typedef	unsigned int		u_int32_t;
 typedef	long long		  int64_t;
 typedef	unsigned long long	u_int64_t;
+typedef long register_t; /* minimal register type for user servers */
 
 #endif	/* _MACHTYPES_H_ */

--- a/src-headers/sys/vnode_if.h
+++ b/src-headers/sys/vnode_if.h
@@ -1,0 +1,10 @@
+#ifndef _SRC_HEADERS_VNODE_IF_H_
+#define _SRC_HEADERS_VNODE_IF_H_
+/*
+ * Placeholder vnode interface definitions for user-space builds.
+ * The real header is generated from vnode_if.src in the kernel tree.
+ */
+struct vnode;
+struct vop_bwrite_args; /* opaque for prototypes */
+extern int vnodeop_desc_stub;
+#endif /* _SRC_HEADERS_VNODE_IF_H_ */

--- a/src-headers/vnode_if.h
+++ b/src-headers/vnode_if.h
@@ -1,0 +1,1 @@
+sys/vnode_if.h

--- a/src-uland/fs-server/Makefile
+++ b/src-uland/fs-server/Makefile
@@ -7,6 +7,7 @@ CFLAGS ?= -O2
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
+CFLAGS   += -DKERNEL
 
 all: $(PROG)
 

--- a/src-uland/fs-server/vfs_bio.c
+++ b/src-uland/fs-server/vfs_bio.c
@@ -48,6 +48,8 @@
 #include <sys/trace.h>
 #include <sys/malloc.h>
 #include <sys/resourcevar.h>
+#include <sys/time.h>
+#include <sys/errno.h>
 
 /*
  * Definitions for the buffer hash lists.

--- a/src-uland/libkern_sched/Makefile
+++ b/src-uland/libkern_sched/Makefile
@@ -7,6 +7,7 @@ CFLAGS ?= -O2
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
+CFLAGS   += -DKERNEL
 
 all: $(LIB)
 

--- a/src-uland/libvm/Makefile
+++ b/src-uland/libvm/Makefile
@@ -8,6 +8,7 @@ CFLAGS ?= -O2
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
+CFLAGS   += -DKERNEL
 
 all: $(LIB)
 

--- a/src-uland/servers/proc_manager/Makefile
+++ b/src-uland/servers/proc_manager/Makefile
@@ -5,6 +5,7 @@ CFLAGS ?= -O2
 CPPFLAGS ?= -I../../../src-headers -I../../../src-headers/machine \
             -I../../../include -I../../../sys -I../../../sys/sys \
             -I../../../sys/i386/include
+CFLAGS   += -DKERNEL
 
 all: $(PROG)
 


### PR DESCRIPTION
## Summary
- define `register_t` in userland headers
- add stub `vnode_if.h` for userland build
- include kernel mode flag in userland makefiles
- include missing headers in `vfs_bio.c`

## Testing
- `make -C src-uland/fs-server clean`
- `make -C src-uland/fs-server` *(fails: invalid use of undefined type `struct vop_bwrite_args`)*