### PR TITLE
Add clang tooling and tidy integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 80

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: '-*,clang-analyzer-*,modernize-*'
+WarningsAsErrors: ''
+FormatStyle: file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format
+        entry: clang-format -i
+        language: system
+        files: \.(c|h)$
+      - id: clang-tidy
+        name: clang-tidy
+        entry: clang-tidy
+        language: system
+        files: \.(c|h)$

--- a/docs/ci_workflows.md
+++ b/docs/ci_workflows.md
@@ -1,6 +1,8 @@
 # GitHub CI Workflows
 
 This document describes recommended workflows for integrating CodeQL security scanning and Reviewdog-based linting. Sample workflow files can be found in `.github/workflows/codeql-analysis.yml` and `.github/workflows/reviewdog.yml`.
+For local linting before pushing, enable the `pre-commit` hooks described in
+[precommit.md](precommit.md).
 
 ## CodeQL with Bundled Query Packs
 

--- a/docs/modernization_plan.md
+++ b/docs/modernization_plan.md
@@ -18,6 +18,7 @@ For a summary of directory mappings during the reorganization see
   modern build options.
 - Prototype CMake build files using **CMake 3.16+** to evaluate a cross-platform build system.
 - Integrate static analysis tools such as `clang-tidy`.
+- Set up a `pre-commit` hook to run `clang-format` and `clang-tidy`.
 
 ## Phase 3: Userland Modernization
 - Update core libraries (`libc`, `libm`) to use ANSI C prototypes.

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -1,0 +1,14 @@
+# Using pre-commit
+
+This repository provides a `.pre-commit-config.yaml` with hooks for
+`clang-format` and `clang-tidy`. Install the pre-commit tool and
+activate the hooks to automatically format code and run static analysis
+before each commit:
+
+```sh
+pip install pre-commit
+pre-commit install
+```
+
+The hooks rely on the configuration files `.clang-format` and
+`.clang-tidy` at the repository root.

--- a/include/exokernel.h
+++ b/include/exokernel.h
@@ -3,8 +3,10 @@
 
 /* Interface exported by the exokernel stubs. */
 
-void   kern_sched_init(void);
-int    kern_open(const char *path, int flags);
-int    kern_vm_fault(void *addr);
+#include <stdbool.h>
+
+void kern_sched_init(void);
+int kern_open(const char *path, int flags);
+bool kern_vm_fault(void *addr);
 
 #endif /* EXOKERNEL_H */

--- a/src-kernel/Makefile
+++ b/src-kernel/Makefile
@@ -3,15 +3,20 @@ LIB = libkern_stubs.a
 
 CC ?= cc
 AR ?= ar
-CFLAGS ?= -O2
+CLANG_TIDY ?= clang-tidy
+CFLAGS ?= -O2 -std=c2x
 
 all: $(LIB)
-
+	
 $(LIB): $(OBJS)
 	$(AR) rcs $@ $(OBJS)
-
+	
 %.o: %.c
+	@$(CLANG_TIDY) $< -- $(CC) $(CFLAGS) || true
 	$(CC) $(CFLAGS) -c $< -o $@
-
+	
 clean:
 	rm -f $(OBJS) $(LIB)
+	
+tidy:
+	$(CLANG_TIDY) $(OBJS:.o=.c) -- $(CC) $(CFLAGS)

--- a/src-kernel/meson.build
+++ b/src-kernel/meson.build
@@ -1,0 +1,14 @@
+project('kern_stubs', 'c', default_options : ['c_std=c23'])
+
+srcs = ['sched_hooks.c', 'vm_hooks.c', 'vfs_hooks.c']
+libkern = static_library('kern_stubs', srcs,
+                         include_directories : include_directories('../include'))
+
+clangtidy = find_program('clang-tidy', required : false)
+if clangtidy.found()
+  foreach f : srcs
+    run_target('tidy-' + f,
+               command : [clangtidy, f, '--', '-I../include'])
+  endforeach
+  run_target('tidy', command : ['true'])
+endif

--- a/src-kernel/vm_hooks.c
+++ b/src-kernel/vm_hooks.c
@@ -1,9 +1,5 @@
-#include <stdio.h>
 #include "../include/exokernel.h"
+#include <stdbool.h>
 /* Stubs delegating to user-space VM library */
-extern int uland_vm_fault(void *addr);
-int
-kern_vm_fault(void *addr)
-{
-    return uland_vm_fault(addr);
-}
+extern bool uland_vm_fault(void *addr);
+bool kern_vm_fault(void *addr) { return uland_vm_fault(addr); }

--- a/usr/src/share/mk/bsd.lib.mk
+++ b/usr/src/share/mk/bsd.lib.mk
@@ -11,6 +11,7 @@ LIBOWN?=	bin
 LIBMODE?=	444
 
 STRIP?=	-s
+CLANG_TIDY?=	clang-tidy
 
 BINGRP?=	bin
 BINOWN?=	bin
@@ -145,6 +146,11 @@ afterinstall: maninstall
 
 .if !target(lint)
 lint:
+.endif
+
+.if !target(tidy)
+tidy:
+@${CLANG_TIDY} ${SRCS:M*.c} -- ${CFLAGS}
 .endif
 
 .if !target(tags)

--- a/usr/src/share/mk/bsd.prog.mk
+++ b/usr/src/share/mk/bsd.prog.mk
@@ -12,6 +12,7 @@
 CFLAGS+=${COPTS}
 
 STRIP?=	-s
+CLANG_TIDY?=	clang-tidy
 
 BINGRP?=	bin
 BINOWN?=	bin
@@ -151,7 +152,14 @@ realinstall: beforeinstall
 .if !target(lint)
 lint: ${SRCS} _PROGSUBDIR
 .if defined(PROG)
-	@${LINT} ${LINTFLAGS} ${CFLAGS} ${.ALLSRC} | more 2>&1
+@${LINT} ${LINTFLAGS} ${CFLAGS} ${.ALLSRC} | more 2>&1
+.endif
+.endif
+
+.if !target(tidy)
+tidy: ${SRCS} _PROGSUBDIR
+.if defined(PROG)
+@${CLANG_TIDY} ${.ALLSRC:M*.c} -- ${CFLAGS}
 .endif
 .endif
 


### PR DESCRIPTION
## Summary
- add clang-format and clang-tidy configs
- document pre-commit hooks
- modernize vm_hooks to use bool
- integrate clang-tidy in mk and meson builds

## Testing
- `make -C src-kernel clean && make -C src-kernel`
- `meson setup builddir src-kernel` *(fails: `meson` not installed)*