### PR TITLE
Add clang-tidy support and update pre-commit

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,5 @@
 Checks: '-*,clang-analyzer-*,modernize-*'
 WarningsAsErrors: ''
 FormatStyle: file
+# clang-tidy is invoked via tools/run_clang_tidy.sh which passes
+# -std=c23 for C sources and -std=c++17 for C++ sources.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ repos:
         name: clang-format
         entry: clang-format -i
         language: system
-        files: \.(c|h)$
+        files: \.(c|cpp|h|hpp)$
       - id: clang-tidy
         name: clang-tidy
-        entry: clang-tidy
+        entry: tools/run_clang_tidy.sh
         language: system
-        files: \.(c|h)$
+        files: \.(c|cpp|h|hpp)$

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -1,9 +1,9 @@
 # Using pre-commit
 
 This repository provides a `.pre-commit-config.yaml` with hooks for
-`clang-format` and `clang-tidy`. Install the pre-commit tool and
-activate the hooks to automatically format code and run static analysis
-before each commit:
+`clang-format` and `clang-tidy`. Running `setup.sh` installs the
+`pre-commit` tool along with `clang-tidy`. Activate the hooks to
+automatically format code and run static analysis before each commit:
 
 ```sh
 pip install pre-commit
@@ -11,4 +11,6 @@ pre-commit install
 ```
 
 The hooks rely on the configuration files `.clang-format` and
-`.clang-tidy` at the repository root.
+`.clang-tidy` at the repository root.  A helper script
+`tools/run_clang_tidy.sh` selects the appropriate language standard
+(C23 or C++17) when invoking `clang-tidy`.

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ apt-get update -y
 # core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
-  clang-format uncrustify astyle editorconfig pre-commit \
+  clang-format clang-tidy uncrustify astyle editorconfig pre-commit \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \

--- a/tools/run_clang_tidy.sh
+++ b/tools/run_clang_tidy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+file="$1"
+args=("${@:2}")
+if [[ "$file" == *.c ]]; then
+    clang-tidy "$file" "${args[@]}" -- -std=c23
+elif [[ "$file" == *.cpp || "$file" == *.cc || "$file" == *.cxx ]]; then
+    clang-tidy "$file" "${args[@]}" -- -std=c++17
+else
+    clang-tidy "$file" "${args[@]}"
+fi


### PR DESCRIPTION
## Summary
- ensure clang-tidy is installed via `setup.sh`
- provide helper script for running clang-tidy with C23/C++17
- hook script into pre-commit configuration
- document the new workflow and installation
- comment about clang-tidy standards

## Testing
- `make -C src-kernel clean all`
