### PR TITLE
Fix missing include guards

### DIFF
--- a/src-headers/machine/cpu.h
+++ b/src-headers/machine/cpu.h
@@ -36,6 +36,9 @@
  *	@(#)cpu.h	8.5 (Berkeley) 5/17/95
  */
 
+#ifndef _MACHINE_CPU_H_
+#define _MACHINE_CPU_H_
+
 /*
  * Definitions unique to i386 cpu support.
  */
@@ -113,3 +116,4 @@ int	want_resched;		/* resched() was called */
 	{ 0, 0 }, \
 	{ "console_device", CTLTYPE_STRUCT }, \
 }
+#endif /* !_MACHINE_CPU_H_ */

--- a/src-headers/machine/limits.h
+++ b/src-headers/machine/limits.h
@@ -33,6 +33,9 @@
  *	@(#)limits.h	8.4 (Berkeley) 4/28/95
  */
 
+#ifndef _MACHINE_LIMITS_H_
+#define _MACHINE_LIMITS_H_
+
 #define	CHAR_BIT	8		/* number of bits in a char */
 #define	MB_LEN_MAX	6		/* Allow 31 bit UTF2 */
 
@@ -83,3 +86,4 @@
 
 #endif /* !_POSIX_SOURCE */
 #endif /* !_ANSI_SOURCE */
+#endif /* !_MACHINE_LIMITS_H_ */

--- a/src-headers/machine/proc.h
+++ b/src-headers/machine/proc.h
@@ -33,6 +33,9 @@
  *	@(#)proc.h	8.1 (Berkeley) 6/11/93
  */
 
+#ifndef _MACHINE_PROC_H_
+#define _MACHINE_PROC_H_
+
 /*
  * Machine-dependent part of the proc structure for hp300.
  */
@@ -43,3 +46,4 @@ struct mdproc {
 
 /* md_flags */
 #define	MDP_AST		0x0001	/* async trap pending */
+#endif /* !_MACHINE_PROC_H_ */

--- a/src-headers/machine/signal.h
+++ b/src-headers/machine/signal.h
@@ -33,6 +33,9 @@
  *	@(#)signal.h	8.2 (Berkeley) 5/3/95
  */
 
+#ifndef _MACHINE_SIGNAL_H_
+#define _MACHINE_SIGNAL_H_
+
 /*
  * Machine-dependent signal definitions
  */
@@ -59,3 +62,4 @@ struct	sigcontext {
 	int	sc_ps;		/* psl to restore */
 };
 #endif
+#endif /* !_MACHINE_SIGNAL_H_ */

--- a/src-headers/machine/trap.h
+++ b/src-headers/machine/trap.h
@@ -36,6 +36,9 @@
  *	@(#)trap.h	8.1 (Berkeley) 6/11/93
  */
 
+#ifndef _MACHINE_TRAP_H_
+#define _MACHINE_TRAP_H_
+
 /*
  * Trap type values
  * also known in trap.c for name strings
@@ -94,3 +97,4 @@
 
 /* Trap's coming from user mode */
 #define	T_USER	0x100
+#endif /* !_MACHINE_TRAP_H_ */

--- a/src-headers/sys/systm.h
+++ b/src-headers/sys/systm.h
@@ -38,6 +38,9 @@
  *	@(#)systm.h	8.7 (Berkeley) 3/29/95
  */
 
+#ifndef _SYS_SYSTM_H_
+#define _SYS_SYSTM_H_
+
 /*
  * The `securelevel' variable controls the security level of the system.
  * It can only be decreased by process 1 (/sbin/init).
@@ -168,3 +171,4 @@ void	stopprofclock __P((struct proc *));
 void	setstatclockrate __P((int hzrate));
 
 #include <libkern/libkern.h>
+#endif /* !_SYS_SYSTM_H_ */

--- a/usr/src/include/assert.h
+++ b/usr/src/include/assert.h
@@ -38,6 +38,9 @@
  *	@(#)assert.h	8.2 (Berkeley) 1/21/94
  */
 
+#ifndef _ASSERT_H_
+#define _ASSERT_H_
+
 /*
  * Unlike other ANSI header files, <assert.h> may usefully be included
  * multiple times, with and without NDEBUG defined.
@@ -63,3 +66,4 @@
 __BEGIN_DECLS
 void __assert __P((const char *, int, const char *));
 __END_DECLS
+#endif /* !_ASSERT_H_ */

--- a/usr/src/include/memory.h
+++ b/usr/src/include/memory.h
@@ -33,4 +33,8 @@
  *	@(#)memory.h	8.1 (Berkeley) 6/2/93
  */
 
+#ifndef _MEMORY_H_
+#define _MEMORY_H_
+
 #include <string.h>
+#endif /* !_MEMORY_H_ */

--- a/usr/src/include/mpool.h
+++ b/usr/src/include/mpool.h
@@ -33,6 +33,9 @@
  *	@(#)mpool.h	8.1 (Berkeley) 6/2/93
  */
 
+#ifndef _MPOOL_H_
+#define _MPOOL_H_
+
 /*
  * The memory pool scheme is a simple one.  Each in memory page is referenced
  * by a bucket which is threaded in three ways.  All active pages are threaded
@@ -133,3 +136,4 @@ int	 mpool_close __P((MPOOL *));
 void	 mpool_stat __P((MPOOL *));
 #endif
 __END_DECLS
+#endif /* !_MPOOL_H_ */

--- a/usr/src/include/stab.h
+++ b/usr/src/include/stab.h
@@ -33,6 +33,9 @@
  *	@(#)stab.h	8.1 (Berkeley) 6/2/93
  */
 
+#ifndef _STAB_H_
+#define _STAB_H_
+
 /*
  * The following are symbols used by various debuggers and by the Pascal
  * compiler.  Each of them must have one (or more) of the bits defined by
@@ -65,3 +68,4 @@
 #define	N_ECOMM		0xe4	/* end common */
 #define	N_ECOML		0xe8	/* end common (local name) */
 #define	N_LENG		0xfe	/* length of preceding entry */
+#endif /* !_STAB_H_ */

--- a/usr/src/include/strings.h
+++ b/usr/src/include/strings.h
@@ -33,4 +33,8 @@
  *	@(#)strings.h	8.1 (Berkeley) 6/2/93
  */
 
+#ifndef _STRINGS_H_
+#define _STRINGS_H_
+
 #include <string.h>
+#endif /* !_STRINGS_H_ */


### PR DESCRIPTION
## Summary
- add missing include guards for machine headers
- add guards for several user-space headers

## Testing
- `make -C src-kernel`