### PR TITLE
Add userland scheduler, VM, and filesystem hooks

### DIFF
--- a/src-headers/fs_server.h
+++ b/src-headers/fs_server.h
@@ -1,0 +1,6 @@
+#ifndef FS_SERVER_H
+#define FS_SERVER_H
+
+int fs_open(const char *path, int flags);
+
+#endif /* FS_SERVER_H */

--- a/src-headers/kern_sched.h
+++ b/src-headers/kern_sched.h
@@ -1,0 +1,8 @@
+#ifndef KERN_SCHED_H
+#define KERN_SCHED_H
+
+/* Derived from sys/kern/kern_synch.c */
+
+void uland_sched_init(void);
+
+#endif /* KERN_SCHED_H */

--- a/src-headers/libvm.h
+++ b/src-headers/libvm.h
@@ -1,0 +1,8 @@
+#ifndef LIBVM_H
+#define LIBVM_H
+
+#include <stdbool.h>
+
+bool uland_vm_fault(void *addr);
+
+#endif /* LIBVM_H */

--- a/src-uland/fs-server/Makefile
+++ b/src-uland/fs-server/Makefile
@@ -1,4 +1,4 @@
-SRCS = $(wildcard vfs_*.c)
+SRCS = fs_open.c $(wildcard vfs_*.c)
 OBJS = $(SRCS:.c=.o)
 PROG = fs_server
 

--- a/src-uland/fs-server/fs_open.c
+++ b/src-uland/fs-server/fs_open.c
@@ -1,0 +1,10 @@
+/* Simple wrapper used by the exokernel file hook. */
+#include <fcntl.h>
+#include <unistd.h>
+#include "fs_server.h"
+
+int
+fs_open(const char *path, int flags)
+{
+    return open(path, flags, 0);
+}

--- a/src-uland/libkern_sched/kern_sched.c
+++ b/src-uland/libkern_sched/kern_sched.c
@@ -660,13 +660,25 @@ setrunnable(p)
  */
 void
 resetpriority(p)
-	register struct proc *p;
+        register struct proc *p;
 {
 	register unsigned int newpriority;
 
 	newpriority = PUSER + p->p_estcpu / 4 + 2 * p->p_nice;
 	newpriority = min(newpriority, MAXPRI);
 	p->p_usrpri = newpriority;
-	if (newpriority < curpriority)
-		need_resched();
+        if (newpriority < curpriority)
+                need_resched();
+}
+
+/*
+ * Entry point called by the exokernel during startup.  Initialize
+ * scheduler state and start the periodic timer callbacks.
+ */
+void
+uland_sched_init(void)
+{
+        rqinit();
+        roundrobin(NULL);
+        schedcpu(NULL);
 }

--- a/src-uland/libvm/vm_entry.c
+++ b/src-uland/libvm/vm_entry.c
@@ -1,0 +1,12 @@
+/* Minimal page fault hook used by the exokernel. */
+#include <vm/vm.h>
+#include "libvm.h"
+
+extern vm_map_t kernel_map;
+
+bool
+uland_vm_fault(void *addr)
+{
+    return vm_fault(kernel_map, (vm_offset_t)addr, VM_PROT_READ|VM_PROT_WRITE,
+                    FALSE) == KERN_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- implement `uland_sched_init` and export via new header
- provide `fs_open` wrapper and header for file server
- add `uland_vm_fault` and header in libvm
- adjust build files to compile new code

## Testing
- `make -C src-uland/libkern_sched` *(fails: machine/frame.h missing)*
- `make -C src-uland/fs-server` *(fails: unknown type names in fcntl.h)*
- `make -C src-uland/libvm` *(fails: Makefile missing separator)*