### PR TITLE
Implement simple ring-buffer IPC

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -57,3 +57,24 @@ parameters, packages the request and relies on a user-space server to
 perform the real work.  This separation keeps the kernel small and easier
 to reason about.
 
+
+### IPC Usage Example
+
+The ring-buffer API exposes three helper functions:
+
+```c
+struct ipc_queue q;
+ipc_queue_init(&q);
+
+struct ipc_message m = { .type = IPC_MSG_OPEN,
+                         .a = (uintptr_t)"/etc/passwd",
+                         .b = O_RDONLY };
+ipc_queue_send(&q, &m);
+if (ipc_queue_recv(&q, &m)) {
+    int fd = (int)m.a;
+    /* use fd */
+}
+```
+
+Kernel hooks such as `kern_open()` push a request message to the queue and wait
+for a corresponding reply from the user-space server.

--- a/src-kernel/Makefile
+++ b/src-kernel/Makefile
@@ -1,4 +1,4 @@
-OBJS = sched_hooks.o vm_hooks.o vfs_hooks.o
+OBJS = sched_hooks.o vm_hooks.o vfs_hooks.o ipc.o
 LIB = libkern_stubs.a
 
 CC ?= cc

--- a/src-kernel/ipc.c
+++ b/src-kernel/ipc.c
@@ -1,0 +1,28 @@
+#include "ipc.h"
+
+/* Shared queue used by kernel stubs and user-space servers */
+struct ipc_queue kern_ipc_queue;
+
+void ipc_queue_init(struct ipc_queue *q)
+{
+    q->head = q->tail = 0;
+}
+
+bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)
+{
+    uint32_t next = (q->head + 1) % IPC_QUEUE_SIZE;
+    if (next == q->tail)
+        return false; /* full */
+    q->msgs[q->head] = *m;
+    q->head = next;
+    return true;
+}
+
+bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)
+{
+    if (q->tail == q->head)
+        return false; /* empty */
+    *m = q->msgs[q->tail];
+    q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
+    return true;
+}

--- a/src-kernel/ipc.h
+++ b/src-kernel/ipc.h
@@ -1,0 +1,36 @@
+#ifndef IPC_H
+#define IPC_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define IPC_QUEUE_SIZE 32
+
+/* Message types used by kernel hooks */
+enum ipc_msg_type {
+    IPC_MSG_SCHED_INIT = 1,
+    IPC_MSG_VM_FAULT,
+    IPC_MSG_OPEN
+};
+
+struct ipc_message {
+    uint32_t type;      /* enum ipc_msg_type */
+    uintptr_t a;
+    uintptr_t b;
+    uintptr_t c;
+};
+
+struct ipc_queue {
+    struct ipc_message msgs[IPC_QUEUE_SIZE];
+    volatile uint32_t head;
+    volatile uint32_t tail;
+};
+
+/* Global queue instance defined in ipc.c */
+extern struct ipc_queue kern_ipc_queue;
+
+void ipc_queue_init(struct ipc_queue *q);
+bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m);
+bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m);
+
+#endif /* IPC_H */

--- a/src-kernel/sched_hooks.c
+++ b/src-kernel/sched_hooks.c
@@ -1,9 +1,13 @@
 #include <stdio.h>
 #include "../include/exokernel.h"
+#include "ipc.h"
 /* Stubs delegating to user-space scheduler */
 extern void uland_sched_init(void);
 void
 kern_sched_init(void)
 {
+    struct ipc_message msg = { .type = IPC_MSG_SCHED_INIT };
+    ipc_queue_send(&kern_ipc_queue, &msg);
+    /* For now also directly call user library */
     uland_sched_init();
 }

--- a/src-kernel/vfs_hooks.c
+++ b/src-kernel/vfs_hooks.c
@@ -1,9 +1,19 @@
 #include <stdio.h>
 #include "../include/exokernel.h"
+#include "ipc.h"
 /* Stubs delegating to user-space file server */
 extern int fs_open(const char *path, int flags);
 int
 kern_open(const char *path, int flags)
 {
+    struct ipc_message msg = {
+        .type = IPC_MSG_OPEN,
+        .a = (uintptr_t)path,
+        .b = (uintptr_t)flags
+    };
+    ipc_queue_send(&kern_ipc_queue, &msg);
+    struct ipc_message reply;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply))
+        return (int)reply.a;
     return fs_open(path, flags);
 }

--- a/src-kernel/vm_hooks.c
+++ b/src-kernel/vm_hooks.c
@@ -1,5 +1,17 @@
 #include "../include/exokernel.h"
 #include <stdbool.h>
+#include "ipc.h"
 /* Stubs delegating to user-space VM library */
 extern bool uland_vm_fault(void *addr);
-bool kern_vm_fault(void *addr) { return uland_vm_fault(addr); }
+
+bool
+kern_vm_fault(void *addr)
+{
+    struct ipc_message msg = { .type = IPC_MSG_VM_FAULT, .a = (uintptr_t)addr };
+    ipc_queue_send(&kern_ipc_queue, &msg);
+    /* Synchronous reply */
+    struct ipc_message reply;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply))
+        return reply.a != 0;
+    return uland_vm_fault(addr);
+}

--- a/src-uland/libipc/Makefile
+++ b/src-uland/libipc/Makefile
@@ -1,0 +1,20 @@
+OBJS = ipc_dummy.o
+LIB  = libipc.a
+
+CC ?= cc
+AR ?= ar
+CPPFLAGS ?= -I../../src-kernel
+CFLAGS ?= -O2
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $(OBJS)
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/src-uland/libipc/ipc.h
+++ b/src-uland/libipc/ipc.h
@@ -1,0 +1,20 @@
+#ifndef LIBIPC_H
+#define LIBIPC_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../../src-kernel/ipc.h"
+
+/* User-space convenience wrappers */
+static inline bool ipc_send(const struct ipc_message *m)
+{
+    return ipc_queue_send(&kern_ipc_queue, m);
+}
+
+static inline bool ipc_recv(struct ipc_message *m)
+{
+    return ipc_queue_recv(&kern_ipc_queue, m);
+}
+
+#endif /* LIBIPC_H */

--- a/src-uland/libipc/ipc_dummy.c
+++ b/src-uland/libipc/ipc_dummy.c
@@ -1,0 +1,2 @@
+#include "ipc.h"
+/* empty compilation unit to create the archive */


### PR DESCRIPTION
## Summary
- add new IPC ring buffer library in `src-kernel`
- add matching lightweight wrapper under `src-uland/libipc`
- update kernel stub hooks to send IPC messages
- document IPC usage in `microkernel_functional_model.md`

## Testing
- `make -C src-kernel clean && make -C src-kernel`
- `make -C src-uland/libipc clean && make -C src-uland/libipc`
