### PR TITLE
Add src-lib dir and update migration scripts

### DIFF
--- a/docs/fhs_migration.md
+++ b/docs/fhs_migration.md
@@ -67,8 +67,8 @@ when modernizing historic BSD trees.
    `tools/post_fhs_cleanup.sh` helper.
 5. Execute `tools/migrate_to_src_layout.sh` (add `--force` when outside the chroot)
    to relocate the sources. The script moves the kernel into `src-kernel`, user
-   programs into `src-uland`, headers into `src-headers` and library objects
-   into `src-lib`.
+   programs into `src-uland`, headers into `src-headers` and collects archive
+   libraries into `src-lib`.
 6. Verify the new symlinks by running `ls -l` on `bin`, `sbin` and related
    directories.
 7. Update makefiles and scripts to reference the new paths. `grep -r "/bin"`
@@ -104,6 +104,7 @@ corresponds to a location in the FHS layout after running the migration tools.
 | `sys/`          | `/usr/src/sys`     | Historical kernel sources |
 | `src-kernel/`   | `/usr/src-kernel`  | Microkernel or exokernel sources |
 | `src-uland/`    | `/usr/src-uland`   | User-space services and libraries |
+| `src-lib/`      | `/usr/src-lib`     | Archive libraries collected during migration |
 | `include/`      | `/usr/include`     | Headers collected by `src-headers` |
 | `docs/`         | `/usr/share/doc`   | Build and modernization notes |
 | `tools/`        | `/usr/share/tools` | Helper scripts used during the build |

--- a/docs/reorg_plan.md
+++ b/docs/reorg_plan.md
@@ -22,4 +22,6 @@ This document outlines tasks for flattening the 4.4BSD-Lite2 source tree and mod
 7. Reorganize kernel and userland sources with
    `tools/migrate_to_src_layout.sh` (or the older `tools/organize_sources.sh`)
    to move them into `src-kernel`, `src-uland`, `src-headers` and `src-lib`.
+   The `src-lib` directory stores archive libraries separated from the rest of
+   the tree.
 

--- a/tools/migrate_to_src_layout.sh
+++ b/tools/migrate_to_src_layout.sh
@@ -60,6 +60,7 @@ move_and_link() {
 move_artifacts() {
     base="$1"
     [ -d "$base" ] || return 0
+    run_cmd "mkdir -p src-lib"
     find "$base" -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.so.*' \) | while read f; do
         rel="${f#$base/}"
         dest="src-lib/$rel"

--- a/tools/organize_sources.sh
+++ b/tools/organize_sources.sh
@@ -60,6 +60,7 @@ move_and_link() {
 move_artifacts() {
     base="$1"
     [ -d "$base" ] || return 0
+    run_cmd "mkdir -p src-lib"
     find "$base" -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.so.*' \) | while read f; do
         rel="${f#$base/}"
         dest="src-lib/$rel"

--- a/tools/post_fhs_cleanup.sh
+++ b/tools/post_fhs_cleanup.sh
@@ -60,6 +60,7 @@ move_and_link() {
 move_artifacts() {
     base="$1"
     [ -d "$base" ] || return 0
+    run_cmd "mkdir -p src-lib"
     find "$base" -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.so.*' \) | while read f; do
         rel="${f#$base/}"
         dest="src-lib/$rel"


### PR DESCRIPTION
## Summary
- add top-level `src-lib/` directory
- make migration scripts create `src-lib` when moving artifacts
- reference `src-lib` in docs as the archive library location

## Testing
- `make` in `usr/src/usr.sbin/config` *(fails: `yacc` missing)*