### PR TITLE
Ensure yacc in setup and docs

### DIFF
--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -2,9 +2,9 @@
 
 This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `make`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
 
-Before building, run the repository's `setup.sh` script as root to install all required toolchains and utilities. The script installs **byacc** so the build can proceed even if your system lacks `yacc`.
+Before building, run the repository's `setup.sh` script as root to install all required toolchains and utilities. The script installs **byacc**, creates a `yacc` alias and, if no system `yacc` exists, attempts to build the bundled implementation under `usr/src/usr.bin/yacc`.
 
-If your host still lacks `yacc` or `bison`, build the repository's bundled version first:
+If your host still lacks `yacc` or `bison`, build the repository's bundled version manually:
 ```sh
 cd usr/src/usr.bin/yacc
 make clean && make

--- a/setup.sh
+++ b/setup.sh
@@ -134,6 +134,16 @@ unzip -d /usr/local /tmp/protoc.zip
 rm /tmp/protoc.zip
 
 # gmake alias
+# ensure yacc exists
+if ! command -v yacc >/dev/null 2>&1; then
+  if command -v byacc >/dev/null 2>&1; then
+    ln -s "$(command -v byacc)" /usr/local/bin/yacc
+  elif [ -f "$(dirname "$0")/usr/src/usr.bin/yacc/Makefile" ]; then
+    (cd "$(dirname "$0")/usr/src/usr.bin/yacc" && make clean && make)
+    install -m755 "$(dirname "$0")/usr/src/usr.bin/yacc/yacc" /usr/local/bin/yacc
+  fi
+fi
+
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
 
 # clean up


### PR DESCRIPTION
## Summary
- guarantee `yacc` exists in `setup.sh`
- explain the alias/fallback build in `building_kernel.md`

## Testing
- `bash -n setup.sh`
- `make -C usr/src/usr.bin/yacc clean` *(fails: missing separator)*
- `bmake -C usr/src/usr.bin/yacc clean` *(fails: command not found)*