### PR TITLE
Add pm_fork and pm_exec entry points

### DIFF
--- a/src-headers/proc_manager.h
+++ b/src-headers/proc_manager.h
@@ -17,4 +17,7 @@ void pgdelete(struct pgrp *pgrp);
 void fixjobc(struct proc *p, struct pgrp *pgrp, int entering);
 void pgrpdump(void);
 
+int pm_fork(void);
+int pm_exec(const char *path, char *const argv[]);
+
 #endif /* PROC_MANAGER_H */

--- a/src-uland/servers/proc_manager/Makefile
+++ b/src-uland/servers/proc_manager/Makefile
@@ -1,4 +1,4 @@
-OBJS = kern_proc.o
+OBJS = kern_proc.o pm_entry.o
 PROG = proc_manager
 CC ?= cc
 CFLAGS ?= -O2

--- a/src-uland/servers/proc_manager/pm_entry.c
+++ b/src-uland/servers/proc_manager/pm_entry.c
@@ -1,0 +1,15 @@
+/* Entry points used by kernel stubs to perform fork and exec in user space. */
+#include <unistd.h>
+#include "proc_manager.h"
+
+int
+pm_fork(void)
+{
+    return fork();
+}
+
+int
+pm_exec(const char *path, char *const argv[])
+{
+    return execv(path, argv);
+}


### PR DESCRIPTION
## Summary
- implement `pm_fork` and `pm_exec` for the process manager
- export the new symbols in `proc_manager.h`
- compile `pm_entry.c` in the process manager build

## Testing
- `make` in `src-uland/servers/proc_manager` *(fails: unknown type name 'sigset_t')*