### PR TITLE
Fix tab indentation in libvm Makefile

### DIFF
--- a/src-uland/libvm/Makefile
+++ b/src-uland/libvm/Makefile
@@ -13,10 +13,10 @@ CFLAGS   += -DKERNEL
 all: $(LIB)
 
 $(LIB): $(OBJS)
-        $(AR) rcs $@ $(OBJS)
+	$(AR) rcs $@ $(OBJS)
 
 %.o: %.c
-        $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(OBJS) $(LIB)


### PR DESCRIPTION
## Summary
- fix tab indentation for commands in `libvm` Makefile

## Testing
- `make clean && make` *(fails: machine/vmparam.h: No such file or directory)*