### PR TITLE
Include ipc.c in static lib build

### DIFF
--- a/src-kernel/meson.build
+++ b/src-kernel/meson.build
@@ -1,6 +1,6 @@
 project('kern_stubs', 'c', default_options : ['c_std=c23'])
 
-srcs = ['proc_hooks.c', 'sched_hooks.c', 'vm_hooks.c', 'vfs_hooks.c']
+srcs = ['proc_hooks.c', 'sched_hooks.c', 'vm_hooks.c', 'vfs_hooks.c', 'ipc.c']
 libkern = static_library('kern_stubs', srcs,
                          include_directories : include_directories('../include'))
 


### PR DESCRIPTION
## Summary
- add `ipc.c` to the Meson build source list so it gets compiled into `libkern_stubs.a`

## Testing
- `make -C src-kernel clean`
- `make -C src-kernel`