### PR TITLE
Initialize IPC queue before scheduler messages

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -11,7 +11,8 @@ system safely.  These include:
 
 - **Thread scheduling hooks** – the kernel delegates policy decisions to the
   user-space scheduler library.  It starts execution in `kern_sched_init()`
-  and performs context switches on request.
+  which initializes the global IPC queue before any messages are sent and
+  then performs context switches on request.
 - **Virtual memory hooks** – page faults call `kern_vm_fault()` which forwards
   to a user-space memory manager for allocation and paging decisions.
 - **System call gate** – simple wrappers like `kern_open()` pass file

--- a/src-kernel/sched_hooks.c
+++ b/src-kernel/sched_hooks.c
@@ -6,6 +6,9 @@ extern void uland_sched_init(void);
 void
 kern_sched_init(void)
 {
+    /* Ensure the message queue is ready before sending */
+    ipc_queue_init(&kern_ipc_queue);
+
     struct ipc_message msg = { .type = IPC_MSG_SCHED_INIT };
     ipc_queue_send(&kern_ipc_queue, &msg);
     /* For now also directly call user library */


### PR DESCRIPTION
## Summary
- initialize the IPC queue before sending any messages
- mention this setup step in the microkernel documentation

## Testing
- `make -C src-kernel clean`
- `make -C src-kernel`