### PR TITLE
Ensure meson and ninja via pip

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,8 @@ done
 
 pip3 install --no-cache-dir \
   tensorflow-cpu jax jaxlib \
-  tensorflow-model-optimization mlflow onnxruntime-tools
+  tensorflow-model-optimization mlflow onnxruntime-tools \
+  meson ninja cmake
 
 # QEMU emulation for foreign binaries
 for pkg in \


### PR DESCRIPTION
## Summary
- add meson/ninja/cmake pip packages in setup.sh to guarantee availability

## Testing
- `bash setup.sh` *(fails: Could not connect to proxy)*
- `make clean && make` in `usr/src/usr.sbin/config` *(fails: `yacc: No such file or directory`)*