### PR TITLE
Implement blocking IPC queue with spinlock

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -79,3 +79,10 @@ if (ipc_queue_recv(&q, &m)) {
 
 Kernel hooks such as `kern_open()` push a request message to the queue and wait
 for a corresponding reply from the user-space server.
+
+The queue implementation originally offered only non-blocking `ipc_queue_send()`
+and `ipc_queue_recv()` calls.  To simplify users of the API a lightweight
+spinlock now protects the ring buffer and two blocking helpers were added:
+`ipc_queue_send_blocking()` and `ipc_queue_recv_blocking()`.  These functions
+busy-wait until the operation completes.  User-space wrappers `ipc_send()` and
+`ipc_recv()` invoke the blocking variants to guarantee delivery.

--- a/src-kernel/ipc.c
+++ b/src-kernel/ipc.c
@@ -1,28 +1,61 @@
 #include "ipc.h"
+#include <stdatomic.h>
 
 /* Shared queue used by kernel stubs and user-space servers */
 struct ipc_queue kern_ipc_queue;
 
+static void lock_queue(struct ipc_queue *q)
+{
+    while (atomic_flag_test_and_set_explicit(&q->lock, memory_order_acquire))
+        ;
+}
+
+static void unlock_queue(struct ipc_queue *q)
+{
+    atomic_flag_clear_explicit(&q->lock, memory_order_release);
+}
+
 void ipc_queue_init(struct ipc_queue *q)
 {
     q->head = q->tail = 0;
+    atomic_flag_clear(&q->lock);
 }
 
 bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)
 {
+    bool ok = false;
+    lock_queue(q);
     uint32_t next = (q->head + 1) % IPC_QUEUE_SIZE;
-    if (next == q->tail)
-        return false; /* full */
-    q->msgs[q->head] = *m;
-    q->head = next;
-    return true;
+    if (next != q->tail) {
+        q->msgs[q->head] = *m;
+        q->head = next;
+        ok = true;
+    }
+    unlock_queue(q);
+    return ok;
 }
 
 bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)
 {
-    if (q->tail == q->head)
-        return false; /* empty */
-    *m = q->msgs[q->tail];
-    q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
-    return true;
+    bool ok = false;
+    lock_queue(q);
+    if (q->tail != q->head) {
+        *m = q->msgs[q->tail];
+        q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
+        ok = true;
+    }
+    unlock_queue(q);
+    return ok;
+}
+
+void ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m)
+{
+    while (!ipc_queue_send(q, m))
+        ;
+}
+
+void ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m)
+{
+    while (!ipc_queue_recv(q, m))
+        ;
 }

--- a/src-kernel/ipc.h
+++ b/src-kernel/ipc.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdatomic.h>
 
 #define IPC_QUEUE_SIZE 32
 
@@ -24,6 +25,7 @@ struct ipc_queue {
     struct ipc_message msgs[IPC_QUEUE_SIZE];
     volatile uint32_t head;
     volatile uint32_t tail;
+    atomic_flag lock;
 };
 
 /* Global queue instance defined in ipc.c */
@@ -32,5 +34,7 @@ extern struct ipc_queue kern_ipc_queue;
 void ipc_queue_init(struct ipc_queue *q);
 bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m);
 bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m);
+void ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m);
+void ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m);
 
 #endif /* IPC_H */

--- a/src-uland/libipc/ipc.h
+++ b/src-uland/libipc/ipc.h
@@ -9,12 +9,14 @@
 /* User-space convenience wrappers */
 static inline bool ipc_send(const struct ipc_message *m)
 {
-    return ipc_queue_send(&kern_ipc_queue, m);
+    ipc_queue_send_blocking(&kern_ipc_queue, m);
+    return true;
 }
 
 static inline bool ipc_recv(struct ipc_message *m)
 {
-    return ipc_queue_recv(&kern_ipc_queue, m);
+    ipc_queue_recv_blocking(&kern_ipc_queue, m);
+    return true;
 }
 
 #endif /* LIBIPC_H */


### PR DESCRIPTION
## Summary
- add a spinlock using `atomic_flag` to protect the shared IPC queue
- provide blocking `ipc_queue_send_blocking` and `ipc_queue_recv_blocking`
- update userland IPC helpers to invoke the blocking operations
- document new semantics in the microkernel model

## Testing
- `make -C src-kernel clean all`
- `make -C src-uland/libipc clean all`
