### PR TITLE
Implement userland IPC queue

### DIFF
--- a/src-uland/libipc/Makefile
+++ b/src-uland/libipc/Makefile
@@ -1,4 +1,4 @@
-OBJS = ipc_dummy.o
+OBJS = ipc.o
 LIB  = libipc.a
 
 CC ?= cc

--- a/src-uland/libipc/ipc.c
+++ b/src-uland/libipc/ipc.c
@@ -1,0 +1,28 @@
+#include "ipc.h"
+
+/* Shared queue used by kernel stubs and user-space servers */
+struct ipc_queue kern_ipc_queue;
+
+void ipc_queue_init(struct ipc_queue *q)
+{
+    q->head = q->tail = 0;
+}
+
+bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)
+{
+    uint32_t next = (q->head + 1) % IPC_QUEUE_SIZE;
+    if (next == q->tail)
+        return false; /* full */
+    q->msgs[q->head] = *m;
+    q->head = next;
+    return true;
+}
+
+bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)
+{
+    if (q->tail == q->head)
+        return false; /* empty */
+    *m = q->msgs[q->tail];
+    q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
+    return true;
+}

--- a/src-uland/libipc/ipc_dummy.c
+++ b/src-uland/libipc/ipc_dummy.c
@@ -1,2 +1,0 @@
-#include "ipc.h"
-/* empty compilation unit to create the archive */


### PR DESCRIPTION
## Summary
- add IPC queue implementation for userland
- build libipc with the new source
- keep userland and kernel IPC headers in sync

## Testing
- `make -C src-uland/libipc clean && make -C src-uland/libipc`
- `make -C src-kernel clean && make -C src-kernel`
