### PR TITLE
Add simple init program

### DIFF
--- a/docs/exokernel_testing.md
+++ b/docs/exokernel_testing.md
@@ -8,10 +8,10 @@ This guide explains how to start the exokernel with only the essential user-leve
 - The exokernel binary built under `src-kernel`
 - User-level managers (scheduler, memory manager, file server) built under `src-uland`
 - A bootable disk image containing the managers in `/bin` or `/usr/bin`
+- The `init` program built under `src-uland/init`
 
 ## Booting in QEMU
-
-1. Create a disk image with the managers installed.
+1. Create a disk image with the managers installed and copy `init` to `/sbin/init`.
 2. Launch QEMU using the exokernel as the kernel image:
    ```sh
    qemu-system-i386 -kernel path/to/exokernel \

--- a/src-uland/init/Makefile
+++ b/src-uland/init/Makefile
@@ -1,0 +1,19 @@
+SRCS = init.c
+OBJS = $(SRCS:.c=.o)
+PROG = init
+
+CC ?= cc
+CFLAGS ?= -O2
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(OBJS) -o $@
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(PROG)
+
+.PHONY: all clean

--- a/src-uland/init/init.c
+++ b/src-uland/init/init.c
@@ -1,0 +1,31 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static const char *servers[] = {
+    "/usr/libexec/proc_manager",
+    "/usr/libexec/fs_server",
+    NULL
+};
+
+int
+main(void)
+{
+    for (const char **srv = servers; *srv != NULL; ++srv) {
+        pid_t pid = fork();
+        if (pid == -1) {
+            perror("fork");
+            return 1;
+        }
+        if (pid == 0) {
+            execl(*srv, *srv, (char *)NULL);
+            perror("execl");
+            _exit(1);
+        }
+    }
+
+    /* Replace this init with a shell once servers start. */
+    execl("/bin/sh", "sh", (char *)NULL);
+    perror("exec shell");
+    return 1;
+}


### PR DESCRIPTION
## Summary
- create `src-uland/init` with a very small init implementation
- add Makefile for building the `init` binary
- document how to place `init` on the boot image for exokernel tests

## Testing
- `make -C src-uland/init`
- `make -C src-uland/init clean`
