### PR TITLE
Add kernel stub self-test

### DIFF
--- a/docs/exokernel_testing.md
+++ b/docs/exokernel_testing.md
@@ -40,3 +40,20 @@ This guide explains how to start the exokernel with only the essential user-leve
 3. Check the console or log messages from the managers to confirm that each request reached the corresponding manager and was granted.
 
 If these steps complete without errors the basic resource allocation APIs are functioning under the minimal boot environment.
+
+## Kernel Stub Self-Test
+
+A small program under `tests/` exercises the exokernel stubs without booting the
+full system. Build and run it after compiling `libkern_stubs.a`:
+
+```sh
+cd src-kernel && make
+cd ../tests && make clean all
+./test_kern
+```
+
+Successful output prints `all ok` and verifies that:
+
+- `kern_open()` delegates to `fs_open()` and opens `README.md`.
+- `kern_vm_fault()` returns `true` using the mock VM handler.
+- `kern_fork()` creates a child process which exits normally.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,28 @@
+CC ?= cc
+CFLAGS ?= -O2 -std=c2x
+CPPFLAGS = -I../tests/include -I../include -I../src-headers -I../src-headers/machine -I../src-kernel
+LIBS = ../src-kernel/libkern_stubs.a
+
+OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o mock_vm.o
+
+all: test_kern
+
+test_kern: $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) $(LIBS) -o $@
+
+fs_open.o: ../src-uland/fs-server/fs_open.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+pm_entry.o: ../src-uland/servers/proc_manager/pm_entry.c
+	$(CC) -I../tests/include $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+vm_entry.o: ../src-uland/libvm/vm_entry.c
+	$(CC) -I../tests/include $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+mock_vm.o: mock_vm.c
+	$(CC) -I../tests/include $(CFLAGS) -c $< -o $@
+
+clean:
+	 rm -f $(OBJS) test_kern
+
+.PHONY: all clean

--- a/tests/include/proc_manager.h
+++ b/tests/include/proc_manager.h
@@ -1,0 +1,5 @@
+#ifndef PROC_MANAGER_H
+#define PROC_MANAGER_H
+int pm_fork(void);
+int pm_exec(const char *path, char *const argv[]);
+#endif

--- a/tests/include/vm/vm.h
+++ b/tests/include/vm/vm.h
@@ -1,0 +1,15 @@
+#ifndef VM_VM_H
+#define VM_VM_H
+#include <stdint.h>
+
+typedef void* vm_map_t;
+typedef uintptr_t vm_offset_t;
+
+#define VM_PROT_READ 1
+#define VM_PROT_WRITE 2
+#define KERN_SUCCESS 0
+#define FALSE 0
+
+int vm_fault(vm_map_t map, vm_offset_t addr, int prot, int wired);
+
+#endif

--- a/tests/mock_vm.c
+++ b/tests/mock_vm.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef void* vm_map_t;
+typedef uintptr_t vm_offset_t;
+
+vm_map_t kernel_map;
+
+int vm_fault(vm_map_t map, vm_offset_t addr, int prot, int wired)
+{
+    (void)map; (void)addr; (void)prot; (void)wired;
+    return 0; /* KERN_SUCCESS */
+}

--- a/tests/test_kern.c
+++ b/tests/test_kern.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include "exokernel.h"
+#include "fs_server.h"
+#include "libvm.h"
+#include "proc_manager.h"
+#include "ipc.h"
+
+int main(void) {
+    ipc_queue_init(&kern_ipc_queue);
+
+    int fd = kern_open("README.md", O_RDONLY);
+    if (fd < 0) {
+        perror("kern_open");
+        return 1;
+    }
+    close(fd);
+
+    if (!kern_vm_fault((void *)0x1000)) {
+        fprintf(stderr, "kern_vm_fault failed\n");
+        return 1;
+    }
+
+    int pid = kern_fork();
+    if (pid < 0) {
+        perror("kern_fork");
+        return 1;
+    }
+    if (pid == 0) {
+        exit(0);
+    } else {
+        int status; waitpid(pid, &status, 0);
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            fprintf(stderr, "child failed\n");
+            return 1;
+        }
+    }
+
+    printf("all ok\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a self-test under `tests/` that links with `libkern_stubs.a`
- mock out the VM and proc manager headers to compile minimal server code
- document running the test in `exokernel_testing.md`

## Testing
- `make -C src-kernel clean all`
- `make -C tests clean all`
- `./tests/test_kern`