### PR TITLE
Use bmake/bison

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,22 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install GCC
-        run: sudo apt-get update && sudo apt-get install -y build-essential gcc-multilib
+      - name: Install GCC and bmake
+        run: sudo apt-get update && sudo apt-get install -y build-essential gcc-multilib bmake
       - name: Generate inventory
-        run: make inventory
+        run: bmake inventory
       - uses: actions/upload-artifact@v3
         with:
           name: file_inventory
           path: docs/file_inventory.txt
       - name: Build with GCC C23 x86_64
-        run: make -C usr/src CC=gcc CSTD=-std=c2x CFLAGS='-m64'
+        run: bmake -C usr/src CC=gcc CSTD=-std=c2x CFLAGS='-m64'
       - name: Build kernel stubs
-        run: make -C src-kernel CC=gcc CFLAGS='-m64'
+        run: bmake -C src-kernel CC=gcc CFLAGS='-m64'
       - name: Build userland libraries
         run: |
-          make -C src-uland/libkern_sched CC=gcc CFLAGS='-m64'
-          make -C src-uland/libvm CC=gcc CFLAGS='-m64'
+          bmake -C src-uland/libkern_sched CC=gcc CFLAGS='-m64'
+          bmake -C src-uland/libvm CC=gcc CFLAGS='-m64'
 
   gcc-i686:
     runs-on: ubuntu-latest
@@ -33,58 +33,58 @@ jobs:
       - name: Install GCC
         run: sudo apt-get update && sudo apt-get install -y build-essential gcc-multilib
       - name: Generate inventory
-        run: make inventory
+        run: bmake inventory
       - uses: actions/upload-artifact@v3
         with:
           name: file_inventory
           path: docs/file_inventory.txt
       - name: Build with GCC C23 i686
-        run: make -C usr/src CC=gcc CSTD=-std=c2x CFLAGS='-m32'
+        run: bmake -C usr/src CC=gcc CSTD=-std=c2x CFLAGS='-m32'
       - name: Build kernel stubs
-        run: make -C src-kernel CC=gcc CFLAGS='-m32'
+        run: bmake -C src-kernel CC=gcc CFLAGS='-m32'
       - name: Build userland libraries
         run: |
-          make -C src-uland/libkern_sched CC=gcc CFLAGS='-m32'
-          make -C src-uland/libvm CC=gcc CFLAGS='-m32'
+          bmake -C src-uland/libkern_sched CC=gcc CFLAGS='-m32'
+          bmake -C src-uland/libvm CC=gcc CFLAGS='-m32'
 
   clang-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Clang
-        run: sudo apt-get update && sudo apt-get install -y clang make gcc-multilib
+      - name: Install Clang and bmake
+        run: sudo apt-get update && sudo apt-get install -y clang bmake gcc-multilib
       - name: Generate inventory
-        run: make inventory
+        run: bmake inventory
       - uses: actions/upload-artifact@v3
         with:
           name: file_inventory
           path: docs/file_inventory.txt
       - name: Build with Clang C23 x86_64
-        run: make -C usr/src CC=clang CSTD=-std=c2x CFLAGS='-m64'
+        run: bmake -C usr/src CC=clang CSTD=-std=c2x CFLAGS='-m64'
       - name: Build kernel stubs
-        run: make -C src-kernel CC=clang CFLAGS='-m64'
+        run: bmake -C src-kernel CC=clang CFLAGS='-m64'
       - name: Build userland libraries
         run: |
-          make -C src-uland/libkern_sched CC=clang CFLAGS='-m64'
-          make -C src-uland/libvm CC=clang CFLAGS='-m64'
+          bmake -C src-uland/libkern_sched CC=clang CFLAGS='-m64'
+          bmake -C src-uland/libvm CC=clang CFLAGS='-m64'
 
   clang-i686:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Clang
-        run: sudo apt-get update && sudo apt-get install -y clang make gcc-multilib
+      - name: Install Clang and bmake
+        run: sudo apt-get update && sudo apt-get install -y clang bmake gcc-multilib
       - name: Generate inventory
-        run: make inventory
+        run: bmake inventory
       - uses: actions/upload-artifact@v3
         with:
           name: file_inventory
           path: docs/file_inventory.txt
       - name: Build with Clang C23 i686
-        run: make -C usr/src CC=clang CSTD=-std=c2x CFLAGS='-m32'
+        run: bmake -C usr/src CC=clang CSTD=-std=c2x CFLAGS='-m32'
       - name: Build kernel stubs
-        run: make -C src-kernel CC=clang CFLAGS='-m32'
+        run: bmake -C src-kernel CC=clang CFLAGS='-m32'
       - name: Build userland libraries
         run: |
-          make -C src-uland/libkern_sched CC=clang CFLAGS='-m32'
-          make -C src-uland/libvm CC=clang CFLAGS='-m32'
+          bmake -C src-uland/libkern_sched CC=clang CFLAGS='-m32'
+          bmake -C src-uland/libvm CC=clang CFLAGS='-m32'

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -1,26 +1,19 @@
 # Building the 4.4BSD-Lite2 kernel
 
-This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `make`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
+This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `bmake`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
 
 Before building, run the repository's `setup.sh` script as root to install all
-required toolchains and utilities.  The script installs **bison** and creates a
-`yacc` alias that points to it for compatibility.  Any packages that fail to
+required toolchains and utilities.  The script installs **bison** and **bmake**.  Any packages that fail to
 install are recorded in `/tmp/setup_failures.log`, and Python packages are
 attempted again via `pip` as a fallback.
 
-If your host still lacks `bison`, build the repository's bundled version
-manually:
-```sh
-cd usr/src/usr.bin/yacc
-make clean && make
-export YACC="$(pwd)/yacc -y"
-```
+If `bison` is missing, install it and export `YACC="bison -y"` before building.
 Then proceed with the steps below.
 
 1. **Build the `config` utility**
    ```sh
    cd usr/src/usr.sbin/config
-   make clean && make
+   bmake clean && bmake
    ```
    This produces a `config` binary used to generate kernel build directories.
 
@@ -35,9 +28,9 @@ Then proceed with the steps below.
 3. **Build the kernel**
    ```sh
    cd ../compile/GENERIC.i386
-   make depend
+   bmake depend
    # Append CFLAGS=-m32 for i686 or CFLAGS=-m64 for x86_64
-   make
+   bmake
    ```
    If successful, the resulting kernel binary (usually `vmunix`) appears in this directory.
 
@@ -51,13 +44,13 @@ The microkernel plan extracts portions of `sys/kern` and `sys/dev` into user-spa
 2. For a user-space server:
    ```sh
    cd servers/<subsystem>
-   make clean && make
+   bmake clean && bmake
    ```
    Install the resulting binary under `/usr/libexec` and configure the boot scripts to start it after the kernel loads.
 3. For a loadable module:
    ```sh
    cd modules/<subsystem>
-   make clean && make
+   bmake clean && bmake
    sudo kldload <subsystem>.ko
    ```
 4. List the module in `/etc/loader.conf` if it should load automatically at boot.
@@ -75,7 +68,7 @@ separately but with the same tools used for the classic kernel:
 1. **Compile the microkernel core**
    ```sh
    cd src-kernel
-   make clean && make
+   bmake clean && bmake
    ```
    Use the standard environment variables and append `CFLAGS=-m32` or
    `CFLAGS=-m64` as appropriate.
@@ -83,7 +76,7 @@ separately but with the same tools used for the classic kernel:
 2. **Build user-space servers and drivers**
    ```sh
    cd src-uland/servers/<name>
-   make clean && make
+   bmake clean && bmake
    ```
    Driver tasks live in `src-uland/drivers/`.  Install each binary under
    `/usr/libexec` and configure startup scripts to launch it early in the boot
@@ -97,15 +90,15 @@ The exokernel layout relocates sources using `tools/organize_sources.sh`. After 
 1. **Compile the exokernel**
    ```sh
    cd src-kernel
-   make clean && make
+   bmake clean && bmake
    ```
-   Use the same environment variables as the classic build. If `YACC` was exported earlier, export it again before invoking `make`. Append `CFLAGS=-m32` or `CFLAGS=-m64` for your architecture as needed.
+   Use the same environment variables as the classic build. If `YACC` was exported earlier, export it again before invoking `bmake`. Append `CFLAGS=-m32` or `CFLAGS=-m64` for your architecture as needed.
 
 2. **Build user-space managers**
    ```sh
    cd src-uland/managers/<name>
-   make clean && make
+   bmake clean && bmake
    ```
    Install each manager under `/usr/libexec` or another appropriate directory.
 
-No additional make targets are defined yet; simply run `make` in each directory to compile the components.
+No additional bmake targets are defined yet; simply run `bmake` in each directory to compile the components.

--- a/docs/exokernel_testing.md
+++ b/docs/exokernel_testing.md
@@ -47,8 +47,8 @@ A small program under `tests/` exercises the exokernel stubs without booting the
 full system. Build and run it after compiling `libkern_stubs.a`:
 
 ```sh
-cd src-kernel && make
-cd ../tests && make clean all
+cd src-kernel && bmake
+cd ../tests && bmake clean all
 ./test_kern
 ```
 


### PR DESCRIPTION
## Summary
- document using `bmake` and `bison`
- use `bmake` in exokernel docs
- install bmake in CI workflow
- ensure bmake and bison present in setup.sh
- alias `yacc` to `bison` and use bmake for gmake

## Testing
- `sudo bash setup.sh` *(fails: couldn't connect to server)*
- `bmake -v` *(fails: command not found)*