### PR TITLE
Default userland builds to C23

### DIFF
--- a/docs/refactor_c23_tasks.md
+++ b/docs/refactor_c23_tasks.md
@@ -91,4 +91,6 @@ This roadmap is intentionally high level. Full conversion of the 4.4BSD-Lite2 tr
   flags when collecting warnings.
 - `usr/src/libpathtrans` now respects `CFLAGS` and `LDFLAGS` so cross-
   architecture builds link correctly.
+- Added a `CSTD` variable to all makefiles under `src-uland/` and
+  appended it to `CFLAGS` so these components build with C23 by default.
 

--- a/src-uland/fs-server/Makefile
+++ b/src-uland/fs-server/Makefile
@@ -4,10 +4,11 @@ PROG = fs_server
 
 CC ?= cc
 CFLAGS ?= -O2
+CSTD ?= -std=c2x
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
-CFLAGS   += -DKERNEL
+CFLAGS   += $(CSTD) -DKERNEL
 
 all: $(PROG)
 
@@ -15,7 +16,7 @@ $(PROG): $(OBJS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(OBJS) -o $@
 
 %.o: %.c
-	        $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(OBJS) $(PROG)

--- a/src-uland/init/Makefile
+++ b/src-uland/init/Makefile
@@ -4,6 +4,8 @@ PROG = init
 
 CC ?= cc
 CFLAGS ?= -O2
+CSTD ?= -std=c2x
+CFLAGS += $(CSTD)
 
 all: $(PROG)
 

--- a/src-uland/libipc/Makefile
+++ b/src-uland/libipc/Makefile
@@ -5,6 +5,8 @@ CC ?= cc
 AR ?= ar
 CPPFLAGS ?= -I../../src-kernel
 CFLAGS ?= -O2
+CSTD ?= -std=c2x
+CFLAGS += $(CSTD)
 
 all: $(LIB)
 

--- a/src-uland/libkern_sched/Makefile
+++ b/src-uland/libkern_sched/Makefile
@@ -4,10 +4,11 @@ LIB  = libkern_sched.a
 CC ?= cc
 AR ?= ar
 CFLAGS ?= -O2
+CSTD ?= -std=c2x
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
-CFLAGS   += -DKERNEL
+CFLAGS   += $(CSTD) -DKERNEL
 
 all: $(LIB)
 

--- a/src-uland/libvm/Makefile
+++ b/src-uland/libvm/Makefile
@@ -5,10 +5,11 @@ LIB  = libvm.a
 CC ?= cc
 AR ?= ar
 CFLAGS ?= -O2
+CSTD ?= -std=c2x
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
-CFLAGS   += -DKERNEL
+CFLAGS   += $(CSTD) -DKERNEL
 
 all: $(LIB)
 

--- a/src-uland/servers/proc_manager/Makefile
+++ b/src-uland/servers/proc_manager/Makefile
@@ -2,10 +2,11 @@ OBJS = kern_proc.o pm_entry.o
 PROG = proc_manager
 CC ?= cc
 CFLAGS ?= -O2
+CSTD ?= -std=c2x
 CPPFLAGS ?= -I../../../src-headers -I../../../src-headers/machine \
             -I../../../include -I../../../sys -I../../../sys/sys \
             -I../../../sys/i386/include
-CFLAGS   += -DKERNEL
+CFLAGS   += $(CSTD) -DKERNEL
 
 all: $(PROG)
 


### PR DESCRIPTION
## Summary
- enable `CSTD=-std=c2x` for every `src-uland` makefile
- pass `$(CSTD)` via `CFLAGS`
- document the change in `refactor_c23_tasks.md`

## Testing
- `make -C src-uland/init clean all` *(fails: unknown type name 'pid_t')*
- `make -C src-uland/fs-server clean all` *(fails: unknown type name 'off_t')*
- `make -C src-uland/libipc clean all`
- `make -C src-uland/libkern_sched clean all` *(fails: machine/segments.h missing)*
- `make -C src-uland/libvm clean all` *(fails: machine/vmparam.h missing)*
- `make -C src-uland/servers/proc_manager clean all` *(fails: orphanpg arg mismatch)*