### PR TITLE
Add clang-tidy helper targets for userland

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -14,3 +14,13 @@ The hooks rely on the configuration files `.clang-format` and
 `.clang-tidy` at the repository root.  A helper script
 `tools/run_clang_tidy.sh` selects the appropriate language standard
 (C23 or C++17) when invoking `clang-tidy`.
+
+Each `src-uland` makefile defines a helper `tidy` target that runs
+`clang-tidy` on that component's sources:
+
+```sh
+cd src-uland/libvm
+make tidy
+```
+
+The command above uses the same options as the pre-commit hook.

--- a/src-uland/fs-server/Makefile
+++ b/src-uland/fs-server/Makefile
@@ -4,6 +4,7 @@ PROG = fs_server
 
 CC ?= cc
 CFLAGS ?= -O2
+CLANG_TIDY ?= ../../tools/run_clang_tidy.sh
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
@@ -15,9 +16,13 @@ $(PROG): $(OBJS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(OBJS) -o $@
 
 %.o: %.c
-	        $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(OBJS) $(PROG)
 
-.PHONY: all clean
+
+.PHONY: all clean tidy
+
+tidy:
+	$(CLANG_TIDY) $(SRCS) -- $(CC) $(CPPFLAGS) $(CFLAGS)

--- a/src-uland/init/Makefile
+++ b/src-uland/init/Makefile
@@ -4,6 +4,7 @@ PROG = init
 
 CC ?= cc
 CFLAGS ?= -O2
+CLANG_TIDY ?= ../../tools/run_clang_tidy.sh
 
 all: $(PROG)
 
@@ -16,4 +17,7 @@ $(PROG): $(OBJS)
 clean:
 	rm -f $(OBJS) $(PROG)
 
-.PHONY: all clean
+.PHONY: all clean tidy
+
+tidy:
+	$(CLANG_TIDY) $(SRCS) -- $(CC) $(CPPFLAGS) $(CFLAGS)

--- a/src-uland/libipc/Makefile
+++ b/src-uland/libipc/Makefile
@@ -5,6 +5,7 @@ CC ?= cc
 AR ?= ar
 CPPFLAGS ?= -I../../src-kernel
 CFLAGS ?= -O2
+CLANG_TIDY ?= ../../tools/run_clang_tidy.sh
 
 all: $(LIB)
 
@@ -17,4 +18,7 @@ $(LIB): $(OBJS)
 clean:
 	rm -f $(OBJS) $(LIB)
 
-.PHONY: all clean
+.PHONY: all clean tidy
+
+tidy:
+	$(CLANG_TIDY) $(OBJS:.o=.c) -- $(CC) $(CPPFLAGS) $(CFLAGS)

--- a/src-uland/libkern_sched/Makefile
+++ b/src-uland/libkern_sched/Makefile
@@ -4,6 +4,7 @@ LIB  = libkern_sched.a
 CC ?= cc
 AR ?= ar
 CFLAGS ?= -O2
+CLANG_TIDY ?= ../../tools/run_clang_tidy.sh
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
@@ -20,5 +21,8 @@ $(LIB): $(OBJS)
 clean:
 	rm -f $(OBJS) $(LIB)
 
-.PHONY: all clean
+.PHONY: all clean tidy
+
+tidy:
+	$(CLANG_TIDY) $(OBJS:.o=.c) -- $(CC) $(CPPFLAGS) $(CFLAGS)
 

--- a/src-uland/libvm/Makefile
+++ b/src-uland/libvm/Makefile
@@ -5,6 +5,7 @@ LIB  = libvm.a
 CC ?= cc
 AR ?= ar
 CFLAGS ?= -O2
+CLANG_TIDY ?= ../../tools/run_clang_tidy.sh
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../include -I../../sys -I../../sys/sys \
             -I../../sys/i386/include
@@ -21,4 +22,7 @@ $(LIB): $(OBJS)
 clean:
 	rm -f $(OBJS) $(LIB)
 
-.PHONY: all clean
+.PHONY: all clean tidy
+	
+tidy:
+	$(CLANG_TIDY) $(OBJS:.o=.c) -- $(CC) $(CPPFLAGS) $(CFLAGS)

--- a/src-uland/servers/proc_manager/Makefile
+++ b/src-uland/servers/proc_manager/Makefile
@@ -2,6 +2,7 @@ OBJS = kern_proc.o pm_entry.o
 PROG = proc_manager
 CC ?= cc
 CFLAGS ?= -O2
+CLANG_TIDY ?= ../../../tools/run_clang_tidy.sh
 CPPFLAGS ?= -I../../../src-headers -I../../../src-headers/machine \
             -I../../../include -I../../../sys -I../../../sys/sys \
             -I../../../sys/i386/include
@@ -18,3 +19,8 @@ $(PROG): $(OBJS)
 clean:
 	rm -f $(OBJS) $(PROG)
 
+.PHONY: all clean tidy
+
+tidy:
+	$(CLANG_TIDY) $(OBJS:.o=.c) -- $(CC) $(CPPFLAGS) $(CFLAGS)
+	


### PR DESCRIPTION
## Summary
- add a `tidy` helper target to every `src-uland` Makefile
- integrate repository's `run_clang_tidy.sh` for consistent C23 options
- document running these checks in `docs/precommit.md`

## Testing
- `make -C src-kernel clean && make -C src-kernel`
- `make -C src-uland/libipc tidy` *(fails: Found compiler errors)*
- `make -C src-uland/fs-server tidy` *(fails: Found compiler errors)*
- `make -C src-uland/libvm clean && make -C src-uland/libvm` *(fails: missing header)*
