### PR TITLE
Fix tidy rules to run helper script

### DIFF
--- a/src-kernel/Makefile
+++ b/src-kernel/Makefile
@@ -4,7 +4,7 @@ LIB = libkern_stubs.a
 
 CC ?= cc
 AR ?= ar
-CLANG_TIDY ?= clang-tidy
+CLANG_TIDY ?= ../tools/run_clang_tidy.sh
 CFLAGS ?= -O2 -std=c2x
 CPPFLAGS += -I../include
 
@@ -22,4 +22,6 @@ clean:
 	rm -f $(OBJS) $(LIB)
 	
 tidy:
-	$(CLANG_TIDY) $(OBJS:.o=.c) -- $(CC) $(CFLAGS)
+	@for src in $(OBJS:.o=.c); do \
+	$(CLANG_TIDY) $$src -- $(CC) $(CPPFLAGS) $(CFLAGS); \
+	done

--- a/usr/src/share/mk/bsd.lib.mk
+++ b/usr/src/share/mk/bsd.lib.mk
@@ -11,7 +11,7 @@ LIBOWN?=	bin
 LIBMODE?=	444
 
 STRIP?=	-s
-CLANG_TIDY?=	clang-tidy
+CLANG_TIDY?=	${.CURDIR:H:H}/tools/run_clang_tidy.sh
 
 BINGRP?=	bin
 BINOWN?=	bin
@@ -149,8 +149,10 @@ lint:
 .endif
 
 .if !target(tidy)
-tidy:
-@${CLANG_TIDY} ${SRCS:M*.c} -- ${CFLAGS}
+	tidy:
+	@for src in ${SRCS:M*.c}; do \
+	${CLANG_TIDY} $$src -- ${CFLAGS}; \
+	done
 .endif
 
 .if !target(tags)

--- a/usr/src/share/mk/bsd.prog.mk
+++ b/usr/src/share/mk/bsd.prog.mk
@@ -12,7 +12,7 @@
 CFLAGS+=${COPTS}
 
 STRIP?=	-s
-CLANG_TIDY?=	clang-tidy
+CLANG_TIDY?=	${.CURDIR:H:H}/tools/run_clang_tidy.sh
 
 BINGRP?=	bin
 BINOWN?=	bin
@@ -157,9 +157,11 @@ lint: ${SRCS} _PROGSUBDIR
 .endif
 
 .if !target(tidy)
-tidy: ${SRCS} _PROGSUBDIR
-.if defined(PROG)
-@${CLANG_TIDY} ${.ALLSRC:M*.c} -- ${CFLAGS}
+	tidy: ${SRCS} _PROGSUBDIR
+	.if defined(PROG)
+	@for src in ${.ALLSRC:M*.c}; do \
+	${CLANG_TIDY} $$src -- ${CFLAGS}; \
+	done
 .endif
 .endif
 


### PR DESCRIPTION
## Summary
- run run_clang_tidy.sh from make `tidy` rules
- iterate over source files rather than passing them all at once

## Testing
- `make clean && make` in `usr/src/usr.sbin/config` *(fails: `yacc: No such file or directory`)*