### PR TITLE
Ensure bmake install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The story: https://en.wikipedia.org/wiki/History_of_the_Berkeley_Software_Distri
 Downloaded from: ftp://alge.anart.no/pub/BSD/4.4BSD-Lite/4.4BSD-Lite2.tar.gz
 
 For kernel build instructions see [docs/building_kernel.md](docs/building_kernel.md).
+Run `setup.sh` first to install required tools like **bmake** via `apt` or `pip`.
 For GitHub CI examples see [docs/ci_workflows.md](docs/ci_workflows.md).
 For FHS migration steps see [docs/fhs_migration.md](docs/fhs_migration.md).
 For microkernel tasks see [docs/microkernel_plan.md](docs/microkernel_plan.md)

--- a/setup.sh
+++ b/setup.sh
@@ -70,6 +70,7 @@ for pkg in \
   autoconf automake libtool m4 gawk flex bison \
   pkg-config file ca-certificates curl git unzip \
   libopenblas-dev liblapack-dev libeigen3-dev \
+  libbsd0 libbsd-dev \
   strace ltrace linux-perf systemtap systemtap-sdt-dev crash \
   valgrind kcachegrind trace-cmd kernelshark \
   libasan6 libubsan1 likwid hwloc; do
@@ -213,6 +214,11 @@ command -v gmake >/dev/null 2>&1 || {
     ln -s "$(command -v make)" /usr/local/bin/gmake
   fi
 }
+
+# verify bmake was installed successfully
+if ! command -v bmake >/dev/null 2>&1; then
+  echo "bmake not found after installation" >&2
+fi
 
 # clean up
 apt-get clean


### PR DESCRIPTION
## Summary
- clarify that setup.sh installs bmake
- add libbsd packages for bmake
- check for bmake after install

## Testing
- `bash setup.sh` *(fails: Could not connect to proxy)*
- `cd usr/src/usr.sbin/config && bmake clean` *(fails: command not found)*
