### PR TITLE
Handle curl failures in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -189,17 +189,34 @@ done
 # IA-16 (8086/286) cross-compiler
 IA16_VER=$(curl -fsSL https://api.github.com/repos/tkchia/gcc-ia16/releases/latest \
            | awk -F\" '/tag_name/{print $4; exit}')
-curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia16-elf-gcc-linux64.tar.xz" \
-  | tar -Jx -C /opt
-echo 'export PATH=/opt/ia16-elf-gcc/bin:$PATH' > /etc/profile.d/ia16.sh
-export PATH=/opt/ia16-elf-gcc/bin:$PATH
+if [ $? -ne 0 ] || [ -z "$IA16_VER" ]; then
+  echo "curl FAILED ia16 version" >> "$LOG_FILE"
+  APT_FAILED+=("ia16-elf-gcc")
+else
+  curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia16-elf-gcc-linux64.tar.xz" -o /tmp/ia16.tar.xz
+  rc=$?
+  if [ $rc -ne 0 ]; then
+    echo "curl FAILED ia16-elf-gcc" >> "$LOG_FILE"
+    APT_FAILED+=("ia16-elf-gcc")
+  else
+    tar -Jx -f /tmp/ia16.tar.xz -C /opt
+    echo 'export PATH=/opt/ia16-elf-gcc/bin:$PATH' > /etc/profile.d/ia16.sh
+    export PATH=/opt/ia16-elf-gcc/bin:$PATH
+  fi
+fi
 
 # protoc installer (pinned)
 PROTO_VERSION=25.1
 curl -fsSL "https://raw.githubusercontent.com/protocolbuffers/protobuf/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip" \
   -o /tmp/protoc.zip
-unzip -d /usr/local /tmp/protoc.zip
-rm /tmp/protoc.zip
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "curl FAILED protoc" >> "$LOG_FILE"
+  APT_FAILED+=("protoc")
+else
+  unzip -d /usr/local /tmp/protoc.zip
+  rm /tmp/protoc.zip
+fi
 
 
 # ensure yacc points to bison and gmake invokes bmake
@@ -225,9 +242,9 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 
 if [ ${#APT_FAILED[@]} -ne 0 ] || [ ${#PIP_FAILED[@]} -ne 0 ]; then
-  echo "Some packages failed to install. See $LOG_FILE for details." >&2
-  echo "APT failures: ${APT_FAILED[*]}" >&2
-  echo "PIP failures: ${PIP_FAILED[*]}" >&2
+  echo "Some downloads or installations failed. See $LOG_FILE for details." >&2
+  [ ${#APT_FAILED[@]} -ne 0 ] && echo "APT/download failures: ${APT_FAILED[*]}" >&2
+  [ ${#PIP_FAILED[@]} -ne 0 ] && echo "PIP failures: ${PIP_FAILED[*]}" >&2
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- check curl results in `setup.sh`
- skip extraction on download failures and track them via `APT_FAILED`
- summarize download failures at the end of setup

## Testing
- `make -C src-kernel clean all`
- `make -C tests clean all`
