### PR TITLE
Add shellcheck pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,8 @@ repos:
         entry: tools/run_clang_tidy.sh
         language: system
         files: \.(c|cpp|h|hpp)$
+      - id: shellcheck
+        name: shellcheck
+        entry: shellcheck
+        language: system
+        files: \.sh$

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -1,7 +1,7 @@
 # Using pre-commit
 
 This repository provides a `.pre-commit-config.yaml` with hooks for
-`clang-format` and `clang-tidy`. Running `setup.sh` installs the
+`clang-format`, `clang-tidy` and `shellcheck`. Running `setup.sh` installs the
 `pre-commit` tool via both `apt` and `pip` and automatically sets up
 the git hooks. After executing the script no manual steps are needed,
 but you can re-install the hooks any time:
@@ -14,3 +14,4 @@ The hooks rely on the configuration files `.clang-format` and
 `.clang-tidy` at the repository root.  A helper script
 `tools/run_clang_tidy.sh` selects the appropriate language standard
 (C23 or C++17) when invoking `clang-tidy`.
+Shell scripts (`*.sh`) are linted with `shellcheck`.

--- a/setup.sh
+++ b/setup.sh
@@ -65,7 +65,7 @@ apt_pin_install bison || install_with_pip bison
 # core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
-  clang-format clang-tidy uncrustify astyle editorconfig pre-commit \
+  clang-format clang-tidy uncrustify astyle editorconfig pre-commit shellcheck \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison \
   pkg-config file ca-certificates curl git unzip \


### PR DESCRIPTION
## Summary
- install shellcheck during setup
- run shellcheck via pre-commit
- document shell linting

## Testing
- `bmake clean && bmake` *(fails: command not found)*
- `pre-commit run --files setup.sh .pre-commit-config.yaml docs/precommit.md` *(fails: command not found)*