### PR TITLE
Ensure byacc is installed

### DIFF
--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -3,7 +3,7 @@
 This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `bmake`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
 
 Before building, run the repository's `setup.sh` script as root to install all
-required toolchains and utilities.  The script installs **bison** and **bmake**.  All results are logged in
+required toolchains and utilities.  The script installs **bison**, **byacc**, and **bmake**.  All results are logged in
 `/tmp/setup.log`.  Packages that fail via `apt` are automatically retried with
 `pip` when possible.
 

--- a/setup.sh
+++ b/setup.sh
@@ -58,16 +58,17 @@ apt-get update -y >/dev/null 2>&1 && echo "APT OK   update" >> "$LOG_FILE" || {
   echo "APT FAIL update" >> "$LOG_FILE"
   APT_FAILED+=("update")
 }
-# guarantee bmake and bison are present
+# guarantee bmake, bison and byacc are present
 apt_pin_install bmake || install_with_pip bmake
 apt_pin_install bison || install_with_pip bison
+apt_pin_install byacc || install_with_pip byacc
 
 # core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
   clang-format clang-tidy uncrustify astyle editorconfig pre-commit \
   make bmake ninja-build cmake meson \
-  autoconf automake libtool m4 gawk flex bison \
+  autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \
   libopenblas-dev liblapack-dev libeigen3-dev \
   libbsd0 libbsd-dev \


### PR DESCRIPTION
## Summary
- make `setup.sh` install byacc with apt or pip
- document that byacc is part of the required toolchain

## Testing
- `make -C tests clean`
- `make -C tests` *(fails: cannot find ../src-kernel/libkern_stubs.a)*