### PR TITLE
Add IPC-based process hooks

### DIFF
--- a/docs/microkernel_plan.md
+++ b/docs/microkernel_plan.md
@@ -65,6 +65,8 @@ The steps in `tools/migrate_to_fhs.sh` will be updated so these directories map 
    - Device drivers and BSD daemons become user space services under `src-uland/servers` and `src-uland/drivers`.
    - Introduce `proc_hooks.c` so `kern_fork()` and `kern_exec()` delegate to the
      user-space `proc_manager`.
+   - Process requests are forwarded over IPC using `IPC_MSG_FORK` and
+     `IPC_MSG_EXEC` message types.
 
 4. **User Space Isolation**
    - Servers communicate with the microkernel via message passing or shared memory APIs.

--- a/src-kernel/ipc.h
+++ b/src-kernel/ipc.h
@@ -11,7 +11,9 @@
 enum ipc_msg_type {
     IPC_MSG_SCHED_INIT = 1,
     IPC_MSG_VM_FAULT,
-    IPC_MSG_OPEN
+    IPC_MSG_OPEN,
+    IPC_MSG_FORK,
+    IPC_MSG_EXEC
 };
 
 struct ipc_message {

--- a/src-kernel/proc_hooks.c
+++ b/src-kernel/proc_hooks.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "../include/exokernel.h"
+#include "ipc.h"
 /* Stubs delegating to user-space process manager */
 extern int pm_fork(void);
 extern int pm_exec(const char *path, char *const argv[]);
@@ -7,12 +8,26 @@ extern int pm_exec(const char *path, char *const argv[]);
 int
 kern_fork(void)
 {
+    struct ipc_message msg = { .type = IPC_MSG_FORK };
+    ipc_queue_send(&kern_ipc_queue, &msg);
+    struct ipc_message reply;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply))
+        return (int)reply.a;
     return pm_fork();
 }
 
 int
 kern_exec(const char *path, char *const argv[])
 {
+    struct ipc_message msg = {
+        .type = IPC_MSG_EXEC,
+        .a = (uintptr_t)path,
+        .b = (uintptr_t)argv
+    };
+    ipc_queue_send(&kern_ipc_queue, &msg);
+    struct ipc_message reply;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply))
+        return (int)reply.a;
     return pm_exec(path, argv);
 }
 


### PR DESCRIPTION
## Summary
- forward fork/exec via IPC messages
- include new message types in `ipc.h`
- note the IPC messages in the microkernel plan

## Testing
- `make clean && make` in `src-kernel`