### PR TITLE
Update Meson build for kernel stubs

### DIFF
--- a/src-kernel/meson.build
+++ b/src-kernel/meson.build
@@ -1,6 +1,7 @@
 project('kern_stubs', 'c', default_options : ['c_std=c23'])
 
-srcs = ['proc_hooks.c', 'sched_hooks.c', 'vm_hooks.c', 'vfs_hooks.c', 'ipc.c']
+srcs = ['proc_hooks.c', 'sched_hooks.c', 'vm_hooks.c', 'vfs_hooks.c']
+srcs += ['ipc.c']
 libkern = static_library('kern_stubs', srcs,
                          include_directories : include_directories('../include'))
 


### PR DESCRIPTION
## Summary
- include ipc.c when building libkern_stubs.a with Meson

## Testing
- `bmake clean && bmake` *(fails: `bmake` not found)*