### PR TITLE
Implement IPC ring-buffer and hook updates

### DIFF
--- a/src-kernel/ipc.h
+++ b/src-kernel/ipc.h
@@ -11,7 +11,9 @@
 enum ipc_msg_type {
     IPC_MSG_SCHED_INIT = 1,
     IPC_MSG_VM_FAULT,
-    IPC_MSG_OPEN
+    IPC_MSG_OPEN,
+    IPC_MSG_PROC_FORK,
+    IPC_MSG_PROC_EXEC
 };
 
 struct ipc_message {

--- a/src-kernel/proc_hooks.c
+++ b/src-kernel/proc_hooks.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "../include/exokernel.h"
+#include "ipc.h"
 /* Stubs delegating to user-space process manager */
 extern int pm_fork(void);
 extern int pm_exec(const char *path, char *const argv[]);
@@ -7,12 +8,26 @@ extern int pm_exec(const char *path, char *const argv[]);
 int
 kern_fork(void)
 {
+    struct ipc_message msg = { .type = IPC_MSG_PROC_FORK };
+    ipc_queue_send(&kern_ipc_queue, &msg);
+    struct ipc_message reply;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply))
+        return (int)reply.a;
     return pm_fork();
 }
 
 int
 kern_exec(const char *path, char *const argv[])
 {
+    struct ipc_message msg = {
+        .type = IPC_MSG_PROC_EXEC,
+        .a = (uintptr_t)path,
+        .b = (uintptr_t)argv
+    };
+    ipc_queue_send(&kern_ipc_queue, &msg);
+    struct ipc_message reply;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply))
+        return (int)reply.a;
     return pm_exec(path, argv);
 }
 

--- a/src-uland/libipc/ipc.c
+++ b/src-uland/libipc/ipc.c
@@ -3,26 +3,58 @@
 /* Shared queue used by kernel stubs and user-space servers */
 struct ipc_queue kern_ipc_queue;
 
+static void lock_queue(struct ipc_queue *q)
+{
+    while (atomic_flag_test_and_set_explicit(&q->lock, memory_order_acquire))
+        ;
+}
+
+static void unlock_queue(struct ipc_queue *q)
+{
+    atomic_flag_clear_explicit(&q->lock, memory_order_release);
+}
+
 void ipc_queue_init(struct ipc_queue *q)
 {
     q->head = q->tail = 0;
+    atomic_flag_clear(&q->lock);
 }
 
 bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)
 {
+    bool ok = false;
+    lock_queue(q);
     uint32_t next = (q->head + 1) % IPC_QUEUE_SIZE;
-    if (next == q->tail)
-        return false; /* full */
-    q->msgs[q->head] = *m;
-    q->head = next;
-    return true;
+    if (next != q->tail) {
+        q->msgs[q->head] = *m;
+        q->head = next;
+        ok = true;
+    }
+    unlock_queue(q);
+    return ok;
 }
 
 bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)
 {
-    if (q->tail == q->head)
-        return false; /* empty */
-    *m = q->msgs[q->tail];
-    q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
-    return true;
+    bool ok = false;
+    lock_queue(q);
+    if (q->tail != q->head) {
+        *m = q->msgs[q->tail];
+        q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
+        ok = true;
+    }
+    unlock_queue(q);
+    return ok;
+}
+
+void ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m)
+{
+    while (!ipc_queue_send(q, m))
+        ;
+}
+
+void ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m)
+{
+    while (!ipc_queue_recv(q, m))
+        ;
 }


### PR DESCRIPTION
## Summary
- expand IPC message types for process manager events
- route `kern_fork` and `kern_exec` through new IPC queue
- make libipc thread-safe and provide blocking helpers

## Testing
- `make -C src-kernel CLANG_TIDY=true`
- `make -C src-uland/libipc`
- `make -C tests`