### PR TITLE
Update scripts for src-lib and document directory

### DIFF
--- a/docs/fhs_migration.md
+++ b/docs/fhs_migration.md
@@ -68,7 +68,8 @@ when modernizing historic BSD trees.
 5. Execute `tools/migrate_to_src_layout.sh` (add `--force` when outside the chroot)
    to relocate the sources. The script moves the kernel into `src-kernel`, user
    programs into `src-uland`, headers into `src-headers` and collects archive
-   libraries into `src-lib`.
+   libraries into `src-lib`. The `src-lib` directory keeps these libraries
+   together so they can be built independently of the rest of the tree.
 6. Verify the new symlinks by running `ls -l` on `bin`, `sbin` and related
    directories.
 7. Update makefiles and scripts to reference the new paths. `grep -r "/bin"`

--- a/docs/reorg_plan.md
+++ b/docs/reorg_plan.md
@@ -23,5 +23,6 @@ This document outlines tasks for flattening the 4.4BSD-Lite2 source tree and mod
    `tools/migrate_to_src_layout.sh` (or the older `tools/organize_sources.sh`)
    to move them into `src-kernel`, `src-uland`, `src-headers` and `src-lib`.
    The `src-lib` directory stores archive libraries separated from the rest of
-   the tree.
+   the tree.  These scripts create `src-lib/.gitkeep` automatically so the
+   directory remains in version control even when empty.
 

--- a/tools/migrate_to_src_layout.sh
+++ b/tools/migrate_to_src_layout.sh
@@ -61,6 +61,7 @@ move_artifacts() {
     base="$1"
     [ -d "$base" ] || return 0
     run_cmd "mkdir -p src-lib"
+    run_cmd "touch src-lib/.gitkeep"
     find "$base" -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.so.*' \) | while read f; do
         rel="${f#$base/}"
         dest="src-lib/$rel"

--- a/tools/organize_sources.sh
+++ b/tools/organize_sources.sh
@@ -61,6 +61,7 @@ move_artifacts() {
     base="$1"
     [ -d "$base" ] || return 0
     run_cmd "mkdir -p src-lib"
+    run_cmd "touch src-lib/.gitkeep"
     find "$base" -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.so.*' \) | while read f; do
         rel="${f#$base/}"
         dest="src-lib/$rel"

--- a/tools/post_fhs_cleanup.sh
+++ b/tools/post_fhs_cleanup.sh
@@ -61,6 +61,7 @@ move_artifacts() {
     base="$1"
     [ -d "$base" ] || return 0
     run_cmd "mkdir -p src-lib"
+    run_cmd "touch src-lib/.gitkeep"
     find "$base" -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.so.*' \) | while read f; do
         rel="${f#$base/}"
         dest="src-lib/$rel"


### PR DESCRIPTION
## Summary
- document usage of the new `src-lib` library directory
- ensure migration scripts create `src-lib/.gitkeep`

## Testing
- `git status --short`