### PR TITLE
Initialize IPC queue via scheduler stub

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@ CFLAGS ?= -O2 -std=c2x
 CPPFLAGS = -I../tests/include -I../include -I../src-headers -I../src-headers/machine -I../src-kernel
 LIBS = ../src-kernel/libkern_stubs.a
 
-OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o mock_vm.o
+OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o sched_stub.o mock_vm.o
 
 all: test_kern
 
@@ -21,6 +21,9 @@ vm_entry.o: ../src-uland/libvm/vm_entry.c
 
 mock_vm.o: mock_vm.c
 	$(CC) -I../tests/include $(CFLAGS) -c $< -o $@
+
+sched_stub.o: sched_stub.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	 rm -f $(OBJS) test_kern

--- a/tests/sched_stub.c
+++ b/tests/sched_stub.c
@@ -1,0 +1,2 @@
+#include "kern_sched.h"
+void uland_sched_init(void) {}

--- a/tests/test_kern.c
+++ b/tests/test_kern.c
@@ -10,7 +10,8 @@
 #include "ipc.h"
 
 int main(void) {
-    ipc_queue_init(&kern_ipc_queue);
+    /* start scheduler which also sets up the IPC queue */
+    kern_sched_init();
 
     int fd = kern_open("README.md", O_RDONLY);
     if (fd < 0) {


### PR DESCRIPTION
## Summary
- call `kern_sched_init()` in the kernel test so the IPC queue is initialized
- add a small stub for `uland_sched_init`
- update the test makefile to build the stub

## Testing
- `make -C src-kernel`
- `make -C tests`
- `./tests/test_kern`