### PR TITLE
Add mk-configure package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ The story: https://en.wikipedia.org/wiki/History_of_the_Berkeley_Software_Distri
 Downloaded from: ftp://alge.anart.no/pub/BSD/4.4BSD-Lite/4.4BSD-Lite2.tar.gz
 
 For kernel build instructions see [docs/building_kernel.md](docs/building_kernel.md).
-Run `setup.sh` first to install required tools like **bmake** via `apt` or `pip`.
+Run `setup.sh` first to install required tools. The script uses `apt-get install` to
+fetch **bmake** and its mk framework and can optionally install **mk-configure**
+to provide an Autotools-style build system layered on top.
 For GitHub CI examples see [docs/ci_workflows.md](docs/ci_workflows.md).
 For FHS migration steps see [docs/fhs_migration.md](docs/fhs_migration.md).
 For microkernel tasks see [docs/microkernel_plan.md](docs/microkernel_plan.md)

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -3,9 +3,11 @@
 This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `bmake`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
 
 Before building, run the repository's `setup.sh` script as root to install all
-required toolchains and utilities.  The script installs **bison**, **byacc**, and **bmake**.  All results are logged in
-`/tmp/setup.log`.  Packages that fail via `apt` are automatically retried with
-`pip` when possible.
+required toolchains and utilities. The script uses `apt-get` to install
+**bison**, **byacc**, and **bmake** (which includes the full mk framework).
+Optionally **mk-configure** can also be installed to provide an Autotools-style
+layer on top of `bmake`. All results are logged in `/tmp/setup.log`. Packages
+that fail via `apt` are automatically retried with `pip` when possible.
 
 If `bison` is missing, install it and export `YACC="bison -y"` before building.
 Then proceed with the steps below.

--- a/setup.sh
+++ b/setup.sh
@@ -58,8 +58,10 @@ apt-get update -y >/dev/null 2>&1 && echo "APT OK   update" >> "$LOG_FILE" || {
   echo "APT FAIL update" >> "$LOG_FILE"
   APT_FAILED+=("update")
 }
-# guarantee bmake, bison and byacc are present
+# guarantee bmake (with its mk framework) is present
+# mk-configure is optional and layers an Autotools-style system on top
 apt_pin_install bmake || install_with_pip bmake
+apt_pin_install mk-configure || install_with_pip mk-configure
 apt_pin_install bison || install_with_pip bison
 apt_pin_install byacc || install_with_pip byacc
 


### PR DESCRIPTION
## Summary
- mention optional mk-configure install in README and build docs
- ensure mk-configure is installed only once in setup script

## Testing
- `sudo bash setup.sh` *(fails: bmake not found after installation)*
- `bmake clean` in `usr/src/usr.sbin/config` *(fails: command not found)*
