### PR TITLE
Fix clang-tidy standard alignment

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -13,7 +13,7 @@ pre-commit install --install-hooks
 The hooks rely on the configuration files `.clang-format` and
 `.clang-tidy` at the repository root.  A helper script
 `tools/run_clang_tidy.sh` selects the appropriate language standard
-(C23 or C++23) when invoking `clang-tidy`.
+(C2x for C or C++17) when invoking `clang-tidy`.
 
 Shell scripts (`*.sh`) are linted with `
 A `.gitignore` file at the repository root prevents common build artifacts

--- a/tools/run_clang_tidy.sh
+++ b/tools/run_clang_tidy.sh
@@ -6,7 +6,8 @@ trap 'rc=$?; echo "FAILED: ${BASH_COMMAND} (exit $rc)" >> "$LOG"' ERR
 file="$1"
 args=("${@:2}")
 if [[ "$file" == *.c ]]; then
-    clang-tidy "$file" "${args[@]}" -- -std=c23
+    # Match the C standard used by the makefiles (-std=c2x)
+    clang-tidy "$file" "${args[@]}" -- -std=c2x
 elif [[ "$file" == *.cpp || "$file" == *.cc || "$file" == *.cxx ]]; then
     clang-tidy "$file" "${args[@]}" -- -std=c++17
 else


### PR DESCRIPTION
## Summary
- adjust clang-tidy helper to use `-std=c2x` for C sources
- clarify the clang-tidy standard in precommit docs

## Testing
- `bmake -C src-kernel` *(fails: `bmake: command not found`)*