### PR TITLE
Ensure bmake presence

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -260,6 +260,7 @@ command -v gmake >/dev/null 2>&1 || {
 # verify bmake was installed successfully
 if ! command -v bmake >/dev/null 2>&1; then
   echo "bmake not found after installation" >&2
+  exit 1
 fi
 
 # clean up


### PR DESCRIPTION
## Summary
- enforce bmake availability in `setup.sh`

## Testing
- `make` in `src-kernel` *(fails: no such file or directory: '-std=c23' etc. but built `libkern_stubs.a`)*