### PR TITLE
Add compiledb tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
   - repo: local
     hooks:
+      - id: compiledb
+        name: generate compile_commands.json
+        entry: tools/generate_compiledb.sh
+        language: system
+        pass_filenames: false
       - id: clang-format
         name: clang-format
         entry: clang-format -i

--- a/README.md
+++ b/README.md
@@ -65,4 +65,5 @@ For exokernel tasks see [docs/exokernel_plan.md](docs/exokernel_plan.md).
 ## Tools
 
 The `tools` directory contains helper scripts. `generate_dependency_graph.py` scans the source tree to build a DOT file of include dependencies and syscall implementations. Run `python3 tools/generate_dependency_graph.py` to produce `dependency_graph.dot` (use `--include-calls` to add a simple call graph).
+`tools/generate_compiledb.sh` runs `compiledb` to create a `compile_commands.json` database for clang-tidy.
 

--- a/docs/modernization_plan.md
+++ b/docs/modernization_plan.md
@@ -19,6 +19,8 @@ For a summary of directory mappings during the reorganization see
 - Prototype CMake build files using **CMake 3.16+** to evaluate a cross-platform build system.
 - Integrate static analysis tools such as `clang-tidy`.
 - Set up a `pre-commit` hook to run `clang-format` and `clang-tidy`.
+- Generate a `compile_commands.json` database using `compiledb` for use with
+  static analysis.
 
 ## Phase 3: Userland Modernization
 - Update core libraries (`libc`, `libm`) to use ANSI C prototypes.

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -15,7 +15,9 @@ The hooks rely on the configuration files `.clang-format` and
 `tools/run_clang_tidy.sh` selects the appropriate language standard
 (C23 or C++23) when invoking `clang-tidy`.
 
-Shell scripts (`*.sh`) are linted with `
-A `.gitignore` file at the repository root prevents common build artifacts
-from being committed. Patterns include `*/obj/`, `*.o`, `*.a`, `*.log` and the
+Shell scripts (`*.sh`) are linted with `shellcheck`.
+Use `tools/generate_compiledb.sh` to create a `compile_commands.json` file for
+`clang-tidy`.
+A `.gitignore` file at the repository root prevents common build artifacts from
+being committed. Patterns include `*/obj/`, `*.o`, `*.a`, `*.log` and the
 `compile/` directory.

--- a/setup.sh
+++ b/setup.sh
@@ -116,7 +116,7 @@ done
 for pip_pkg in \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools \
-  meson ninja cmake pre-commit; do
+  meson ninja cmake pre-commit compiledb; do
   pip3 install "$pip_pkg" >/dev/null 2>&1
   rc=$?
   if [ $rc -ne 0 ]; then

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -5,4 +5,5 @@ Examples:
 - `analyze_codebase.py` – count source files.
 - `generate_cscope.sh` and `generate_ctags.sh` – index helpers.
 - `build_collect_warnings.sh` – build and capture warnings.
+- `generate_compiledb.sh` – produce a compile database for clang-tidy.
 No automated tests are required to modify these scripts.

--- a/tools/generate_compiledb.sh
+++ b/tools/generate_compiledb.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TARGET_DIR=${1:-usr/src}
+compiledb -n bmake -C "$TARGET_DIR"


### PR DESCRIPTION
## Summary
- install compiledb via pip in setup.sh
- add a script to generate compile_commands.json
- run compiledb in pre-commit hook
- document compiledb use in README and docs
- fix docs/precommit.md wording

## Testing
- `bmake inventory` *(fails: command not found)*