### PR TITLE
Validate bmake install in setup

### DIFF
--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -11,6 +11,10 @@ for **bmake**, will download the upstream source and build it locally. Optionall
 `bmake`. All results are logged in `/tmp/setup.log`. Packages that fail via
 `apt` are automatically retried with `pip` when possible.
 
+The script also validates that the `bmake` executable is present and that the
+`bmake` package was installed successfully via `dpkg`; it aborts if either
+check fails.
+
 If `bison` is missing, install it and export `YACC="bison -y"` before building.
 Then proceed with the steps below.
 

--- a/setup.sh
+++ b/setup.sh
@@ -263,6 +263,12 @@ if ! command -v bmake >/dev/null 2>&1; then
   exit 1
 fi
 
+# ensure the package itself is registered with dpkg
+if ! dpkg -s bmake >/dev/null 2>&1; then
+  echo "bmake package is not installed" >&2
+  exit 1
+fi
+
 # clean up
 apt-get clean
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- check the dpkg registration of bmake in setup.sh
- document that setup.sh now validates the bmake package install

## Testing
- `sudo bash setup.sh` *(fails: bmake not found after installation)*
- `bmake clean && bmake` in `usr/src/usr.sbin/config` *(fails: command not found)*