### PR TITLE
Ensure libipc queue uses atomic operations

### DIFF
--- a/src-uland/libipc/ipc.c
+++ b/src-uland/libipc/ipc.c
@@ -1,4 +1,5 @@
 #include "ipc.h"
+#include <stdatomic.h>
 
 /* Shared queue used by kernel stubs and user-space servers */
 struct ipc_queue kern_ipc_queue;


### PR DESCRIPTION
## Summary
- include `<stdatomic.h>` in `libipc` queue implementation
- rebuild `libipc.a`

## Testing
- `make -C src-uland/libipc clean`
- `make -C src-uland/libipc`