### PR TITLE
Add libipc header and update Makefiles

### DIFF
--- a/docs/file_inventory.txt
+++ b/docs/file_inventory.txt
@@ -214,6 +214,7 @@ root/.profile
 root/.rhosts
 root/AGENTS.md
 setup.sh
+src-headers/libipc.h
 src-kernel/.gitkeep
 src-kernel/AGENTS.md
 src-kernel/Makefile

--- a/src-headers/libipc.h
+++ b/src-headers/libipc.h
@@ -1,0 +1,22 @@
+#ifndef LIBIPC_H
+#define LIBIPC_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../../src-kernel/ipc.h"
+
+/* User-space convenience wrappers */
+static inline bool ipc_send(const struct ipc_message *m)
+{
+    ipc_queue_send_blocking(&kern_ipc_queue, m);
+    return true;
+}
+
+static inline bool ipc_recv(struct ipc_message *m)
+{
+    ipc_queue_recv_blocking(&kern_ipc_queue, m);
+    return true;
+}
+
+#endif /* LIBIPC_H */

--- a/src-uland/init/Makefile
+++ b/src-uland/init/Makefile
@@ -5,6 +5,7 @@ PROG = init
 CC ?= cc
 CFLAGS ?= -O2
 CSTD ?= -std=c2x
+CPPFLAGS ?= -I../../src-headers
 CFLAGS += $(CSTD)
 
 all: $(PROG)

--- a/src-uland/libipc/Makefile
+++ b/src-uland/libipc/Makefile
@@ -3,7 +3,7 @@ LIB  = libipc.a
 
 CC ?= cc
 AR ?= ar
-CPPFLAGS ?= -I../../src-kernel
+CPPFLAGS ?= -I../../src-headers -I../../src-kernel
 CFLAGS ?= -O2
 CSTD ?= -std=c2x
 CFLAGS += $(CSTD)


### PR DESCRIPTION
## Summary
- expose libipc.h for userland builds
- search src-headers when compiling userland init and libipc
- track libipc header in docs inventory

## Testing
- `make -C src-uland/libipc clean all`
- `make -C src-uland/init clean all` *(fails: unknown type name 'pid_t')*