### PR TITLE
Add shellcheck to setup and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
         entry: shellcheck
         language: system
         files: \.sh$
+  - repo: https://github.com/koalaman/shellcheck
+    rev: 'v0.9.0'
+    hooks:
+      - id: shellcheck
+        files: \.sh$

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -3,7 +3,8 @@
 This repository provides a `.pre-commit-config.yaml` with hooks for
 `clang-format`, `clang-tidy` and `shellcheck`. Running `setup.sh` installs the
 `pre-commit` tool via both `apt` and `pip` and automatically sets up
-the git hooks. After executing the script no manual steps are needed,
+the git hooks. The script also installs `shellcheck` using `apt_pin_install`
+with a fallback to `pip`. After executing the script no manual steps are needed,
 but you can re-install the hooks any time:
 
 ```sh

--- a/setup.sh
+++ b/setup.sh
@@ -86,6 +86,7 @@ command -v bmake >/dev/null 2>&1 || build_bmake_from_source
 apt_pin_install mk-configure || install_with_pip mk-configure
 apt_pin_install bison || install_with_pip bison
 apt_pin_install byacc || install_with_pip byacc
+apt_pin_install shellcheck || install_with_pip shellcheck
 
 # core build tools, formatters, analysis, science libs
 for pkg in \


### PR DESCRIPTION
## Summary
- install `shellcheck` with apt fallback to pip
- add `shellcheck` hook to pre-commit config
- document shell linting setup in the precommit notes

## Testing
- `make -C tests` *(fails: cannot find ../src-kernel/libkern_stubs.a)*
- `cd usr/src/usr.sbin/config && bmake clean && bmake` *(fails: bmake: command not found)*
- `pre-commit run --files setup.sh .pre-commit-config.yaml docs/precommit.md` *(fails: pre-commit: command not found)*