### PR TITLE
Fix setup script fallback for bmake

### DIFF
--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -6,10 +6,12 @@ Before building, run the repository's `setup.sh` script as root to install all
 required toolchains and utilities. The script first attempts to install
 **bison**, **byacc**, and **bmake** (which includes the full mk framework)
 using `apt-get`. If the package installation fails it falls back to `pip` and,
-for **bmake**, will download the upstream source and build it locally. Optionally
-**mk-configure** can be installed to provide an Autotools-style layer on top of
-`bmake`. All results are logged in `/tmp/setup.log`. Packages that fail via
-`apt` are automatically retried with `pip` when possible.
+for **bmake**, will download the upstream source and build it locally.
+When built from source the script generates a small `.deb` so `dpkg` still
+records the package. Optionally **mk-configure** can be installed to provide
+an Autotools-style layer on top of `bmake`. All results are logged in
+`/tmp/setup.log`. Packages that fail via `apt` are automatically retried with
+`pip` when possible.
 
 The script also validates that the `bmake` executable is present and that the
 `bmake` package was installed successfully via `dpkg`; it aborts if either

--- a/setup.sh
+++ b/setup.sh
@@ -63,6 +63,21 @@ build_bmake_from_source(){
       APT_FAILED+=("bmake-source")
     else
       echo "SRC OK   bmake" >> "$LOG_FILE"
+      # create a minimal deb so dpkg records bmake as installed
+      pkgdir=$(mktemp -d)
+      mkdir -p "$pkgdir/DEBIAN"
+      cat > "$pkgdir/DEBIAN/control" <<EOF
+Package: bmake
+Version: 2024-source
+Section: misc
+Priority: optional
+Architecture: $(dpkg --print-architecture)
+Maintainer: local
+Description: locally built bmake
+EOF
+      dpkg-deb --build "$pkgdir" >/dev/null 2>&1
+      dpkg -i "$pkgdir.deb" >/dev/null 2>&1
+      rm -rf "$pkgdir" "$pkgdir.deb"
     fi
   else
     echo "SRC DL   FAIL bmake" >> "$LOG_FILE"


### PR DESCRIPTION
## Summary
- ensure `setup.sh` registers a dpkg package when bmake is built from source
- document bmake's new fallback install behavior

## Testing
- `bash -n setup.sh`
- `make inventory`