### PR TITLE
Add codespell and pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,9 @@ repos:
     hooks:
       - id: shellcheck
         files: \.sh$
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+        name: codespell
+        files: \.(c|cpp|h|hpp|md|sh|txt)$

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -17,8 +17,9 @@ The script also validates that the `bmake` executable is present and that the
 `bmake` package was installed successfully via `dpkg`; it aborts if either
 check fails.
 
-If `bison` is missing, install it and export `YACC="bison -y"` before building.
-Then proceed with the steps below.
+If `bison` is missing, install it and rerun `setup.sh`. The script now sets
+`YACC="bison -y"` automatically using `/etc/profile.d/yacc.sh`. Then proceed
+with the steps below.
 
 1. **Build the `config` utility**
    ```sh
@@ -102,7 +103,10 @@ The exokernel layout relocates sources using `tools/organize_sources.sh`. After 
    cd src-kernel
    bmake clean && bmake
    ```
-   Use the same environment variables as the classic build. If `YACC` was exported earlier, export it again before invoking `bmake`. Append `CFLAGS=-m32` or `CFLAGS=-m64` for your architecture as needed.
+Use the same environment variables as the classic build. `setup.sh` exports
+`YACC=bison -y` for you. If the variable is missing in your shell, export it
+before invoking `bmake`. Append `CFLAGS=-m32` or `CFLAGS=-m64` for your
+architecture as needed.
 
 2. **Build user-space managers**
    ```sh

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -1,11 +1,12 @@
 # Using pre-commit
 
 This repository provides a `.pre-commit-config.yaml` with hooks for
-`clang-format`, `clang-tidy` and `shellcheck`. Running `setup.sh` installs the
-`pre-commit` tool via both `apt` and `pip` and automatically sets up
-the git hooks. The script also installs `shellcheck` using `apt_pin_install`
-with a fallback to `pip`. After executing the script no manual steps are needed,
-but you can re-install the hooks any time:
+`clang-format`, `clang-tidy`, `shellcheck` and `codespell`. Running `setup.sh`
+installs the `pre-commit` tool via both `apt` and `pip`, installs `codespell`,
+and automatically configures the git hooks. The script also installs
+`shellcheck` using `apt_pin_install` with a fallback to `pip`. After executing
+the script no manual steps are needed, but you can re-install the hooks any
+time:
 
 ```sh
 pre-commit install --install-hooks

--- a/setup.sh
+++ b/setup.sh
@@ -101,12 +101,17 @@ command -v bmake >/dev/null 2>&1 || build_bmake_from_source
 apt_pin_install mk-configure || install_with_pip mk-configure
 apt_pin_install bison || install_with_pip bison
 apt_pin_install byacc || install_with_pip byacc
+if command -v bison >/dev/null 2>&1; then
+  export YACC="bison -y"
+  echo 'export YACC="bison -y"' > /etc/profile.d/yacc.sh
+fi
 apt_pin_install shellcheck || install_with_pip shellcheck
+apt_pin_install codespell || install_with_pip codespell
 
 # core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
-  clang-format clang-tidy uncrustify astyle editorconfig pre-commit shellcheck \
+  clang-format clang-tidy uncrustify astyle editorconfig pre-commit shellcheck codespell \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \
@@ -132,7 +137,7 @@ done
 for pip_pkg in \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools \
-  meson ninja cmake pre-commit compiledb; do
+  meson ninja cmake pre-commit compiledb codespell; do
   pip3 install "$pip_pkg" >/dev/null 2>&1
   rc=$?
   if [ $rc -ne 0 ]; then


### PR DESCRIPTION
## Summary
- install `codespell` via `apt`/`pip` in `setup.sh`
- export YACC in setup and update docs for pre-commit
- run codespell via pre-commit hook

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `pre-commit run --files .pre-commit-config.yaml docs/precommit.md setup.sh` *(fails: command not found)*