### PR TITLE
Add scoped spinlock utility

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -82,7 +82,8 @@ for a corresponding reply from the user-space server.
 
 The queue implementation originally offered only non-blocking `ipc_queue_send()`
 and `ipc_queue_recv()` calls.  To simplify users of the API a lightweight
-spinlock now protects the ring buffer and two blocking helpers were added:
+the ring buffer is protected by a small spinlock implemented in
+`include/spinlock.h`. Two blocking helpers were added:
 `ipc_queue_send_blocking()` and `ipc_queue_recv_blocking()`.  These functions
 busy-wait until the operation completes.  User-space wrappers `ipc_send()` and
 `ipc_recv()` invoke the blocking variants to guarantee delivery.

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -1,0 +1,45 @@
+#ifndef SPINLOCK_H
+#define SPINLOCK_H
+
+#include <stdatomic.h>
+
+typedef struct spinlock {
+    atomic_flag flag;
+} spinlock_t;
+
+static inline void spinlock_init(spinlock_t *l)
+{
+    atomic_flag_clear(&l->flag);
+}
+
+static inline void spinlock_lock(spinlock_t *l)
+{
+    while (atomic_flag_test_and_set_explicit(&l->flag, memory_order_acquire))
+        ;
+}
+
+static inline int spinlock_trylock(spinlock_t *l)
+{
+    return !atomic_flag_test_and_set_explicit(&l->flag, memory_order_acquire);
+}
+
+static inline void spinlock_unlock(spinlock_t *l)
+{
+    atomic_flag_clear_explicit(&l->flag, memory_order_release);
+}
+
+typedef struct spinlock_guard {
+    spinlock_t *lock;
+} spinlock_guard_t;
+
+static inline void spinlock_guard_release(spinlock_guard_t *g)
+{
+    if (g->lock)
+        spinlock_unlock(g->lock);
+}
+
+#define SCOPED_SPINLOCK(name, lockptr) \
+    spinlock_guard_t name __attribute__((cleanup(spinlock_guard_release))) = { .lock = (lockptr) }; \
+    spinlock_lock(name.lock)
+
+#endif /* SPINLOCK_H */

--- a/src-kernel/ipc.c
+++ b/src-kernel/ipc.c
@@ -1,24 +1,23 @@
 #include "ipc.h"
-#include <stdatomic.h>
+#include "spinlock.h"
 
 /* Shared queue used by kernel stubs and user-space servers */
 struct ipc_queue kern_ipc_queue;
 
 static void lock_queue(struct ipc_queue *q)
 {
-    while (atomic_flag_test_and_set_explicit(&q->lock, memory_order_acquire))
-        ;
+    spinlock_lock(&q->lock);
 }
 
 static void unlock_queue(struct ipc_queue *q)
 {
-    atomic_flag_clear_explicit(&q->lock, memory_order_release);
+    spinlock_unlock(&q->lock);
 }
 
 void ipc_queue_init(struct ipc_queue *q)
 {
     q->head = q->tail = 0;
-    atomic_flag_clear(&q->lock);
+    spinlock_init(&q->lock);
 }
 
 bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)

--- a/src-kernel/ipc.h
+++ b/src-kernel/ipc.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdatomic.h>
+#include "spinlock.h"
 
 #define IPC_QUEUE_SIZE 32
 
@@ -27,7 +28,7 @@ struct ipc_queue {
     struct ipc_message msgs[IPC_QUEUE_SIZE];
     volatile uint32_t head;
     volatile uint32_t tail;
-    atomic_flag lock;
+    spinlock_t lock;
 };
 
 /* Global queue instance defined in ipc.c */


### PR DESCRIPTION
## Summary
- implement a small spinlock primitive in `include/spinlock.h`
- switch IPC queue locking to use the new spinlock
- document the new header in `microkernel_functional_model.md`

## Testing
- `make clean` and `make all` in `src-kernel`