### PR TITLE
Add shared spinlock abstraction

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -82,7 +82,7 @@ for a corresponding reply from the user-space server.
 
 The queue implementation originally offered only non-blocking `ipc_queue_send()`
 and `ipc_queue_recv()` calls.  To simplify users of the API a lightweight
-spinlock now protects the ring buffer and two blocking helpers were added:
+`spinlock_t` from `spinlock.h` now protects the ring buffer and two blocking helpers were added:
 `ipc_queue_send_blocking()` and `ipc_queue_recv_blocking()`.  These functions
 busy-wait until the operation completes.  User-space wrappers `ipc_send()` and
 `ipc_recv()` invoke the blocking variants to guarantee delivery.

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -1,0 +1,26 @@
+#ifndef SPINLOCK_H
+#define SPINLOCK_H
+
+#include <stdatomic.h>
+
+typedef struct {
+    atomic_flag flag;
+} spinlock_t;
+
+static inline void spinlock_init(spinlock_t *lock)
+{
+    atomic_flag_clear(&lock->flag);
+}
+
+static inline void spinlock_lock(spinlock_t *lock)
+{
+    while (atomic_flag_test_and_set_explicit(&lock->flag, memory_order_acquire))
+        ;
+}
+
+static inline void spinlock_unlock(spinlock_t *lock)
+{
+    atomic_flag_clear_explicit(&lock->flag, memory_order_release);
+}
+
+#endif /* SPINLOCK_H */

--- a/src-kernel/ipc.c
+++ b/src-kernel/ipc.c
@@ -1,24 +1,23 @@
 #include "ipc.h"
-#include <stdatomic.h>
+#include "../include/spinlock.h"
 
 /* Shared queue used by kernel stubs and user-space servers */
 struct ipc_queue kern_ipc_queue;
 
 static void lock_queue(struct ipc_queue *q)
 {
-    while (atomic_flag_test_and_set_explicit(&q->lock, memory_order_acquire))
-        ;
+    spinlock_lock(&q->lock);
 }
 
 static void unlock_queue(struct ipc_queue *q)
 {
-    atomic_flag_clear_explicit(&q->lock, memory_order_release);
+    spinlock_unlock(&q->lock);
 }
 
 void ipc_queue_init(struct ipc_queue *q)
 {
     q->head = q->tail = 0;
-    atomic_flag_clear(&q->lock);
+    spinlock_init(&q->lock);
 }
 
 bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)

--- a/src-kernel/ipc.h
+++ b/src-kernel/ipc.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdatomic.h>
+#include "../include/spinlock.h"
 
 #define IPC_QUEUE_SIZE 32
 
@@ -27,7 +28,7 @@ struct ipc_queue {
     struct ipc_message msgs[IPC_QUEUE_SIZE];
     volatile uint32_t head;
     volatile uint32_t tail;
-    atomic_flag lock;
+    spinlock_t lock;
 };
 
 /* Global queue instance defined in ipc.c */

--- a/src-uland/libipc/ipc.c
+++ b/src-uland/libipc/ipc.c
@@ -1,24 +1,23 @@
 #include "ipc.h"
-#include <stdatomic.h>
+#include "../../include/spinlock.h"
 
 /* Shared queue used by kernel stubs and user-space servers */
 struct ipc_queue kern_ipc_queue;
 
 static void lock_queue(struct ipc_queue *q)
 {
-    while (atomic_flag_test_and_set_explicit(&q->lock, memory_order_acquire))
-        ;
+    spinlock_lock(&q->lock);
 }
 
 static void unlock_queue(struct ipc_queue *q)
 {
-    atomic_flag_clear_explicit(&q->lock, memory_order_release);
+    spinlock_unlock(&q->lock);
 }
 
 void ipc_queue_init(struct ipc_queue *q)
 {
     q->head = q->tail = 0;
-    atomic_flag_clear(&q->lock);
+    spinlock_init(&q->lock);
 }
 
 bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)


### PR DESCRIPTION
## Summary
- introduce `spinlock.h` with minimal spinlock API
- switch IPC queue implementation to use `spinlock_t`
- update microkernel docs mentioning the new header

## Testing
- `make -C src-kernel`
- `make -C tests`