### PR TITLE
Add README note about dependency graph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ For exokernel tasks see [docs/exokernel_plan.md](docs/exokernel_plan.md).
 
 ## Tools
 
-The `tools` directory contains helper scripts. `generate_dependency_graph.py` scans the source tree to build a DOT file of include dependencies and syscall implementations. Run `python3 tools/generate_dependency_graph.py` to produce `dependency_graph.dot` (use `--include-calls` to add a simple call graph).
+The `tools` directory contains helper scripts. `generate_dependency_graph.py` scans the source tree to build a DOT file of include dependencies and syscall implementations. Run `python3 tools/generate_dependency_graph.py` to produce `dependency_graph.dot` (use `--include-calls` to add a simple call graph). The `dependency_graph.dot` file tracked in this repository was generated using this command.
 `tools/generate_compiledb.sh` runs `compiledb` to create a `compile_commands.json` database for clang-tidy.
 

--- a/dependency_graph.dot
+++ b/dependency_graph.dot
@@ -1,3 +1,4 @@
+// Generated via python3 tools/generate_dependency_graph.py
 digraph G {
   "usr/src/bin/cat/cat.c" -> "usr/src/include/ctype.h";
   "usr/src/bin/cat/cat.c" -> "usr/src/include/err.h";


### PR DESCRIPTION
## Summary
- clarify that `dependency_graph.dot` is generated by running `python3 tools/generate_dependency_graph.py`
- add a comment at the top of `dependency_graph.dot` noting the generation script

## Testing
- `none`