### PR TITLE
Add yacc and lex rules for config

### DIFF
--- a/usr/src/usr.sbin/config/Makefile
+++ b/usr/src/usr.sbin/config/Makefile
@@ -4,7 +4,7 @@ CFLAGS += -I. -I$(CURDIR)
 SRCS = config.c main.c lang.c mkioconf.c mkmakefile.c mkglue.c mkheaders.c \
        mkswapconf.c
 LDADD = -ll
-CLEANFILES = y.tab.h lang.c config.c y.tab.c
+CLEANFILES = y.tab.h lang.c config.c y.tab.c lex.yy.c
 
 OBJS = $(SRCS:.c=.o)
 
@@ -12,6 +12,14 @@ all: $(PROG)
 
 $(PROG): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LDADD) -o $@
+
+config.c y.tab.h: config.y
+	$(YACC) -d $<
+	mv y.tab.c config.c
+
+lang.c: lang.l
+	$(LEX) $<
+	mv lex.yy.c lang.c
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
## Summary
- generate `config.c` and `y.tab.h` from `config.y`
- generate `lang.c` from `lang.l`
- clean all generated parser files

## Testing
- `bmake` *(fails: command not found)*
- `gmake` *(fails: `yacc` not found)*