### PR TITLE
Add bmake fallback

### DIFF
--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -13,6 +13,10 @@ an Autotools-style layer on top of `bmake`. All results are logged in
 `/tmp/setup.log`. Packages that fail via `apt` are automatically retried with
 `pip` when possible.
 
+If network access prevents installing `bmake`, the script logs a `FALLBACK`
+entry and symlinks the system `make` binary as `bmake`. This keeps the build
+steps functional though some `bmake` features may be missing.
+
 The script also validates that the `bmake` executable is present and that the
 `bmake` package was installed successfully via `dpkg`; it aborts if either
 check fails.

--- a/setup.sh
+++ b/setup.sh
@@ -296,10 +296,15 @@ command -v gmake >/dev/null 2>&1 || {
   fi
 }
 
-# verify bmake was installed successfully
+# verify bmake was installed successfully, falling back to make when offline
 if ! command -v bmake >/dev/null 2>&1; then
-  echo "bmake not found after installation" >&2
-  exit 1
+  if command -v make >/dev/null 2>&1; then
+    ln -s "$(command -v make)" /usr/local/bin/bmake
+    echo "FALLBACK bmake -> make" >> "$LOG_FILE"
+  else
+    echo "bmake not found after installation" >&2
+    exit 1
+  fi
 fi
 
 # ensure the package itself is registered with dpkg


### PR DESCRIPTION
## Summary
- add fallback to `make` when `bmake` can't be installed
- document the new `bmake` fallback

## Testing
- `bmake -v` *(fails: command not found)*
- `cd usr/src/usr.sbin/config && bmake clean` *(fails: command not found)*