### PR TITLE
Install bmake via aptitude

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install GCC and bmake
-        run: sudo apt-get update && sudo apt-get install -y build-essential gcc-multilib bmake
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gcc-multilib aptitude
+          sudo aptitude -y install bmake
       - name: Generate inventory
         run: bmake inventory
       - uses: actions/upload-artifact@v3
@@ -30,8 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install GCC
-        run: sudo apt-get update && sudo apt-get install -y build-essential gcc-multilib
+      - name: Install GCC and bmake
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gcc-multilib aptitude
+          sudo aptitude -y install bmake
       - name: Generate inventory
         run: bmake inventory
       - uses: actions/upload-artifact@v3
@@ -52,7 +58,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Clang and bmake
-        run: sudo apt-get update && sudo apt-get install -y clang bmake gcc-multilib
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang gcc-multilib aptitude
+          sudo aptitude -y install bmake
       - name: Generate inventory
         run: bmake inventory
       - uses: actions/upload-artifact@v3
@@ -73,7 +82,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Clang and bmake
-        run: sudo apt-get update && sudo apt-get install -y clang bmake gcc-multilib
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang gcc-multilib aptitude
+          sudo aptitude -y install bmake
       - name: Generate inventory
         run: bmake inventory
       - uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ The story: https://en.wikipedia.org/wiki/History_of_the_Berkeley_Software_Distri
 Downloaded from: ftp://alge.anart.no/pub/BSD/4.4BSD-Lite/4.4BSD-Lite2.tar.gz
 
 For kernel build instructions see [docs/building_kernel.md](docs/building_kernel.md).
-Run `setup.sh` first to install required tools. The script uses `apt-get install` to
-fetch **bmake** and its mk framework and can optionally install **mk-configure**
+Run `setup.sh` first to install required tools. The script installs `aptitude`
+and then uses it to fetch **bmake** and its mk framework. It can optionally
+install **mk-configure**
 to provide an Autotools-style build system layered on top.
 For GitHub CI examples see [docs/ci_workflows.md](docs/ci_workflows.md).
 For FHS migration steps see [docs/fhs_migration.md](docs/fhs_migration.md).

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -3,9 +3,9 @@
 This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `bmake`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
 
 Before building, run the repository's `setup.sh` script as root to install all
-required toolchains and utilities. The script first attempts to install
-**bison**, **byacc**, and **bmake** (which includes the full mk framework)
-using `apt-get`. If the package installation fails it falls back to `pip` and,
+required toolchains and utilities. The script first installs `aptitude` and
+then uses it to install **bison**, **byacc**, and **bmake** (which includes the
+full mk framework). If the package installation fails it falls back to `pip` and
 for **bmake**, will download the upstream source and build it locally.
 When built from source the script generates a small `.deb` so `dpkg` still
 records the package. Optionally **mk-configure** can be installed to provide


### PR DESCRIPTION
## Summary
- install bmake using aptitude in `setup.sh`
- document aptitude usage in README and build guide
- update CI workflow to install aptitude then bmake

## Testing
- `bmake clean` in `usr/src/usr.sbin/config` *(fails: bmake not found)*
- `bmake -C tests` *(fails: bmake not found)*