### PR TITLE
Document dependency graph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ For exokernel tasks see [docs/exokernel_plan.md](docs/exokernel_plan.md).
 
 ## Tools
 
-The `tools` directory contains helper scripts. `generate_dependency_graph.py` scans the source tree to build a DOT file of include dependencies and syscall implementations. Run `python3 tools/generate_dependency_graph.py` to produce `dependency_graph.dot` (use `--include-calls` to add a simple call graph). The `dependency_graph.dot` file tracked in this repository was generated using this command.
+The `tools` directory contains helper scripts. `generate_dependency_graph.py` scans the source tree to build a DOT file of include dependencies and syscall implementations. Run `python3 tools/generate_dependency_graph.py` to produce `dependency_graph.dot` (use `--include-calls` to add a simple call graph). The `dependency_graph.dot` file tracked in this repository was generated using this command and can be regenerated at any time with `python3 tools/generate_dependency_graph.py`.
 `tools/generate_compiledb.sh` runs `compiledb` to create a `compile_commands.json` database for clang-tidy.
 

--- a/dependency_graph.dot
+++ b/dependency_graph.dot
@@ -1,4 +1,4 @@
-// Generated via python3 tools/generate_dependency_graph.py
+// Generated via `python3 tools/generate_dependency_graph.py`; do not edit by hand.
 digraph G {
   "usr/src/bin/cat/cat.c" -> "usr/src/include/ctype.h";
   "usr/src/bin/cat/cat.c" -> "usr/src/include/err.h";


### PR DESCRIPTION
## Summary
- clarify in README that `dependency_graph.dot` is produced via `python3 tools/generate_dependency_graph.py`
- note in the graph file itself that it is auto-generated

## Testing
- `git status --short`