### PR TITLE
Update dependency graph script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For exokernel tasks see [docs/exokernel_plan.md](docs/exokernel_plan.md).
 
 ## Tools
 
-The `tools` directory contains helper scripts. `generate_dependency_graph.py` scans the source tree to build a DOT file of include dependencies and syscall implementations. Run `python3 tools/generate_dependency_graph.py` to produce `dependency_graph.dot` (use `--include-calls` to add a simple call graph). The `dependency_graph.dot` file tracked in this repository was generated using this command and can be regenerated at any time with `python3 tools/generate_dependency_graph.py`.
+The `tools` directory contains helper scripts. `generate_dependency_graph.py` scans the source tree to build a DOT file of include dependencies and syscall implementations. Run `python3 tools/generate_dependency_graph.py` to produce `dependency_graph.dot`. Use `--include-prefix` to add header search prefixes or `--ignore-unresolved-includes` to drop missing headers. Pass `--include-calls` to add a simple call graph. The `dependency_graph.dot` file tracked in this repository was generated using this command and can be regenerated at any time with `python3 tools/generate_dependency_graph.py`.
 All Python utilities require **Python 3**.
 `tools/generate_compiledb.sh` runs `compiledb` to create a `compile_commands.json` database for clang-tidy.
 

--- a/docs/modernization_plan.md
+++ b/docs/modernization_plan.md
@@ -10,6 +10,9 @@ For a summary of directory mappings during the reorganization see
 ## Phase 1: Codebase Analysis
 - Generate cross-reference databases using `cscope` and `ctags`.
 - Use `python3 tools/analyze_codebase.py` to count source files by extension.
+- Generate an include dependency graph with `python3 tools/generate_dependency_graph.py`.
+  Use `--include-prefix` for additional header locations and
+  `--ignore-unresolved-includes` to drop missing headers from the graph.
 - Document architectural assumptions found in headers and assembly files.
 
 ## Phase 2: Infrastructure Updates


### PR DESCRIPTION
## Summary
- dedupe edges before writing dependency_graph.dot
- add options for include path prefixes and ignoring unresolved includes
- document updated script options

## Testing
- `python3 -m py_compile tools/generate_dependency_graph.py`