### PR TITLE
Add exokernel image packaging helper

### DIFF
--- a/docs/exokernel_testing.md
+++ b/docs/exokernel_testing.md
@@ -7,11 +7,22 @@ This guide explains how to start the exokernel with only the essential user-leve
 - `qemu-system-i386` or another x86 emulator
 - The exokernel binary built under `src-kernel`
 - User-level managers (scheduler, memory manager, file server) built under `src-uland`
-- A bootable disk image containing the managers in `/bin` or `/usr/bin`
+- A bootable disk image containing the managers in `/bin` or `/usr/bin` (use
+  `tools/create_exokernel_image.sh` to generate it)
 - The `init` program built under `src-uland/init`
 
+### Creating the Disk Image
+Run the helper script after building the kernel and managers:
+
+```sh
+tools/create_exokernel_image.sh build/exo.img 64M
+```
+
+This produces `build/exo.img`, an ext2 image with the compiled programs in
+place. Pass this file to QEMU using `-hda`.
+
 ## Booting in QEMU
-1. Create a disk image with the managers installed and copy `init` to `/sbin/init`.
+1. Build a disk image using `tools/create_exokernel_image.sh`.
 2. Launch QEMU using the exokernel as the kernel image:
    ```sh
    qemu-system-i386 -kernel path/to/exokernel \

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -6,4 +6,5 @@ Examples:
 - `generate_cscope.sh` and `generate_ctags.sh` – index helpers.
 - `build_collect_warnings.sh` – build and capture warnings.
 - `generate_compiledb.sh` – produce a compile database for clang-tidy.
+- `create_exokernel_image.sh` – assemble a bootable disk image with managers.
 No automated tests are required to modify these scripts.

--- a/tools/create_exokernel_image.sh
+++ b/tools/create_exokernel_image.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Create a bootable disk image with the exokernel and user managers.
+# Usage: create_exokernel_image.sh [image-path] [size]
+# size defaults to 64M. Requires root privileges for mounting.
+
+set -e
+
+IMAGE=${1:-exokernel.img}
+SIZE=${2:-64M}
+
+KERNEL_BIN=${KERNEL_BIN:-src-kernel/exokernel}
+INIT_BIN=${INIT_BIN:-src-uland/init/init}
+FS_SERVER_BIN=${FS_SERVER_BIN:-src-uland/fs-server/fs_server}
+PROC_MGR_BIN=${PROC_MGR_BIN:-src-uland/servers/proc_manager/proc_manager}
+
+if [ ! -f "$KERNEL_BIN" ]; then
+    echo "Missing kernel binary: $KERNEL_BIN" >&2
+    exit 1
+fi
+for f in "$INIT_BIN" "$FS_SERVER_BIN" "$PROC_MGR_BIN"; do
+    [ -f "$f" ] || { echo "Missing user program: $f" >&2; exit 1; }
+done
+
+# Create empty image and format it
+dd if=/dev/zero of="$IMAGE" bs=1 count=0 seek=$SIZE
+mke2fs -q "$IMAGE"
+
+MNT=$(mktemp -d)
+mount -o loop "$IMAGE" "$MNT"
+
+mkdir -p "$MNT/boot" "$MNT/bin" "$MNT/sbin"
+cp "$KERNEL_BIN" "$MNT/boot/"
+cp "$INIT_BIN" "$MNT/sbin/init"
+cp "$FS_SERVER_BIN" "$MNT/bin/"
+cp "$PROC_MGR_BIN" "$MNT/bin/"
+
+sync
+umount "$MNT"
+rmdir "$MNT"
+
+echo "Created $IMAGE"


### PR DESCRIPTION
## Summary
- add `create_exokernel_image.sh` for building a bootable image
- document how to use the helper in `exokernel_testing.md`
- note the new script in `tools/AGENTS.md`

## Testing
- `git status --short`