### PR TITLE
Add reincarnation watchdog server

### DIFF
--- a/docs/microkernel_plan.md
+++ b/docs/microkernel_plan.md
@@ -108,3 +108,13 @@ When executed without `--dry-run`, the script relocates `sys/` into
 paths. Running it after the migration scripts ensures the microkernel build
 operates on the consolidated layout referenced throughout this plan.
 
+## Reincarnation Server
+
+A small watchdog service named `reincarnation` launches before the other user
+managers. Each server periodically sends an `IPC_MSG_HEARTBEAT` message with its
+PID to this monitor. The reincarnation server listens for these heartbeats via
+`libipc` and notes the last time each server responded. If a heartbeat is missed
+for several seconds a warning is printed and the service can be restarted. This
+component mirrors the MINIX3 approach and illustrates how managers can watch one
+another purely through IPC.
+

--- a/src-headers/ipc.h
+++ b/src-headers/ipc.h
@@ -14,7 +14,8 @@ enum ipc_msg_type {
     IPC_MSG_VM_FAULT,
     IPC_MSG_OPEN,
     IPC_MSG_PROC_FORK,
-    IPC_MSG_PROC_EXEC
+    IPC_MSG_PROC_EXEC,
+    IPC_MSG_HEARTBEAT
 };
 
 struct ipc_message {

--- a/src-uland/init/Makefile
+++ b/src-uland/init/Makefile
@@ -8,7 +8,12 @@ CSTD ?= -std=c2x
 CPPFLAGS ?= -I../../src-headers
 CFLAGS += $(CSTD)
 
-all: $(PROG)
+SUBDIRS = ../servers/reincarnation
+
+all: $(PROG) subdirs
+
+subdirs:
+	$(MAKE) -C $(SUBDIRS)
 
 $(PROG): $(OBJS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(OBJS) -o $@
@@ -18,5 +23,6 @@ $(PROG): $(OBJS)
 
 clean:
 	rm -f $(OBJS) $(PROG)
+	$(MAKE) -C $(SUBDIRS) clean
 
-.PHONY: all clean
+.PHONY: all clean subdirs

--- a/src-uland/init/init.c
+++ b/src-uland/init/init.c
@@ -1,8 +1,10 @@
 #include <unistd.h>
+#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 static const char *servers[] = {
+    "/usr/libexec/reincarnation",
     "/usr/libexec/proc_manager",
     "/usr/libexec/fs_server",
     NULL

--- a/src-uland/servers/reincarnation/Makefile
+++ b/src-uland/servers/reincarnation/Makefile
@@ -1,0 +1,22 @@
+SRCS = reincarnation.c
+OBJS = $(SRCS:.c=.o)
+PROG = reincarnation
+
+CC ?= cc
+CFLAGS ?= -O2
+CSTD ?= -std=c2x
+CPPFLAGS ?= -I../../../src-headers -I../../libipc
+CFLAGS += $(CSTD)
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(OBJS) ../../libipc/libipc.a -o $@
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(PROG)
+
+.PHONY: all clean

--- a/src-uland/servers/reincarnation/reincarnation.c
+++ b/src-uland/servers/reincarnation/reincarnation.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <time.h>
+#include "ipc.h"
+#include "../libipc/ipc.h"
+
+struct managed {
+    const char *path;
+    pid_t pid;
+    time_t last_beat;
+};
+
+static struct managed managed_servers[] = {
+    {"/usr/libexec/proc_manager", 0, 0},
+    {"/usr/libexec/fs_server", 0, 0},
+    {NULL, 0, 0}
+};
+
+static void spawn_servers(void)
+{
+    for (struct managed *m = managed_servers; m->path; ++m) {
+        pid_t pid = fork();
+        if (pid == -1) {
+            perror("fork");
+            continue;
+        }
+        if (pid == 0) {
+            execl(m->path, m->path, (char *)NULL);
+            perror("execl");
+            _exit(1);
+        }
+        m->pid = pid;
+        m->last_beat = time(NULL);
+    }
+}
+
+int main(void)
+{
+    spawn_servers();
+
+    struct ipc_message msg;
+    for (;;) {
+        if (ipc_recv(&msg) && msg.type == IPC_MSG_HEARTBEAT) {
+            for (struct managed *m = managed_servers; m->path; ++m) {
+                if (m->pid == (pid_t)msg.a)
+                    m->last_beat = time(NULL);
+            }
+        }
+
+        time_t now = time(NULL);
+        for (struct managed *m = managed_servers; m->path; ++m) {
+            if (m->pid > 0 && now - m->last_beat > 5) {
+                fprintf(stderr, "%s missed heartbeat\n", m->path);
+                m->last_beat = now;
+            }
+        }
+        usleep(500000);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a reincarnation server monitoring processes via IPC heartbeats
- wire up building the new server from the init makefile
- start the reincarnation server before other managers in `init.c`
- document the new server design in the microkernel plan
- extend IPC message types with `IPC_MSG_HEARTBEAT`

## Testing
- `make -C src-uland/libipc`
- `make -C src-uland/servers/reincarnation clean all`
- `make -C src-uland/init clean all`
