### PR TITLE
Add security mode API header

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -36,6 +36,9 @@ User-space components implement nearly all traditional BSD services:
 - The **scheduler library** and **VM library** in `src-uland/libkern_sched`
   and `src-uland/libvm` make policy decisions for scheduling and memory
   management.
+- Capability management uses `cap_set_security_mode(cap_endpoint, mode)` to
+  toggle security levels (`FAST`, `HARDENED` or `PARANOID`) for a running
+  service.
 - Additional drivers will appear under `src-uland/servers` as standalone
   tasks communicating with the kernel via the IPC layer.
 

--- a/include/security_mode.h
+++ b/include/security_mode.h
@@ -1,0 +1,16 @@
+#ifndef SECURITY_MODE_H
+#define SECURITY_MODE_H
+
+/* Security mode selection for capabilities. */
+
+/* Operational modes for capability endpoints. */
+enum security_mode {
+    SEC_MODE_FAST = 0,
+    SEC_MODE_HARDENED,
+    SEC_MODE_PARANOID
+};
+
+/* Set the operating mode of a capability endpoint. */
+void cap_set_security_mode(int cap_endpoint, enum security_mode mode);
+
+#endif /* SECURITY_MODE_H */


### PR DESCRIPTION
## Summary
- add `include/security_mode.h` with FAST/HARDENED/PARANOID modes
- document `cap_set_security_mode()` in the microkernel functional model

## Testing
- `bmake clean && bmake` *(fails: `bmake` not found)*