### PR TITLE
Add memory allocator documentation

### DIFF
--- a/docs/memory_allocator.md
+++ b/docs/memory_allocator.md
@@ -1,0 +1,16 @@
+# Kernel Memory Allocator
+
+This note describes the planned memory allocation mechanisms used by the microkernel and its servers.
+
+## Slab-style allocator with per-CPU caches
+
+Each CPU maintains its own slab cache holding small objects grouped by size class. Slabs are carved from contiguous pages and refilled from a global pool when exhausted. Metadata lives outside the slab pages so that cache lines remain focused on objects.
+
+## Physical page allocator for IOMMU mappings
+
+Drivers that require DMA-capable memory obtain pages from a dedicated physical allocator. It tracks contiguous page runs and provides alignment suitable for IOMMU mapping. The allocator integrates with the VM subsystem but bypasses higher-level caches.
+
+## Emergency reserves
+
+Critical paths such as interrupt handlers rely on a small reserve of preallocated pages. These reserves are replenished in the background so that allocation rarely fails even under memory pressure. Calls fall back to the emergency pool after the per-CPU and global caches are drained.
+

--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -15,6 +15,8 @@ system safely.  These include:
   then performs context switches on request.
 - **Virtual memory hooks** – page faults call `kern_vm_fault()` which forwards
   to a user-space memory manager for allocation and paging decisions.
+- **Kernel memory allocator** – see [memory_allocator.md](memory_allocator.md)
+  for the slab-style design with per-CPU caches.
 - **System call gate** – simple wrappers like `kern_open()` pass file
   operations to the file server running in user space.
 - **IPC primitives** – the kernel exposes message queues for servers and


### PR DESCRIPTION
## Summary
- document kernel memory allocator design
- crosslink new doc from microkernel functional model

## Testing
- `pre-commit` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*