### PR TITLE
Add subdir build steps to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
-.PHONY: inventory
+.PHONY: all inventory
+
+SUBDIRS = \
+    src-lib/libipc \
+    src-kernel \
+    src-uland/libkern_sched \
+    src-uland/libvm \
+    src-uland/fs-server \
+    src-uland/servers/proc_manager \
+    src-uland/init \
+    tests
+
+all:
+	@for dir in $(SUBDIRS); do \
+	$(MAKE) -C $$dir CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)"; \
+	done
 
 inventory:
 	python3 tools/create_inventory.py


### PR DESCRIPTION
## Summary
- invoke library and server builds from root `Makefile`
- propagate `CFLAGS` and `CPPFLAGS` to all submakes

## Testing
- `make all` *(fails: missing headers)*
- ❌ `pre-commit` *(command not found)*