### PR TITLE
Update FHS docs with hybrid layout plan

### DIFF
--- a/docs/fhs_migration.md
+++ b/docs/fhs_migration.md
@@ -4,7 +4,10 @@
 This repository preserves the historic 4.4BSD tree which places `bin`, `sbin` and
 other directories at the root of the filesystem. The `tools/migrate_to_fhs.sh`
 script converts the layout to a more modern FHS style by copying these
-directories under `/usr` and creating the appropriate symlinks.
+directories under `/usr` and creating the appropriate symlinks. The result is a
+*hybrid* layout that keeps the legacy paths available while moving active
+development under `/usr/src`; see [hybrid_plan.md](hybrid_plan.md) for a short
+overview.
 
 The script is idempotent and may be rerun to update files as needed. By default
 it only executes when run inside a chroot to avoid modifying a live system.
@@ -81,7 +84,17 @@ when modernizing historic BSD trees.
 10. Keep a log of each mapping for future developers.
 
 Following these steps alongside the broader plan in `reorg_plan.md` helps turn
-the BSD distribution into a structure that is familiar to modern systems.
+the BSD distribution into a structure that is familiar to modern systems. The
+next stage of the [hybrid plan](hybrid_plan.md) continues reorganizing sources
+under `/usr/src`.
+
+## Preferred Source Layout Script
+
+After running `migrate_to_fhs.sh`, the recommended tool for relocating sources
+is `tools/migrate_to_src_layout.sh`. This script supersedes the older
+`tools/organize_sources.sh` helper and gathers the kernel, user programs and
+libraries into the `src-*` directories. Run it soon after the FHS migration to
+complete the hybrid layout.
 ## Remaining Manual Symlinks
 Some directories are not handled by `migrate_to_fhs.sh` and must be linked manually.
 After running `tools/migrate_to_src_layout.sh` the kernel sources live in `src-kernel`.

--- a/docs/hybrid_plan.md
+++ b/docs/hybrid_plan.md
@@ -1,0 +1,27 @@
+# Hybrid FHS/Legacy Layout Plan
+
+This short note explains the "hybrid" source tree model used after the initial
+[FHS migration](fhs_migration.md). The goal is to keep compatibility with
+historic paths while still adopting a more conventional `/usr/src` layout.
+
+## Motivation
+
+Some build scripts expect the traditional BSD hierarchy with `bin`, `sbin` and
+other directories at the root. Others work best when headers and sources live
+under `/usr/src` in an FHS-style structure. The hybrid model preserves the root
+symlinks created by `migrate_to_fhs.sh` but moves active development into the
+`src-*` directories.
+
+## Workflow
+
+1. Run `tools/migrate_to_fhs.sh` inside a chroot (use `--force` otherwise) to
+   populate `/usr` and create compatibility symlinks.
+2. Immediately follow with `tools/migrate_to_src_layout.sh` to relocate the
+   kernel, userland and libraries under `src-kernel`, `src-uland` and `src-lib`.
+   This script supersedes the older `tools/organize_sources.sh` helper.
+3. Update build scripts as described in [reorg_plan.md](reorg_plan.md) so that
+   new code references the `src-*` paths while legacy targets continue to work
+   via symlinks.
+
+With this approach the repository works as a bridge between the historical
+layout and a modern source tree.

--- a/docs/reorg_plan.md
+++ b/docs/reorg_plan.md
@@ -26,3 +26,7 @@ This document outlines tasks for flattening the 4.4BSD-Lite2 source tree and mod
    the tree.  These scripts create `src-lib/.gitkeep` automatically so the
    directory remains in version control even when empty.
 
+The combination of `migrate_to_fhs.sh` and `migrate_to_src_layout.sh` forms the
+basis of the [hybrid plan](hybrid_plan.md) which retains historical paths while
+organizing active development under `/usr/src`.
+


### PR DESCRIPTION
## Summary
- document the hybrid FHS/legacy model
- prefer `migrate_to_src_layout.sh` after the FHS move
- mention the hybrid plan in the reorg guide

## Testing
- `pre-commit` *(fails: command not found)*