### PR TITLE
Fix network driver null check

### DIFF
--- a/docs/modernization_plan.md
+++ b/docs/modernization_plan.md
@@ -50,3 +50,6 @@ For a summary of directory mappings during the reorganization see
 
 When the overall source lines of code (SLOC) exceed budget, modules can be pruned to keep the project manageable. Experimental drivers that are not required for the main target hardware and userland servers that have no active use should be removed first. A module qualifies for pruning when it lacks test coverage, has no known downstream consumers, or duplicates functionality already provided elsewhere in the tree. This trimming keeps the codebase under the SLOC limit while focusing modernization efforts on well-supported components.
 
+### Tool failures
+- pre-commit: command not found when running pre-commit hooks.
+

--- a/usr/src/sys/i386/isa/if_we.c
+++ b/usr/src/sys/i386/isa/if_we.c
@@ -159,9 +159,13 @@ weprobe(is)
 	sc->we_vmem_addr = (caddr_t)is->id_maddr;
 	sc->we_vmem_size = is->id_msize;
 	sc->we_vmem_ring = sc->we_vmem_addr + (WD_PAGE_SIZE * WD_TXBUF_SIZE);
-	sc->we_vmem_end = sc->we_vmem_addr + is->id_msize;
+        sc->we_vmem_end = sc->we_vmem_addr + is->id_msize;
+        if (sc->we_vmem_addr == 0 || sc->we_vmem_size == 0) {
+            printf("we%d: no shared memory configured\n", is->id_unit);
+            return (0);
+        }
 
-	/*
+        /*
 	 * Save board ROM station address
 	 */
 	for (i = 0; i < ETHER_ADDR_LEN; ++i)


### PR DESCRIPTION
## Summary
- add missing null pointer check for network driver memory region
- document tool failure for pre-commit

## Testing
- `clang-format -lines=162:167 -i usr/src/sys/i386/isa/if_we.c`
- `pre-commit run --files sys/i386/isa/if_we.c` *(fails: command not found)*