### PR TITLE
Introduce exokernel stubs

### DIFF
--- a/usr/src/sys/conf/files
+++ b/usr/src/sys/conf/files
@@ -272,3 +272,4 @@ vm/vm_swap.c		standard
 vm/vm_unix.c		standard
 vm/vm_user.c		standard
 vm/vnode_pager.c	optional vnodepager
+../src-kernel/libkern_stubs.a	standard

--- a/usr/src/sys/kern/init_main.c
+++ b/usr/src/sys/kern/init_main.c
@@ -64,6 +64,7 @@
 #include <machine/cpu.h>
 
 #include <vm/vm.h>
+#include "exokernel.h"
 
 #ifdef HPFPLIB
 char	copyright[] =
@@ -294,9 +295,10 @@ main(framep)
 		/* NOTREACHED */
 	}
 
-	/* The scheduler is an infinite loop. */
-	scheduler();
-	/* NOTREACHED */
+       /* Initialize the scheduler hooks then enter the main loop. */
+       kern_sched_init();
+       scheduler();
+       /* NOTREACHED */
 }
 
 /*

--- a/usr/src/sys/kern/init_sysent.c
+++ b/usr/src/sys/kern/init_sysent.c
@@ -10,13 +10,13 @@
 #include <sys/signal.h>
 #include <sys/mount.h>
 #include <sys/syscallargs.h>
+#include "exokernel.h"
 int	nosys();
 int	exit();
-int	fork();
+int     kern_fork();
 int	read();
 int	write();
-int	open();
-int	close();
+int     kern_open();
 int	wait4();
 int	link();
 int	unlink();
@@ -67,7 +67,7 @@ int	reboot();
 int	revoke();
 int	symlink();
 int	readlink();
-int	execve();
+int  kern_exec();
 int	umask();
 int	chroot();
 int	msync();
@@ -251,13 +251,13 @@ struct sysent sysent[] = {
 	{ 1, s(struct exit_args),
 	    exit },				/* 1 = exit */
 	{ 0, 0,
-	    fork },				/* 2 = fork */
+	    kern_fork },				/* 2 = fork */
 	{ 3, s(struct read_args),
 	    read },				/* 3 = read */
 	{ 3, s(struct write_args),
 	    write },				/* 4 = write */
 	{ 3, s(struct open_args),
-	    open },				/* 5 = open */
+	    kern_open },				/* 5 = open */
 	{ 1, s(struct close_args),
 	    close },				/* 6 = close */
 	{ 4, s(struct wait4_args),
@@ -370,7 +370,7 @@ struct sysent sysent[] = {
 	{ 3, s(struct readlink_args),
 	    readlink },				/* 58 = readlink */
 	{ 3, s(struct execve_args),
-	    execve },				/* 59 = execve */
+	    kern_exec },				/* 59 = execve */
 	{ 1, s(struct umask_args),
 	    umask },				/* 60 = umask */
 	{ 1, s(struct chroot_args),
@@ -384,7 +384,7 @@ struct sysent sysent[] = {
 	{ 2, s(struct msync_args),
 	    msync },				/* 65 = msync */
 	{ 0, 0,
-	    vfork },				/* 66 = vfork */
+	    kern_fork },				/* 66 = vfork */
 	{ 0, 0,
 	    nosys },				/* 67 = obsolete vread */
 	{ 0, 0,

--- a/usr/src/sys/kern/kern_fork.c
+++ b/usr/src/sys/kern/kern_fork.c
@@ -45,6 +45,7 @@
 #include <sys/kernel.h>
 #include <sys/malloc.h>
 #include <sys/proc.h>
+#include "exokernel.h"
 #include <sys/resourcevar.h>
 #include <sys/vnode.h>
 #include <sys/file.h>
@@ -57,8 +58,7 @@ fork(p, uap, retval)
 	void *uap;
 	register_t *retval;
 {
-
-	return (fork1(p, 0, retval));
+        return kern_fork();
 }
 
 /* ARGSUSED */
@@ -67,8 +67,7 @@ vfork(p, uap, retval)
 	void *uap;
 	register_t *retval;
 {
-
-	return (fork1(p, 1, retval));
+        return kern_fork();
 }
 
 int	nprocs = 1;		/* process 0 */

--- a/usr/src/sys/vm/vm_fault.c
+++ b/usr/src/sys/vm/vm_fault.c
@@ -72,6 +72,7 @@
 #include <vm/vm.h>
 #include <vm/vm_page.h>
 #include <vm/vm_pageout.h>
+#include "exokernel.h"
 
 /*
  *	vm_fault:
@@ -98,6 +99,8 @@ vm_fault(map, vaddr, fault_type, change_wiring)
 	vm_prot_t	fault_type;
 	boolean_t	change_wiring;
 {
+        if (kern_vm_fault((void *)vaddr))
+                return KERN_SUCCESS;
 	vm_object_t		first_object;
 	vm_offset_t		first_offset;
 	vm_map_entry_t		entry;


### PR DESCRIPTION
## Summary
- include exokernel headers in kernel sources
- initialize scheduler hooks on boot
- route fork/open/exec calls through `kern_*` wrappers
- forward VM faults via `kern_vm_fault`
- link `libkern_stubs.a` when building the kernel

## Testing
- `pre-commit` *(fails: command not found)*
- `./setup.sh` *(fails: APT failures)*