### PR TITLE
Add root Makefile test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all inventory
+.PHONY: all inventory test
 
 SUBDIRS = \
     src-lib/libipc \
@@ -17,3 +17,6 @@ all:
 
 inventory:
 	python3 tools/create_inventory.py
+
+test:
+	$(MAKE) -C tests

--- a/docs/ci_workflows.md
+++ b/docs/ci_workflows.md
@@ -147,7 +147,7 @@ test-kern:
     - name: Build test binary
       run: |
         bmake -C src-kernel CC=gcc
-        bmake -C tests CC=gcc
+        bmake test CC=gcc
     - name: Run test_kern
       run: ./tests/test_kern > test_kern.log
     - uses: actions/upload-artifact@v3

--- a/docs/exokernel_testing.md
+++ b/docs/exokernel_testing.md
@@ -59,8 +59,8 @@ full system. Build and run it after compiling `libkern_stubs.a`:
 
 ```sh
 cd src-kernel && bmake
-cd ../tests && bmake clean all
-./test_kern
+bmake test
+./tests/test_kern
 ```
 
 Successful output prints `all ok` and verifies that:


### PR DESCRIPTION
## Summary
- add `test` phony target to Makefile
- update CI workflow example
- mention new target in exokernel testing guide

## Testing
- `make test` *(fails: undefined reference to `kern_ipc_queue`)*