### PR TITLE
Fix lint workflow deps

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -29,7 +29,8 @@ jobs:
     - name: Install linter runtime deps
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y shellcheck
+        sudo apt-get install -y shellcheck golangci-lint
+        sudo pip3 install black ruff
     - name: Run ${{ matrix.linter.id }} & feed Reviewdog
       uses: reviewdog/reviewdog@v0.20.3
       with:


### PR DESCRIPTION
## Summary
- install all linters for reviewdog

## Testing
- `timeout 5s ./setup.sh >/tmp/setup.log 2>&1; rc=$?; echo RC:$rc; tail -n 20 /tmp/setup.log 2>/dev/null`
- `cd usr/src/usr.sbin/config && bmake clean && bmake; echo RC:$?` *(fails: `bmake` not found)*