### PR TITLE
Add cross arch notes and language port stubs

### DIFF
--- a/SOURCE_TREE_OVERVIEW.md
+++ b/SOURCE_TREE_OVERVIEW.md
@@ -12,6 +12,7 @@ This repository contains the 4.4BSD-Lite2 sources as released by the University 
 - `etc/`, `dev/`, `root/` – system configuration, device files and root account files
 - `usr/` – userland programs and manual pages
 - `var/` – runtime data
+- `ports/` – experimental language ports (Chicken Scheme, Go)
 - `Domestic/` and `Foreign/` – cryptographic software separated due to export regulations of the time
 
 ## Using this source tree

--- a/docs/cross_architecture_porting.md
+++ b/docs/cross_architecture_porting.md
@@ -1,0 +1,25 @@
+# Cross-Architecture Porting Notes
+
+This guide summarizes considerations for targeting 16‑bit, 32‑bit and
+64‑bit x86 processors using the C23 standard.  The aim is to keep the
+codebase portable across Intel and AMD chips while still allowing
+platform specific optimisation.
+
+## Strategy
+
+- Introduce `<src-headers/arch.h>` which exposes `ARCH_BITS` and helper
+  macros derived from `__SIZEOF_POINTER__`.
+- Build common sources with `-std=c2x` and rely on the new header for
+  pointer-width checks.
+- Place generic assembly routines under `asm/` with per‑architecture
+  variants in `asm/i16/`, `asm/i386/` and `asm/amd64/`. The build system
+  selects the best match based on `ARCH_BITS`.
+- Prefer compiler intrinsics over handwritten assembly except where
+  specific tuning is required.
+
+## Next Steps
+
+1. Audit existing `.s` files and move them into the `asm/` hierarchy.
+2. Update makefiles so `ARCH_BITS` chooses the correct variant.
+3. Verify builds on 32‑bit and 64‑bit hosts, then attempt a 16‑bit
+   cross compile.

--- a/docs/refactor_c23_tasks.md
+++ b/docs/refactor_c23_tasks.md
@@ -114,3 +114,6 @@ Periodic reconciliation walks the CPUs and advances any stale epoch
 counters.  This keeps the per-CPU epochs bounded so old generations do
 not linger indefinitely.
 
+- Created `src-headers/arch.h` with C23 macros to detect 16-, 32- and 64-bit
+  architectures.
+- Added a new `ports/` tree containing initial Chicken Scheme and Go stubs.

--- a/ports/README.md
+++ b/ports/README.md
@@ -1,0 +1,7 @@
+# Language Ports
+
+Experimental ports of selected utilities and libraries to other languages.
+Each subdirectory contains a separate build.
+
+- `chicken/` – utilities written in or callable from Chicken Scheme.
+- `go/` – Go implementations of core tools.

--- a/ports/chicken/README.md
+++ b/ports/chicken/README.md
@@ -1,0 +1,6 @@
+# Chicken Scheme Port
+
+This directory collects experiments porting userland functionality to the
+Chicken Scheme environment. The goal is to prototype services in Scheme
+while reusing C23 libraries via FFI. The code is intentionally minimal
+for now.

--- a/ports/chicken/hello.scm
+++ b/ports/chicken/hello.scm
@@ -1,0 +1,3 @@
+;; Example stub used during porting
+(display "hello from chicken")
+(newline)

--- a/ports/go/README.md
+++ b/ports/go/README.md
@@ -1,0 +1,5 @@
+# Go Port
+
+Initial placeholder for Go-based utilities. Go offers a static toolchain
+suitable for cross-platform builds. The port will mirror existing
+userland functionality and call into C23 libraries via cgo when needed.

--- a/ports/go/hello.go
+++ b/ports/go/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello from go")
+}

--- a/src-headers/arch.h
+++ b/src-headers/arch.h
@@ -1,0 +1,43 @@
+#ifndef ARCH_H
+#define ARCH_H
+
+/*
+ * Modern architecture detection helpers for 16, 32 and 64-bit x86
+ * systems. These macros rely on standard C23 features and allow the
+ * codebase to adapt to Intel and AMD processors.
+ */
+
+#include <stdint.h>
+
+#if defined(__SIZEOF_POINTER__)
+#  if __SIZEOF_POINTER__ == 2
+#    define ARCH_16BIT 1
+#  elif __SIZEOF_POINTER__ == 4
+#    define ARCH_32BIT 1
+#  elif __SIZEOF_POINTER__ == 8
+#    define ARCH_64BIT 1
+#  else
+#    error "Unsupported pointer width"
+#  endif
+#else
+#  error "__SIZEOF_POINTER__ not defined"
+#endif
+
+#if defined(ARCH_64BIT)
+#  define ARCH_BITS 64
+#elif defined(ARCH_32BIT)
+#  define ARCH_BITS 32
+#else
+#  define ARCH_BITS 16
+#endif
+
+#if __STDC_VERSION__ >= 202000L
+#  define ARCH_UNREACHABLE() __builtin_unreachable()
+#else
+#  define ARCH_UNREACHABLE() ((void)0)
+#endif
+
+_Static_assert(ARCH_BITS == 16 || ARCH_BITS == 32 || ARCH_BITS == 64,
+               "Unsupported architecture size");
+
+#endif /* ARCH_H */


### PR DESCRIPTION
## Summary
- document plan for 16-, 32- and 64-bit C23 builds
- add architecture helper header `arch.h`
- track progress in C23 refactor roadmap
- start `ports/` tree with Chicken Scheme and Go examples
- mention ports directory in tree overview

## Testing
- `make -C src-kernel`