### PR TITLE
Add C++ spinlock wrapper

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -99,3 +99,11 @@ busy-wait until the operation completes.  User-space wrappers `ipc_send()` and
 The spinlock header now exposes `SPINLOCK_DEFINE()` and
 `spin_pause()` helpers to simplify definition and reduce CPU usage
 during contention.
+
+## C++23 interface
+
+`src-headers/spinlock.hpp` offers a thin RAII wrapper around the
+spinlock primitives.  It defines `SpinLock` and `LockGuard` classes
+and a `with_lock()` helper that accepts a lambda expression.  This
+lets modern C++ code share the same synchronization mechanism used by
+the C stubs.

--- a/src-headers/spinlock.hpp
+++ b/src-headers/spinlock.hpp
@@ -1,0 +1,35 @@
+#ifndef SPINLOCK_HPP
+#define SPINLOCK_HPP
+
+#include "spinlock.h"
+#include <utility>
+
+class SpinLock {
+public:
+    constexpr SpinLock() : lock_(SPINLOCK_INITIALIZER) {}
+    void lock() noexcept { spinlock_lock(&lock_); }
+    bool try_lock() noexcept { return spinlock_trylock(&lock_); }
+    void unlock() noexcept { spinlock_unlock(&lock_); }
+    spinlock_t* native_handle() noexcept { return &lock_; }
+private:
+    spinlock_t lock_;
+};
+
+class LockGuard {
+public:
+    explicit LockGuard(SpinLock& l) : lock_(l) { lock_.lock(); }
+    ~LockGuard() { lock_.unlock(); }
+    LockGuard(const LockGuard&) = delete;
+    LockGuard& operator=(const LockGuard&) = delete;
+private:
+    SpinLock& lock_;
+};
+
+template<typename Func>
+inline auto with_lock(SpinLock& l, Func&& f) -> decltype(f())
+{
+    LockGuard g(l);
+    return std::forward<Func>(f)();
+}
+
+#endif // SPINLOCK_HPP

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,14 +1,19 @@
 CC ?= cc
 CFLAGS ?= -O2 -std=c2x
+CXX ?= c++
+CXXFLAGS ?= -O2 -std=c++23
 CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel
-LIBS = ../src-kernel/libkern_stubs.a
+LIBS = ../src-kernel/libkern_stubs.a ../src-lib/libipc/libipc.a
 
 OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o sched_stub.o mock_vm.o
 
-all: test_kern
+all: test_kern spinlock_cpp
 
 test_kern: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LIBS) -o $@
+
+spinlock_cpp: test_spinlock.o
+	$(CXX) $(CXXFLAGS) test_spinlock.o -o $@
 
 fs_open.o: ../src-uland/fs-server/fs_open.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
@@ -25,7 +30,10 @@ mock_vm.o: mock_vm.c
 sched_stub.o: sched_stub.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
+test_spinlock.o: test_spinlock.cpp
+	$(CXX) $(CXXFLAGS) -I../src-headers -c $< -o $@
+
 clean:
-	 rm -f $(OBJS) test_kern
+	rm -f $(OBJS) test_kern spinlock_cpp test_spinlock.o
 
 .PHONY: all clean

--- a/tests/test_spinlock.cpp
+++ b/tests/test_spinlock.cpp
@@ -1,0 +1,28 @@
+#include "spinlock.hpp"
+#include <thread>
+#include <vector>
+#include <iostream>
+
+SpinLock g_lock;
+int counter = 0;
+
+void worker()
+{
+    for(int i=0;i<1000;i++)
+        with_lock(g_lock, []{ ++counter; });
+}
+
+int main()
+{
+    std::vector<std::thread> threads;
+    for(int i=0;i<4;i++)
+        threads.emplace_back(worker);
+    for(auto& t : threads)
+        t.join();
+    if(counter != 4000) {
+        std::cout << "spinlock failed\n";
+        return 1;
+    }
+    std::cout << "spinlock ok\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- provide C++ RAII wrapper for spinlocks
- add test exercising the wrapper with threads
- update microkernel docs about the C++ interface
- link libipc when building tests

## Testing
- `make -C src-kernel`
- `make -C tests`
- `./tests/spinlock_cpp`
- `./tests/test_kern` *(fails: child failed)*