### PR TITLE
Fix kernel stub reply handling and tests

### DIFF
--- a/src-kernel/proc_hooks.c
+++ b/src-kernel/proc_hooks.c
@@ -12,8 +12,10 @@ kern_fork(void)
     struct ipc_message msg = { .type = IPC_MSG_PROC_FORK };
     ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
-    if (ipc_queue_recv(&kern_ipc_queue, &reply))
-        return (int)reply.a;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply)) {
+        if (reply.type != IPC_MSG_PROC_FORK)
+            return (int)reply.a;
+    }
     return pm_fork();
 }
 

--- a/src-kernel/vfs_hooks.c
+++ b/src-kernel/vfs_hooks.c
@@ -13,7 +13,9 @@ kern_open(const char *path, int flags)
     };
     ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
-    if (ipc_queue_recv(&kern_ipc_queue, &reply))
-        return (int)reply.a;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply)) {
+        if (reply.type != IPC_MSG_OPEN)
+            return (int)reply.a;
+    }
     return fs_open(path, flags);
 }

--- a/src-kernel/vm_hooks.c
+++ b/src-kernel/vm_hooks.c
@@ -11,7 +11,9 @@ kern_vm_fault(void *addr)
     ipc_queue_send(&kern_ipc_queue, &msg);
     /* Synchronous reply */
     struct ipc_message reply;
-    if (ipc_queue_recv(&kern_ipc_queue, &reply))
-        return reply.a != 0;
+    if (ipc_queue_recv(&kern_ipc_queue, &reply)) {
+        if (reply.type != IPC_MSG_VM_FAULT)
+            return reply.a != 0;
+    }
     return uland_vm_fault(addr);
 }

--- a/tests/test_kern.c
+++ b/tests/test_kern.c
@@ -35,7 +35,7 @@ int main(void) {
     } else {
         int status; waitpid(pid, &status, 0);
         if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-            fprintf(stderr, "child failed\n");
+            fprintf(stderr, "child failed: pid=%d status=%d\n", pid, status);
             return 1;
         }
     }

--- a/tests/test_spinlock.cpp
+++ b/tests/test_spinlock.cpp
@@ -1,6 +1,6 @@
 #include "spinlock.hpp"
+#include <array>
 #include <thread>
-#include <vector>
 #include <iostream>
 
 SpinLock g_lock;
@@ -8,18 +8,18 @@ int counter = 0;
 
 void worker()
 {
-    for(int i=0;i<1000;i++)
-        with_lock(g_lock, []{ ++counter; });
+    for (int i = 0; i < 1000; ++i)
+        with_lock(g_lock, [] { ++counter; });
 }
 
 int main()
 {
-    std::vector<std::thread> threads;
-    for(int i=0;i<4;i++)
-        threads.emplace_back(worker);
-    for(auto& t : threads)
-        t.join();
-    if(counter != 4000) {
+    {
+        std::array<std::jthread, 4> threads;
+        for (auto& t : threads)
+            t = std::jthread(worker);
+    } // threads join here
+    if (counter != 4000) {
         std::cout << "spinlock failed\n";
         return 1;
     }


### PR DESCRIPTION
## Summary
- treat IPC messages from the same process as no-op
- fall back to user helpers when no reply arrives
- improve child failure message in `test_kern`

## Testing
- `make -C src-kernel`
- `make -C tests`
- `./tests/test_kern`
- `./tests/spinlock_cpp`
