### PR TITLE
Modernize types and header guards

### DIFF
--- a/src-headers/arch.h
+++ b/src-headers/arch.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef ARCH_H
 #define ARCH_H
 

--- a/src-headers/compat/svr4/svr4_machdep.h
+++ b/src-headers/compat/svr4/svr4_machdep.h
@@ -1,3 +1,4 @@
+#pragma once
 /*$NetBSD: svr4_machdep.h,v 1.16 2008/04/28 20:23:24 martin Exp $*/
 
 /*-

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef EXOKERNEL_H
 #define EXOKERNEL_H
 

--- a/src-headers/fs_server.h
+++ b/src-headers/fs_server.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef FS_SERVER_H
 #define FS_SERVER_H
 

--- a/src-headers/ipc.h
+++ b/src-headers/ipc.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef IPC_H
 #define IPC_H
 

--- a/src-headers/kern_sched.h
+++ b/src-headers/kern_sched.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef KERN_SCHED_H
 #define KERN_SCHED_H
 

--- a/src-headers/libipc.h
+++ b/src-headers/libipc.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef LIBIPC_H
 #define LIBIPC_H
 

--- a/src-headers/libvm.h
+++ b/src-headers/libvm.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef LIBVM_H
 #define LIBVM_H
 

--- a/src-headers/machine/ansi.h
+++ b/src-headers/machine/ansi.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/cpu.h
+++ b/src-headers/machine/cpu.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/endian.h
+++ b/src-headers/machine/endian.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1987, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/frame.h
+++ b/src-headers/machine/frame.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/limits.h
+++ b/src-headers/machine/limits.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/param.h
+++ b/src-headers/machine/param.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/proc.h
+++ b/src-headers/machine/proc.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/signal.h
+++ b/src-headers/machine/signal.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1986, 1989, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/trap.h
+++ b/src-headers/machine/trap.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-headers/machine/types.h
+++ b/src-headers/machine/types.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -35,6 +36,7 @@
 
 #ifndef	_MACHTYPES_H_
 #define	_MACHTYPES_H_
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -46,21 +48,9 @@ typedef struct label_t {
 } label_t;
 #endif
 
-typedef	unsigned long	vm_offset_t;
-typedef	unsigned long	vm_size_t;
+typedef uintptr_t       vm_offset_t;
+typedef uintptr_t       vm_size_t;
 
-/*
- * Basic integral types.  Omit the typedef if
- * not possible for a machine/compiler combination.
- */
-typedef	__signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 typedef long register_t; /* minimal register type for user servers */
 
 #endif	/* _MACHTYPES_H_ */

--- a/src-headers/proc_manager.h
+++ b/src-headers/proc_manager.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef PROC_MANAGER_H
 #define PROC_MANAGER_H
 

--- a/src-headers/spinlock.h
+++ b/src-headers/spinlock.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef SPINLOCK_H
 #define SPINLOCK_H
 

--- a/src-headers/spinlock.hpp
+++ b/src-headers/spinlock.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef SPINLOCK_HPP
 #define SPINLOCK_HPP
 

--- a/src-headers/sys/systm.h
+++ b/src-headers/sys/systm.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1988, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -40,6 +41,8 @@
 
 #ifndef _SYS_SYSTM_H_
 #define _SYS_SYSTM_H_
+
+#include <stdnoreturn.h>
 
 /*
  * The `securelevel' variable controls the security level of the system.
@@ -121,11 +124,7 @@ int	seltrue __P((dev_t dev, int which, struct proc *p));
 void	*hashinit __P((int count, int type, u_long *hashmask));
 int	nosys __P((struct proc *, void *, register_t *));
 
-#ifdef __GNUC__
-volatile void	panic __P((const char *, ...));
-#else
-void	panic __P((const char *, ...));
-#endif
+_Noreturn void   panic __P((const char *, ...));
 void	tablefull __P((const char *));
 void	addlog __P((const char *, ...));
 void	log __P((int, const char *, ...));

--- a/src-headers/sys/vnode_if.h
+++ b/src-headers/sys/vnode_if.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef _SRC_HEADERS_VNODE_IF_H_
 #define _SRC_HEADERS_VNODE_IF_H_
 /*

--- a/src-lib/libvm/vm_map.c
+++ b/src-lib/libvm/vm_map.c
@@ -1872,7 +1872,7 @@ vm_map_copy(dst_map, src_map,
 	if (src_map == dst_map) {
 		vm_map_lock(src_map);
 	}
-	else if ((long) src_map < (long) dst_map) {
+	else if ((uintptr_t)src_map < (uintptr_t)dst_map) {
 	 	vm_map_lock(src_map);
 		vm_map_lock(dst_map);
 	} else {

--- a/src-lib/libvm/vm_object.c
+++ b/src-lib/libvm/vm_object.c
@@ -873,7 +873,7 @@ vm_object_setpager(object, pager, paging_offset,
  */
 
 #define vm_object_hash(pager) \
-	(((unsigned long)pager)%VM_OBJECT_HASH_COUNT)
+        (((uintptr_t)(pager)) % VM_OBJECT_HASH_COUNT)
 
 /*
  *	vm_object_lookup looks in the object cache for an object with the

--- a/src-lib/libvm/vm_page.c
+++ b/src-lib/libvm/vm_page.c
@@ -293,7 +293,7 @@ vm_page_startup(start, end)
  *	NOTE:  This macro depends on vm_page_bucket_count being a power of 2.
  */
 #define vm_page_hash(object, offset) \
-	(((unsigned long)object+(unsigned long)atop(offset))&vm_page_hash_mask)
+        (((uintptr_t)(object) + (uintptr_t)atop(offset)) & vm_page_hash_mask)
 
 /*
  *	vm_page_insert:		[ internal use only ]


### PR DESCRIPTION
## Summary
- prefer `<stdint.h>` typedefs in `machine/types.h`
- add `#pragma once` to headers
- modernize panic declaration and pointer casts

## Testing
- `make -C src-kernel`
- `make -C tests`
- `./tests/test_kern`