### PR TITLE
Add sample CMake and Meson builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.16)
+project(tarantula C)
+
+find_package(BISON)
+if(BISON_FOUND)
+  message(STATUS "Bison found: ${BISON_EXECUTABLE}")
+else()
+  message(WARNING "bison not found - some tools may not build")
+endif()
+
+add_library(ipc STATIC src-lib/libipc/ipc.c)
+target_include_directories(ipc PUBLIC ${CMAKE_SOURCE_DIR}/src-headers)
+
+add_library(kern_stubs STATIC
+  src-kernel/proc_hooks.c
+  src-kernel/sched_hooks.c
+  src-kernel/vm_hooks.c
+  src-kernel/vfs_hooks.c
+)
+target_include_directories(kern_stubs PUBLIC ${CMAKE_SOURCE_DIR}/src-headers)
+target_link_libraries(kern_stubs PUBLIC ipc)
+
+file(GLOB FS_SERVER_SRC src-uland/fs-server/*.c)
+add_executable(fs_server ${FS_SERVER_SRC})
+target_include_directories(fs_server PRIVATE
+  ${CMAKE_SOURCE_DIR}/src-headers
+  ${CMAKE_SOURCE_DIR}/src-headers/machine
+  ${CMAKE_SOURCE_DIR}/sys
+  ${CMAKE_SOURCE_DIR}/sys/sys
+  ${CMAKE_SOURCE_DIR}/sys/i386/include)
+target_compile_definitions(fs_server PRIVATE KERNEL)
+target_link_libraries(fs_server PRIVATE ipc)
+
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Run `setup.sh` first to install required tools. The script installs `aptitude`
 and then uses `apt` to fetch **bmake** and its mk framework. It can optionally
 install **mk-configure**
 to provide an Autotools-style build system layered on top.
+The tree also ships a minimal **CMake** configuration.  Generate Ninja files
+with:
+
+```sh
+cmake -S . -B build -G Ninja
+cmake --build build
+```
+`find_package(BISON)` checks that **bison** is available.  An example
+`meson.build` offers the same layout for Meson users.
 `setup.sh` also checks `third_party/apt` for local `.deb` files and
 `third_party/pip` for Python wheels before contacting the network.
 Populate these directories with `apt-get download <pkg>` and

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -26,6 +26,16 @@ If `bison` is missing, install it and rerun `setup.sh`. The script now sets
 `YACC="bison -y"` automatically using `/etc/profile.d/yacc.sh`. Then proceed
 with the steps below.
 
+The repository also includes a simple **CMake** build. After installing the
+dependencies you can configure the entire tree using Ninja:
+
+```sh
+cmake -S . -B build -G Ninja
+cmake --build build
+```
+`find_package(BISON)` verifies that **bison** is installed. Meson users can run
+`meson setup build && ninja -C build` with the provided `meson.build`.
+
 All helper scripts expect the environment variables `SRC_ULAND` and
 `SRC_KERNEL` to point to the userland and kernel source directories. They
 default to `src-uland` and `src-kernel` respectively. Adjust these variables

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,41 @@
+project('tarantula', 'c', default_options : ['c_std=c23'])
+
+bison = find_program('bison', required : false)
+if not bison.found()
+  warning('bison not found; some tools may not build')
+endif
+
+libipc = static_library('ipc', 'src-lib/libipc/ipc.c',
+                        include_directories : include_directories('src-headers'))
+
+kern_srcs = [
+  'src-kernel/proc_hooks.c',
+  'src-kernel/sched_hooks.c',
+  'src-kernel/vm_hooks.c',
+  'src-kernel/vfs_hooks.c',
+]
+libkern = static_library('kern_stubs', kern_srcs,
+                         include_directories : include_directories('src-headers'),
+                         dependencies : libipc)
+
+fs_srcs = files(
+  'src-uland/fs-server/fs_open.c',
+  'src-uland/fs-server/vfs_bio.c',
+  'src-uland/fs-server/vfs_cache.c',
+  'src-uland/fs-server/vfs_cluster.c',
+  'src-uland/fs-server/vfs_conf.c',
+  'src-uland/fs-server/vfs_init.c',
+  'src-uland/fs-server/vfs_lookup.c',
+  'src-uland/fs-server/vfs_subr.c',
+  'src-uland/fs-server/vfs_syscalls.c',
+  'src-uland/fs-server/vfs_vnops.c'
+)
+executable('fs_server', fs_srcs,
+           include_directories : include_directories('src-headers',
+                                                    'src-headers/machine',
+                                                    'sys',
+                                                    'sys/sys',
+                                                    'sys/i386/include'),
+           c_args : ['-DKERNEL'],
+           link_with : libipc)
+


### PR DESCRIPTION
## Summary
- add a top level `CMakeLists.txt` that detects Bison
- provide a matching `meson.build` example
- document optional CMake/Meson usage and Bison detection

## Testing
- `bmake -C src-kernel` *(fails: command not found)*
- `cmake -S . -B build -G Ninja`
- `cmake --build build` *(fails: missing headers)*