### PR TITLE
Introduce scheduler spinlock

### DIFF
--- a/src-headers/sched_lock.h
+++ b/src-headers/sched_lock.h
@@ -1,0 +1,19 @@
+#ifndef SCHED_LOCK_H
+#define SCHED_LOCK_H
+
+#include "spinlock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SPINLOCK_DECLARE(sched_lock);
+
+void sched_lock_acquire(void);
+void sched_lock_release(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SCHED_LOCK_H */

--- a/src-headers/spinlock.h
+++ b/src-headers/spinlock.h
@@ -135,18 +135,14 @@ static inline void spinlock_guard_release(spinlock_guard_t *g)
     spinlock_guard_t name __attribute__((cleanup(spinlock_guard_release))) = { .lock = (lockptr) }; \
     spinlock_lock(name.lock)
 
-#ifndef CONFIG_SMP
-# define CONFIG_SMP 1
-#endif
-
-#if CONFIG_SMP
-# define spin_lock(l)   spinlock_lock(l)
-# define spin_unlock(l) spinlock_unlock(l)
-# define spin_trylock(l) spinlock_trylock(l)
-#else
+#ifdef SPINLOCK_UNIPROCESSOR
 # define spin_lock(l)   ((void)0)
 # define spin_unlock(l) ((void)0)
 # define spin_trylock(l) (1)
+#else
+# define spin_lock(l)   spinlock_lock(l)
+# define spin_unlock(l) spinlock_unlock(l)
+# define spin_trylock(l) spinlock_trylock(l)
 #endif
 
 #endif /* SPINLOCK_H */

--- a/src-lib/libkern_sched/Makefile
+++ b/src-lib/libkern_sched/Makefile
@@ -1,4 +1,4 @@
-OBJS = kern_sched.o
+OBJS = kern_sched.o sched_lock.o
 LIB  = libkern_sched.a
 
 CC ?= cc

--- a/src-lib/libkern_sched/kern_sched.c
+++ b/src-lib/libkern_sched/kern_sched.c
@@ -52,6 +52,7 @@
 #endif
 
 #include <machine/cpu.h>
+#include "sched_lock.h"
 
 u_char	curpriority;		/* usrpri of curproc */
 int	lbolt;			/* once a second sleep address */

--- a/src-lib/libkern_sched/sched_lock.c
+++ b/src-lib/libkern_sched/sched_lock.c
@@ -1,0 +1,13 @@
+#include "sched_lock.h"
+
+SPINLOCK_DEFINE(sched_lock);
+
+void sched_lock_acquire(void)
+{
+    spin_lock(&sched_lock);
+}
+
+void sched_lock_release(void)
+{
+    spin_unlock(&sched_lock);
+}

--- a/usr/src/sys/i386/i386/locore.s
+++ b/usr/src/sys/i386/i386/locore.s
@@ -125,6 +125,7 @@ _atdevphys:	.long	0	# location of device mapping ptes (phys)
 	.globl	_IdlePTD, _KPTphys
 _IdlePTD:	.long	0
 _KPTphys:	.long	0
+        call    _sched_lock_release
 
 	.space 512
 tmpstk:
@@ -1131,6 +1132,7 @@ movl	8(%esp),%eax
  */
 	ALIGN32
 ENTRY(setrunqueue)
+        call    _sched_lock_acquire
 	movl	4(%esp),%eax
 	cmpl	$0,P_BACK(%eax)		# should not be on q already
 	je	set1
@@ -1147,6 +1149,7 @@ set1:
 	movl	%ecx,P_BACK(%eax)
 	movl	%eax,P_BACK(%edx)
 	movl	%eax,P_FORW(%ecx)
+        call    _sched_lock_release
 	ret
 
 set2:	.asciz	"setrunqueue"
@@ -1158,6 +1161,7 @@ set2:	.asciz	"setrunqueue"
  */
 	ALIGN32
 ENTRY(remrq)
+        call    _sched_lock_acquire
 	movl	4(%esp),%eax
 	movzbl	P_PRIORITY(%eax),%edx
 	shrl	$2,%edx
@@ -1182,6 +1186,7 @@ rem1:
 	shrl	$3,%edx			# yes, set bit as still full
 	btsl	%edx,_whichqs
 rem2:
+        call    _sched_lock_release
 	movl	$0,P_BACK(%eax)		# zap reverse link to indicate off list
 	ret
 

--- a/usr/src/sys/pmax/pmax/locore.s
+++ b/usr/src/sys/pmax/pmax/locore.s
@@ -785,6 +785,8 @@ NON_LEAF(setrunqueue, STAND_FRAME_SIZE, ra)
 	.mask	0x80000000, (STAND_RA_OFFSET - STAND_FRAME_SIZE)
 	lw	t0, P_BACK(a0)		## firewall: p->p_back must be 0
 	sw	ra, STAND_RA_OFFSET(sp)	##
+        jal     sched_lock_acquire
+        nop
 	beq	t0, zero, 1f		##
 	lbu	t0, P_PRIORITY(a0)	# put on p->p_priority / 4 queue
 	PANIC("setrunqueue")		##
@@ -804,6 +806,8 @@ NON_LEAF(setrunqueue, STAND_FRAME_SIZE, ra)
 	sw	t1, P_BACK(a0)		# p->p_back = qp->ph_rlink
 	sw	a0, P_FORW(t1)		# p->p_back->p_forw = p;
 	sw	a0, P_BACK(t0)		# qp->ph_rlink = p
+        jal     sched_lock_release
+        nop
 	j	ra
 	addu	sp, sp, STAND_FRAME_SIZE
 END(setrunqueue)
@@ -816,6 +820,8 @@ END(setrunqueue)
 NON_LEAF(remrq, STAND_FRAME_SIZE, ra)
 	subu	sp, sp, STAND_FRAME_SIZE
 	.mask	0x80000000, (STAND_RA_OFFSET - STAND_FRAME_SIZE)
+        jal     sched_lock_acquire
+        nop
 	lbu	t0, P_PRIORITY(a0)	# get from p->p_priority / 4 queue
 	li	t1, 1			# compute corresponding bit
 	srl	t0, t0, 2		# compute index into 'whichqs'
@@ -842,7 +848,9 @@ NON_LEAF(remrq, STAND_FRAME_SIZE, ra)
 	sw	t2, whichqs
 2:
 	sw	zero, P_BACK(a0)	## for firewall checking
-	j	ra
+        jal     sched_lock_release
+        nop
+        j       ra
 	addu	sp, sp, STAND_FRAME_SIZE
 END(remrq)
 


### PR DESCRIPTION
## Summary
- add global `sched_lock` and helper APIs
- protect run queue helpers with new spinlock
- compile spinlock macros as no-ops when `SPINLOCK_UNIPROCESSOR` is defined

## Testing
- `pre-commit` *(fails: `pre-commit` not installed)*