### PR TITLE
Refactor IPC queue API with status codes

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -80,7 +80,7 @@ struct ipc_message m = { .type = IPC_MSG_OPEN,
                          .a = (uintptr_t)"/etc/passwd",
                          .b = O_RDONLY };
 ipc_queue_send(&q, &m);
-if (ipc_queue_recv(&q, &m)) {
+if (ipc_queue_recv(&q, &m) == IPC_OK) {
     int fd = (int)m.a;
     /* use fd */
 }
@@ -90,7 +90,9 @@ Kernel hooks such as `kern_open()` push a request message to the queue and wait
 for a corresponding reply from the user-space server.
 
 The queue implementation originally offered only non-blocking `ipc_queue_send()`
-and `ipc_queue_recv()` calls.  To simplify users of the API a lightweight
+and `ipc_queue_recv()` calls.  Operations now return an `ipc_status_t`
+value where `IPC_EMPTY` and `IPC_FULL` indicate the queue state.  To
+simplify users of the API a lightweight
 the ring buffer is protected by a small spinlock implemented in
 `src-headers/spinlock.h`. Two blocking helpers were added:
 `ipc_queue_send_blocking()` and `ipc_queue_recv_blocking()`.  These functions

--- a/src-headers/ipc.h
+++ b/src-headers/ipc.h
@@ -8,6 +8,14 @@
 
 #define IPC_QUEUE_SIZE 32
 
+/* Status codes for queue operations */
+typedef enum {
+    IPC_OK = 0,
+    IPC_EMPTY,
+    IPC_FULL,
+    IPC_TIMEOUT
+} ipc_status_t;
+
 /* Message types used by kernel hooks */
 enum ipc_msg_type {
     IPC_MSG_SCHED_INIT = 1,
@@ -36,9 +44,9 @@ struct ipc_queue {
 extern struct ipc_queue kern_ipc_queue;
 
 void ipc_queue_init(struct ipc_queue *q);
-bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m);
-bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m);
-void ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m);
-void ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m);
+ipc_status_t ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m);
+ipc_status_t ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m);
+ipc_status_t ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m);
+ipc_status_t ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m);
 
 #endif /* IPC_H */

--- a/src-headers/libipc.h
+++ b/src-headers/libipc.h
@@ -7,16 +7,14 @@
 #include "ipc.h"
 
 /* User-space convenience wrappers */
-static inline bool ipc_send(const struct ipc_message *m)
+static inline ipc_status_t ipc_send(const struct ipc_message *m)
 {
-    ipc_queue_send_blocking(&kern_ipc_queue, m);
-    return true;
+    return ipc_queue_send_blocking(&kern_ipc_queue, m);
 }
 
-static inline bool ipc_recv(struct ipc_message *m)
+static inline ipc_status_t ipc_recv(struct ipc_message *m)
 {
-    ipc_queue_recv_blocking(&kern_ipc_queue, m);
-    return true;
+    return ipc_queue_recv_blocking(&kern_ipc_queue, m);
 }
 
 #endif /* LIBIPC_H */

--- a/src-kernel/proc_hooks.c
+++ b/src-kernel/proc_hooks.c
@@ -10,9 +10,9 @@ kern_fork(void)
 {
 
     struct ipc_message msg = { .type = IPC_MSG_PROC_FORK };
-    ipc_queue_send(&kern_ipc_queue, &msg);
+    (void)ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
-    if (ipc_queue_recv(&kern_ipc_queue, &reply)) {
+    if (ipc_queue_recv(&kern_ipc_queue, &reply) == IPC_OK) {
         if (reply.type != IPC_MSG_PROC_FORK)
             return (int)reply.a;
     }
@@ -27,9 +27,9 @@ kern_exec(const char *path, char *const argv[])
         .a = (uintptr_t)path,
         .b = (uintptr_t)argv
     };
-    ipc_queue_send(&kern_ipc_queue, &msg);
+    (void)ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
-    if (ipc_queue_recv(&kern_ipc_queue, &reply))
+    if (ipc_queue_recv(&kern_ipc_queue, &reply) == IPC_OK)
         return (int)reply.a;
     return pm_exec(path, argv);
 }

--- a/src-kernel/sched_hooks.c
+++ b/src-kernel/sched_hooks.c
@@ -10,7 +10,7 @@ kern_sched_init(void)
     ipc_queue_init(&kern_ipc_queue);
 
     struct ipc_message msg = { .type = IPC_MSG_SCHED_INIT };
-    ipc_queue_send(&kern_ipc_queue, &msg);
+    (void)ipc_queue_send(&kern_ipc_queue, &msg);
     /* For now also directly call user library */
     uland_sched_init();
 }

--- a/src-kernel/vfs_hooks.c
+++ b/src-kernel/vfs_hooks.c
@@ -11,9 +11,9 @@ kern_open(const char *path, int flags)
         .a = (uintptr_t)path,
         .b = (uintptr_t)flags
     };
-    ipc_queue_send(&kern_ipc_queue, &msg);
+    (void)ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
-    if (ipc_queue_recv(&kern_ipc_queue, &reply)) {
+    if (ipc_queue_recv(&kern_ipc_queue, &reply) == IPC_OK) {
         if (reply.type != IPC_MSG_OPEN)
             return (int)reply.a;
     }

--- a/src-kernel/vm_hooks.c
+++ b/src-kernel/vm_hooks.c
@@ -8,10 +8,10 @@ bool
 kern_vm_fault(void *addr)
 {
     struct ipc_message msg = { .type = IPC_MSG_VM_FAULT, .a = (uintptr_t)addr };
-    ipc_queue_send(&kern_ipc_queue, &msg);
+    (void)ipc_queue_send(&kern_ipc_queue, &msg);
     /* Synchronous reply */
     struct ipc_message reply;
-    if (ipc_queue_recv(&kern_ipc_queue, &reply)) {
+    if (ipc_queue_recv(&kern_ipc_queue, &reply) == IPC_OK) {
         if (reply.type != IPC_MSG_VM_FAULT)
             return reply.a != 0;
     }

--- a/src-uland/libipc/ipc.h
+++ b/src-uland/libipc/ipc.h
@@ -7,16 +7,14 @@
 #include <ipc.h>
 
 /* User-space convenience wrappers */
-static inline bool ipc_send(const struct ipc_message *m)
+static inline ipc_status_t ipc_send(const struct ipc_message *m)
 {
-    ipc_queue_send_blocking(&kern_ipc_queue, m);
-    return true;
+    return ipc_queue_send_blocking(&kern_ipc_queue, m);
 }
 
-static inline bool ipc_recv(struct ipc_message *m)
+static inline ipc_status_t ipc_recv(struct ipc_message *m)
 {
-    ipc_queue_recv_blocking(&kern_ipc_queue, m);
-    return true;
+    return ipc_queue_recv_blocking(&kern_ipc_queue, m);
 }
 
 #endif /* LIBIPC_H */

--- a/src-uland/servers/reincarnation/reincarnation.c
+++ b/src-uland/servers/reincarnation/reincarnation.c
@@ -42,7 +42,7 @@ int main(void)
 
     struct ipc_message msg;
     for (;;) {
-        if (ipc_recv(&msg) && msg.type == IPC_MSG_HEARTBEAT) {
+        if (ipc_recv(&msg) == IPC_OK && msg.type == IPC_MSG_HEARTBEAT) {
             for (struct managed *m = managed_servers; m->path; ++m) {
                 if (m->pid == (pid_t)msg.a)
                     m->last_beat = time(NULL);


### PR DESCRIPTION
## Summary
- define `ipc_status_t` enumeration in `ipc.h`
- update `ipc_queue_*` functions to return status values
- adapt kernel hooks, userland wrappers, and a server to new API
- document new status return behavior

## Testing
- `make -C src-lib/libipc`
- `make -C src-kernel`
- `make test`