### PR TITLE
Add IPC receive timeout

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -95,7 +95,10 @@ the ring buffer is protected by a small spinlock implemented in
 `src-headers/spinlock.h`. Two blocking helpers were added:
 `ipc_queue_send_blocking()` and `ipc_queue_recv_blocking()`.  These functions
 busy-wait until the operation completes.  User-space wrappers `ipc_send()` and
-`ipc_recv()` invoke the blocking variants to guarantee delivery.
+`ipc_recv()` invoke the blocking variants to guarantee delivery.  A timed
+receive helper `ipc_queue_recv_timeout()` waits up to the requested
+milliseconds and returns a status code so higher layers can implement the
+`Recv_T(a,T)` semantics.
 The spinlock header now exposes `SPINLOCK_DEFINE()` and `spin_pause()`
 helpers to simplify definition and reduce CPU usage during contention.
 It detects the CPU cache line size via the `cpuid` instruction so the

--- a/src-headers/ipc.h
+++ b/src-headers/ipc.h
@@ -37,7 +37,22 @@ extern struct ipc_queue kern_ipc_queue;
 
 void ipc_queue_init(struct ipc_queue *q);
 bool ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m);
-bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m);
+
+enum ipc_recv_status {
+    IPC_RECV_OK = 0,
+    IPC_RECV_EMPTY,
+    IPC_RECV_TIMEOUT
+};
+
+enum ipc_recv_status ipc_queue_recv_timeout(struct ipc_queue *q,
+                                            struct ipc_message *m,
+                                            uint32_t timeout_ms);
+
+static inline bool ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)
+{
+    return ipc_queue_recv_timeout(q, m, 0) == IPC_RECV_OK;
+}
+
 void ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m);
 void ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m);
 

--- a/src-headers/libipc.h
+++ b/src-headers/libipc.h
@@ -19,4 +19,10 @@ static inline bool ipc_recv(struct ipc_message *m)
     return true;
 }
 
+static inline enum ipc_recv_status ipc_recv_timeout(struct ipc_message *m,
+                                                    uint32_t timeout_ms)
+{
+    return ipc_queue_recv_timeout(&kern_ipc_queue, m, timeout_ms);
+}
+
 #endif /* LIBIPC_H */


### PR DESCRIPTION
## Summary
- extend IPC queue API with timed receive
- provide user wrappers implementing Recv_T
- document new helper in functional model

## Testing
- `make -C src-kernel`
- `make -C tests`
- `./tests/test_kern`