### PR TITLE
Add libcapnp stub and memserver example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 
+
 .PHONY: all inventory test
+
+CAPNP ?= 0
 
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror
@@ -17,9 +20,13 @@ SUBDIRS = \
     src-uland/init \
     tests
 
+ifeq ($(CAPNP),1)
+SUBDIRS += third_party/libcapnp tools/memserver modern/tests
+endif
+
 all:
 	@for dir in $(SUBDIRS); do \
-	$(MAKE) -C $$dir CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)"; \
+	$(MAKE) -C $$dir CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" CAPNP="$(CAPNP)"; \
 	done
 
 inventory:
@@ -27,3 +34,6 @@ inventory:
 
 test:
 	$(MAKE) -C tests
+ifeq ($(CAPNP),1)
+	$(MAKE) -C modern/tests
+endif

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -84,3 +84,17 @@ return true;
 A future enhancement may add optional timeout parameters to the blocking
 routines, but the current API relies on explicit polling when timing out
 is required.
+
+## Cap'n Proto Stub
+
+When the build is invoked with `CAPNP=1` a minimal `libcapnp` library is
+compiled under `third_party/libcapnp`.  The stub currently implements only a
+single helper:
+
+```c
+int capnp_parse(const char *buf, size_t len, struct capnp_message *msg);
+```
+
+The `tools/memserver` program links against this stub.  It loads a file into
+memory and prints the parsed message size.  A basic regression test lives under
+`modern/tests` and is built automatically when `CAPNP=1` is supplied to `make`.

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -1,0 +1,17 @@
+CC ?= cc
+CPPFLAGS ?= -I../../third_party/libcapnp
+CFLAGS ?= -O2 -std=c23 -Wall -Werror
+LIBS = ../../third_party/libcapnp/libcapnp.a
+
+all: memserver_test
+
+memserver_test: memserver_test.o $(LIBS)
+$(CC) $(CFLAGS) memserver_test.o $(LIBS) -o $@
+
+memserver_test.o: memserver_test.c
+$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+rm -f memserver_test.o memserver_test
+
+.PHONY: all clean

--- a/modern/tests/README.md
+++ b/modern/tests/README.md
@@ -1,0 +1,2 @@
+This test demonstrates the libcapnp stub by verifying that a short buffer is parsed correctly.
+Build with `make CAPNP=1` at the project root.

--- a/modern/tests/memserver_test.c
+++ b/modern/tests/memserver_test.c
@@ -1,0 +1,13 @@
+#include "../../third_party/libcapnp/message.h"
+#include <assert.h>
+#include <string.h>
+
+int main(void)
+{
+    const char data[] = "abc";
+    struct capnp_message msg;
+    capnp_parse(data, sizeof(data)-1, &msg);
+    assert(msg.size == sizeof(data)-1);
+    assert(memcmp(msg.data, "abc", 3) == 0);
+    return 0;
+}

--- a/third_party/libcapnp/Makefile
+++ b/third_party/libcapnp/Makefile
@@ -1,0 +1,20 @@
+OBJS = message.o
+LIB  = libcapnp.a
+
+CC ?= cc
+AR ?= ar
+CPPFLAGS ?=
+CFLAGS ?= -O2 -std=c23 -Wall -Werror
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+$(AR) rcs $@ $(OBJS)
+
+%.o: %.c
+$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/third_party/libcapnp/README.md
+++ b/third_party/libcapnp/README.md
@@ -1,0 +1,2 @@
+This is a tiny placeholder implementation of libcapnp used for tests.
+Only the message parsing helpers are provided.

--- a/third_party/libcapnp/message.c
+++ b/third_party/libcapnp/message.c
@@ -1,0 +1,8 @@
+#include "message.h"
+
+int capnp_parse(const char *buf, size_t size, struct capnp_message *msg)
+{
+    msg->data = buf;
+    msg->size = size;
+    return 0;
+}

--- a/third_party/libcapnp/message.h
+++ b/third_party/libcapnp/message.h
@@ -1,0 +1,13 @@
+#ifndef CAPNP_MESSAGE_H
+#define CAPNP_MESSAGE_H
+
+#include <stddef.h>
+
+struct capnp_message {
+    const char *data;
+    size_t size;
+};
+
+int capnp_parse(const char *buf, size_t size, struct capnp_message *msg);
+
+#endif /* CAPNP_MESSAGE_H */

--- a/tools/memserver/Makefile
+++ b/tools/memserver/Makefile
@@ -1,0 +1,17 @@
+CC ?= cc
+CPPFLAGS ?= -I../../third_party/libcapnp
+CFLAGS ?= -O2 -std=c23 -Wall -Werror
+LIBS = ../../third_party/libcapnp/libcapnp.a
+
+all: memserver
+
+memserver: main.o $(LIBS)
+$(CC) $(CFLAGS) main.o $(LIBS) -o $@
+
+main.o: main.c
+$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+rm -f main.o memserver
+
+.PHONY: all clean

--- a/tools/memserver/README.md
+++ b/tools/memserver/README.md
@@ -1,0 +1,1 @@
+`memserver` reads a binary message into memory and prints the parsed length using the libcapnp stub.

--- a/tools/memserver/main.c
+++ b/tools/memserver/main.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../../third_party/libcapnp/message.h"
+
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <file>\n", argv[0]);
+        return 1;
+    }
+
+    FILE *f = fopen(argv[1], "rb");
+    if (!f) {
+        perror("fopen");
+        return 1;
+    }
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc(size);
+    if (!buf) {
+        fclose(f);
+        return 1;
+    }
+    fread(buf, 1, size, f);
+    fclose(f);
+
+    struct capnp_message msg;
+    capnp_parse(buf, size, &msg);
+    printf("parsed message of %zu bytes\n", msg.size);
+
+    free(buf);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add minimal `libcapnp` library under `third_party`
- introduce `CAPNP` option in root Makefile
- compile stub and `tools/memserver` when enabled
- provide `modern/tests` demo using the stub
- document new stub usage in `docs/IPC.md`

## Testing
- `make CAPNP=1` *(fails: unrecognized command-line option '-std=c23')*
- `make CAPNP=1 test` *(fails: unrecognized command-line option '-std=c23')*