### PR TITLE
Fix pointer casts in vm libraries

### DIFF
--- a/src-lib/libvm/vm_map.c
+++ b/src-lib/libvm/vm_map.c
@@ -70,6 +70,7 @@
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/malloc.h>
+#include <stdint.h>
 
 #include <vm/vm.h>
 #include <vm/vm_page.h>
@@ -2590,8 +2591,9 @@ vm_map_print(map, full)
 
 	iprintf("%s map 0x%x: pmap=0x%x,ref=%d,nentries=%d,version=%d\n",
 		(map->is_main_map ? "Task" : "Share"),
- 		(int) map, (int) (map->pmap), map->ref_count, map->nentries,
-		map->timestamp);
+               (uintptr_t) map, (uintptr_t) (map->pmap),
+               map->ref_count, map->nentries,
+               map->timestamp);
 
 	if (!full && indent)
 		return;
@@ -2599,8 +2601,10 @@ vm_map_print(map, full)
 	indent += 2;
 	for (entry = map->header.next; entry != &map->header;
 				entry = entry->next) {
-		iprintf("map entry 0x%x: start=0x%x, end=0x%x, ",
-			(int) entry, (int) entry->start, (int) entry->end);
+               iprintf("map entry 0x%x: start=0x%x, end=0x%x, ",
+                       (uintptr_t) entry,
+                       (uintptr_t) entry->start,
+                       (uintptr_t) entry->end);
 		if (map->is_main_map) {
 		     	static char *inheritance_name[4] =
 				{ "share", "copy", "none", "donate_copy"};
@@ -2613,9 +2617,9 @@ vm_map_print(map, full)
 		}
 
 		if (entry->is_a_map || entry->is_sub_map) {
-		 	printf("share=0x%x, offset=0x%x\n",
-				(int) entry->object.share_map,
-				(int) entry->offset);
+                       printf("share=0x%x, offset=0x%x\n",
+                               (uintptr_t) entry->object.share_map,
+                               (uintptr_t) entry->offset);
 			if ((entry->prev == &map->header) ||
 			    (!entry->prev->is_a_map) ||
 			    (entry->prev->object.share_map !=
@@ -2627,9 +2631,9 @@ vm_map_print(map, full)
 				
 		}
 		else {
-			printf("object=0x%x, offset=0x%x",
-				(int) entry->object.vm_object,
-				(int) entry->offset);
+                       printf("object=0x%x, offset=0x%x",
+                               (uintptr_t) entry->object.vm_object,
+                               (uintptr_t) entry->offset);
 			if (entry->copy_on_write)
 				printf(", copy (%s)",
 				       entry->needs_copy ? "needed" : "done");

--- a/src-lib/libvm/vm_object.c
+++ b/src-lib/libvm/vm_object.c
@@ -70,6 +70,7 @@
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/malloc.h>
+#include <stdint.h>
 
 #include <vm/vm.h>
 #include <vm/vm_page.h>
@@ -1417,12 +1418,12 @@ vm_object_print(object, full)
 	if (object == NULL)
 		return;
 
-	iprintf("Object 0x%x: size=0x%x, res=%d, ref=%d, ",
-		(int) object, (int) object->size,
-		object->resident_page_count, object->ref_count);
-	printf("pager=0x%x+0x%x, shadow=(0x%x)+0x%x\n",
-	       (int) object->pager, (int) object->paging_offset,
-	       (int) object->shadow, (int) object->shadow_offset);
+       iprintf("Object 0x%x: size=0x%x, res=%d, ref=%d, ",
+               (uintptr_t) object, (int) object->size,
+               object->resident_page_count, object->ref_count);
+       printf("pager=0x%x+0x%x, shadow=(0x%x)+0x%x\n",
+              (uintptr_t) object->pager, (uintptr_t) object->paging_offset,
+              (uintptr_t) object->shadow, (uintptr_t) object->shadow_offset);
 	printf("cache: next=0x%x, prev=0x%x\n",
 	       object->cached_list.tqe_next, object->cached_list.tqe_prev);
 


### PR DESCRIPTION
## Summary
- modernize pointer casts in libvm debug output
- include `<stdint.h>` for uintptr_t

## Testing
- `bmake -C src-kernel` *(fails: `bmake` not found)*