### PR TITLE
Initialize scheduler spinlock

### DIFF
--- a/docs/microkernel_functional_model.md
+++ b/docs/microkernel_functional_model.md
@@ -11,8 +11,8 @@ system safely.  These include:
 
 - **Thread scheduling hooks** – the kernel delegates policy decisions to the
   user-space scheduler library.  It starts execution in `kern_sched_init()`
-  which initializes the global IPC queue before any messages are sent and
-  then performs context switches on request.
+  which initializes the scheduler spinlock and the global IPC queue before any
+  messages are sent and then performs context switches on request.
 - **Virtual memory hooks** – page faults call `kern_vm_fault()` which forwards
   to a user-space memory manager for allocation and paging decisions.
 - **Kernel memory allocator** – see [memory_allocator.md](memory_allocator.md)

--- a/src-kernel/sched_hooks.c
+++ b/src-kernel/sched_hooks.c
@@ -6,7 +6,8 @@ extern void uland_sched_init(void);
 void
 kern_sched_init(void)
 {
-    /* Ensure the message queue is ready before sending */
+    /* Initialize scheduler lock and IPC queue before sending messages */
+    spinlock_init(&sched_lock);
     ipc_queue_init(&kern_ipc_queue);
 
     struct ipc_message msg = { .type = IPC_MSG_SCHED_INIT };


### PR DESCRIPTION
## Summary
- initialize scheduler lock before sending first scheduler message
- mention scheduler lock initialization in the microkernel model notes

## Testing
- `bmake -C src-kernel` *(fails: command not found)*