### PR TITLE
Introduce exo_ipc_status enum

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -37,31 +37,32 @@ write a populated structure into the queue and consumers read it back.
 
 ### Status Codes
 
-Queue operations return one of four status values:
+Queue operations return an `exo_ipc_status` value:
 
-- `IPC_STATUS_SUCCESS` – the operation completed successfully.
-- `IPC_STATUS_EMPTY` – a receive operation found no messages.
-- `IPC_STATUS_FULL` – a send operation found the queue full.
-- `IPC_STATUS_TIMEOUT` – a timed receive exceeded the retry budget.
+- `EXO_IPC_OK` – the operation completed successfully.
+- `EXO_IPC_EMPTY` – a receive operation found no messages.
+- `EXO_IPC_FULL` – a send operation found the queue full.
+- `EXO_IPC_TIMEOUT` – a timed receive exceeded the retry budget.
+- `EXO_IPC_ERROR` – an unspecified failure occurred.
 
 ## Send and Receive Semantics
 
-Two non‑blocking helpers operate on a queue and return an `ipc_status_t`
+Two non‑blocking helpers operate on a queue and return an `exo_ipc_status`
 value describing the outcome:
 
-- `ipc_status_t ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)`
-  – attempts to enqueue `m` and returns `IPC_STATUS_SUCCESS`,
-  `IPC_STATUS_FULL` or `IPC_STATUS_TIMEOUT`.
-- `ipc_status_t ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)` –
-  attempts to dequeue the next message and returns `IPC_STATUS_SUCCESS` or
-  `IPC_STATUS_EMPTY`.
+- `exo_ipc_status ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)`
+  – attempts to enqueue `m` and returns `EXO_IPC_OK`,
+  `EXO_IPC_FULL` or `EXO_IPC_TIMEOUT`.
+- `exo_ipc_status ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)` –
+  attempts to dequeue the next message and returns `EXO_IPC_OK` or
+  `EXO_IPC_EMPTY`.
 
 Blocking variants `ipc_queue_send_blocking()` and
 `ipc_queue_recv_blocking()` repeatedly call the non‑blocking forms until
 they succeed.  The wrappers `ipc_send()` and `ipc_recv()` in
 `libipc.h` invoke these blocking functions and report the resulting
 status. A convenience wrapper `ipc_recv_t()` polls with a limited
-retry count before returning `IPC_STATUS_TIMEOUT`.
+retry count before returning `EXO_IPC_TIMEOUT`.
 
 ## Timeout Behavior
 

--- a/include/exo_ipc.h
+++ b/include/exo_ipc.h
@@ -1,0 +1,13 @@
+#ifndef EXO_IPC_H
+#define EXO_IPC_H
+
+/* Status codes for exokernel IPC operations */
+typedef enum {
+    EXO_IPC_OK = 0,
+    EXO_IPC_EMPTY,
+    EXO_IPC_FULL,
+    EXO_IPC_TIMEOUT,
+    EXO_IPC_ERROR
+} exo_ipc_status;
+
+#endif /* EXO_IPC_H */

--- a/src-headers/ipc.h
+++ b/src-headers/ipc.h
@@ -6,16 +6,10 @@
 #include <stdbool.h>
 #include <stdatomic.h>
 #include "spinlock.h"
+#include <exo_ipc.h>
 
 #define IPC_QUEUE_SIZE 32
 
-/* Status codes for queue operations */
-typedef enum {
-    IPC_STATUS_SUCCESS = 0,
-    IPC_STATUS_EMPTY,
-    IPC_STATUS_FULL,
-    IPC_STATUS_TIMEOUT
-} ipc_status_t;
 
 /* Message types used by kernel hooks */
 enum ipc_msg_type {
@@ -45,12 +39,12 @@ struct ipc_queue {
 extern struct ipc_queue kern_ipc_queue;
 
 void ipc_queue_init(struct ipc_queue *q);
-ipc_status_t ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m);
-ipc_status_t ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m);
-ipc_status_t ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m);
-ipc_status_t ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m);
-ipc_status_t ipc_queue_recv_timed(struct ipc_queue *q, struct ipc_message *m,
-                                  unsigned tries);
+exo_ipc_status ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m);
+exo_ipc_status ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m);
+exo_ipc_status ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m);
+exo_ipc_status ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m);
+exo_ipc_status ipc_queue_recv_timed(struct ipc_queue *q, struct ipc_message *m,
+                                    unsigned tries);
 
 /* Basic per-process mailbox */
 struct ipc_mailbox {

--- a/src-headers/libipc.h
+++ b/src-headers/libipc.h
@@ -6,19 +6,20 @@
 #include <stdbool.h>
 
 #include "ipc.h"
+#include <exo_ipc.h>
 
 /* User-space convenience wrappers */
-static inline ipc_status_t ipc_send(const struct ipc_message *m)
+static inline exo_ipc_status ipc_send(const struct ipc_message *m)
 {
     return ipc_queue_send_blocking(&kern_ipc_queue, m);
 }
 
-static inline ipc_status_t ipc_recv(struct ipc_message *m)
+static inline exo_ipc_status ipc_recv(struct ipc_message *m)
 {
     return ipc_queue_recv_blocking(&kern_ipc_queue, m);
 }
 
-static inline ipc_status_t ipc_recv_t(struct ipc_message *m, unsigned tries)
+static inline exo_ipc_status ipc_recv_t(struct ipc_message *m, unsigned tries)
 {
     return ipc_queue_recv_timed(&kern_ipc_queue, m, tries);
 }

--- a/src-kernel/Makefile
+++ b/src-kernel/Makefile
@@ -7,7 +7,7 @@ CC ?= cc
 AR ?= ar
 CLANG_TIDY ?= ../tools/run_clang_tidy.sh
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
-CPPFLAGS += -I../src-headers
+CPPFLAGS += -I../src-headers -I../include
 
 
 all: $(LIBIPC) $(LIB)

--- a/src-kernel/proc_hooks.c
+++ b/src-kernel/proc_hooks.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include "exokernel.h"
 #include "ipc.h"
+#include <exo_ipc.h>
 /* Stubs delegating to user-space process manager */
 extern int pm_fork(void);
 extern int pm_exec(const char *path, char *const argv[]);
@@ -13,7 +14,7 @@ kern_fork(void)
     (void)ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
     struct ipc_mailbox *mb = ipc_mailbox_current();
-    if (ipc_queue_recv_timed(&mb->queue, &reply, 1000) == IPC_STATUS_SUCCESS) {
+    if (ipc_queue_recv_timed(&mb->queue, &reply, 1000) == EXO_IPC_OK) {
         if (reply.type != IPC_MSG_PROC_FORK)
             return (int)reply.a;
     }
@@ -31,7 +32,7 @@ kern_exec(const char *path, char *const argv[])
     (void)ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
     struct ipc_mailbox *mb2 = ipc_mailbox_current();
-    if (ipc_queue_recv_timed(&mb2->queue, &reply, 1000) == IPC_STATUS_SUCCESS)
+    if (ipc_queue_recv_timed(&mb2->queue, &reply, 1000) == EXO_IPC_OK)
         return (int)reply.a;
     return pm_exec(path, argv);
 }

--- a/src-kernel/vfs_hooks.c
+++ b/src-kernel/vfs_hooks.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include "exokernel.h"
 #include "ipc.h"
+#include <exo_ipc.h>
 /* Stubs delegating to user-space file server */
 extern int fs_open(const char *path, int flags);
 int
@@ -14,7 +15,7 @@ kern_open(const char *path, int flags)
     (void)ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
     struct ipc_mailbox *mb = ipc_mailbox_current();
-    if (ipc_queue_recv_timed(&mb->queue, &reply, 1000) == IPC_STATUS_SUCCESS) {
+    if (ipc_queue_recv_timed(&mb->queue, &reply, 1000) == EXO_IPC_OK) {
         if (reply.type != IPC_MSG_OPEN)
             return (int)reply.a;
     }

--- a/src-kernel/vm_hooks.c
+++ b/src-kernel/vm_hooks.c
@@ -1,6 +1,7 @@
 #include "exokernel.h"
 #include <stdbool.h>
 #include "ipc.h"
+#include <exo_ipc.h>
 /* Stubs delegating to user-space VM library */
 extern bool uland_vm_fault(void *addr);
 
@@ -12,7 +13,7 @@ kern_vm_fault(void *addr)
     /* Synchronous reply */
     struct ipc_message reply;
     struct ipc_mailbox *mb = ipc_mailbox_current();
-    if (ipc_queue_recv_timed(&mb->queue, &reply, 1000) == IPC_STATUS_SUCCESS) {
+    if (ipc_queue_recv_timed(&mb->queue, &reply, 1000) == EXO_IPC_OK) {
         if (reply.type != IPC_MSG_VM_FAULT)
             return reply.a != 0;
     }

--- a/src-lib/libipc/Makefile
+++ b/src-lib/libipc/Makefile
@@ -3,7 +3,7 @@ LIB  = libipc.a
 
 CC ?= cc
 AR ?= ar
-CPPFLAGS ?= -I../../src-headers
+CPPFLAGS ?= -I../../src-headers -I../../include
 CFLAGS ?= -O2
 CSTD ?= -std=c23
 CFLAGS += $(CSTD) -Wall -Werror

--- a/src-lib/libipc/ipc.c
+++ b/src-lib/libipc/ipc.c
@@ -1,4 +1,5 @@
 #include "ipc.h"
+#include <exo_ipc.h>
 #include <unistd.h>
 
 /* Shared queue used by kernel stubs and user-space servers */
@@ -23,60 +24,60 @@ void ipc_queue_init(struct ipc_queue *q)
     spinlock_init(&q->lock);
 }
 
-ipc_status_t ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)
+exo_ipc_status ipc_queue_send(struct ipc_queue *q, const struct ipc_message *m)
 {
-    ipc_status_t status = IPC_STATUS_FULL;
+    exo_ipc_status status = EXO_IPC_FULL;
     lock_queue(q);
     uint32_t next = (q->head + 1) % IPC_QUEUE_SIZE;
     if (next != q->tail) {
         q->msgs[q->head] = *m;
         q->head = next;
-        status = IPC_STATUS_SUCCESS;
+        status = EXO_IPC_OK;
     }
     unlock_queue(q);
     return status;
 }
 
-ipc_status_t ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)
+exo_ipc_status ipc_queue_recv(struct ipc_queue *q, struct ipc_message *m)
 {
-    ipc_status_t status = IPC_STATUS_EMPTY;
+    exo_ipc_status status = EXO_IPC_EMPTY;
     lock_queue(q);
     if (q->tail != q->head) {
         *m = q->msgs[q->tail];
         q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
-        status = IPC_STATUS_SUCCESS;
+        status = EXO_IPC_OK;
     }
     unlock_queue(q);
     return status;
 }
 
-ipc_status_t ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m)
+exo_ipc_status ipc_queue_send_blocking(struct ipc_queue *q, const struct ipc_message *m)
 {
-    ipc_status_t st;
-    while ((st = ipc_queue_send(q, m)) == IPC_STATUS_FULL)
+    exo_ipc_status st;
+    while ((st = ipc_queue_send(q, m)) == EXO_IPC_FULL)
         ;
     return st;
 }
 
-ipc_status_t ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m)
+exo_ipc_status ipc_queue_recv_blocking(struct ipc_queue *q, struct ipc_message *m)
 {
-    ipc_status_t st;
-    while ((st = ipc_queue_recv(q, m)) == IPC_STATUS_EMPTY)
+    exo_ipc_status st;
+    while ((st = ipc_queue_recv(q, m)) == EXO_IPC_EMPTY)
         ;
     return st;
 }
 
-ipc_status_t ipc_queue_recv_timed(struct ipc_queue *q, struct ipc_message *m,
-                                  unsigned tries)
+exo_ipc_status ipc_queue_recv_timed(struct ipc_queue *q, struct ipc_message *m,
+                                    unsigned tries)
 {
-    ipc_status_t st;
+    exo_ipc_status st;
     while (tries-- > 0) {
         st = ipc_queue_recv(q, m);
-        if (st != IPC_STATUS_EMPTY)
+        if (st != EXO_IPC_EMPTY)
             return st;
         spin_pause();
     }
-    return IPC_STATUS_TIMEOUT;
+    return EXO_IPC_TIMEOUT;
 }
 
 void ipc_mailbox_init(void)

--- a/src-uland/fs-server/Makefile
+++ b/src-uland/fs-server/Makefile
@@ -7,7 +7,7 @@ CFLAGS ?= -O2
 CSTD ?= -std=c23
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
             -I../../sys -I../../sys/sys \
-            -I../../sys/i386/include
+            -I../../sys/i386/include -I../../include
 CFLAGS   += $(CSTD) -DKERNEL -Wall -Werror
 
 all: $(PROG)

--- a/src-uland/init/Makefile
+++ b/src-uland/init/Makefile
@@ -5,7 +5,7 @@ PROG = init
 CC ?= cc
 CFLAGS ?= -O2
 CSTD ?= -std=c23
-CPPFLAGS ?= -I../../src-headers
+CPPFLAGS ?= -I../../src-headers -I../../include
 CFLAGS += $(CSTD) -Wall -Werror
 
 SUBDIRS = ../servers/reincarnation

--- a/src-uland/libipc/Makefile
+++ b/src-uland/libipc/Makefile
@@ -4,7 +4,7 @@ LIBIPC = $(LIBIPC_DIR)/libipc.a
 
 CC ?= cc
 AR ?= ar
-CPPFLAGS ?= -I../../src-headers
+CPPFLAGS ?= -I../../src-headers -I../../include
 CFLAGS ?= -O2
 CSTD ?= -std=c23
 CFLAGS += $(CSTD) -Wall -Werror

--- a/src-uland/libipc/ipc.h
+++ b/src-uland/libipc/ipc.h
@@ -5,19 +5,20 @@
 #include <stdbool.h>
 
 #include <ipc.h>
+#include <exo_ipc.h>
 
 /* User-space convenience wrappers */
-static inline ipc_status_t ipc_send(const struct ipc_message *m)
+static inline exo_ipc_status ipc_send(const struct ipc_message *m)
 {
     return ipc_queue_send_blocking(&kern_ipc_queue, m);
 }
 
-static inline ipc_status_t ipc_recv(struct ipc_message *m)
+static inline exo_ipc_status ipc_recv(struct ipc_message *m)
 {
     return ipc_queue_recv_blocking(&kern_ipc_queue, m);
 }
 
-static inline ipc_status_t ipc_recv_t(struct ipc_message *m, unsigned tries)
+static inline exo_ipc_status ipc_recv_t(struct ipc_message *m, unsigned tries)
 {
     return ipc_queue_recv_timed(&kern_ipc_queue, m, tries);
 }

--- a/src-uland/libvm/Makefile
+++ b/src-uland/libvm/Makefile
@@ -6,7 +6,7 @@ CC ?= cc
 AR ?= ar
 CPPFLAGS ?= -I../../src-headers -I../../src-headers/machine \
         -I../../sys -I../../sys/sys \
-        -I../../sys/i386/include
+        -I../../sys/i386/include -I../../include
 CFLAGS ?= -O2
 CSTD ?= -std=c23
 CFLAGS += $(CSTD) -DKERNEL -Wall -Werror

--- a/src-uland/servers/proc_manager/Makefile
+++ b/src-uland/servers/proc_manager/Makefile
@@ -5,7 +5,7 @@ CFLAGS ?= -O2
 CSTD ?= -std=c23
 CPPFLAGS ?= -I../../../src-headers -I../../../src-headers/machine \
             -I../../../sys -I../../../sys/sys \
-            -I../../../sys/i386/include
+            -I../../../sys/i386/include -I../../../include
 CFLAGS   += $(CSTD) -DKERNEL -Wall -Werror
 
 all: $(PROG)

--- a/src-uland/servers/reincarnation/Makefile
+++ b/src-uland/servers/reincarnation/Makefile
@@ -5,7 +5,7 @@ PROG = reincarnation
 CC ?= cc
 CFLAGS ?= -O2
 CSTD ?= -std=c23
-CPPFLAGS ?= -I../../../src-headers -I../../libipc
+CPPFLAGS ?= -I../../../src-headers -I../../libipc -I../../../include
 CFLAGS += $(CSTD) -Wall -Werror
 
 all: $(PROG)

--- a/src-uland/servers/reincarnation/reincarnation.c
+++ b/src-uland/servers/reincarnation/reincarnation.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <time.h>
 #include "ipc.h"
+#include <exo_ipc.h>
 #include "../libipc/ipc.h"
 
 struct managed {
@@ -42,7 +43,7 @@ int main(void)
 
     struct ipc_message msg;
     for (;;) {
-        if (ipc_recv(&msg) == IPC_STATUS_SUCCESS && msg.type == IPC_MSG_HEARTBEAT) {
+        if (ipc_recv(&msg) == EXO_IPC_OK && msg.type == IPC_MSG_HEARTBEAT) {
             for (struct managed *m = managed_servers; m->path; ++m) {
                 if (m->pid == (pid_t)msg.a)
                     m->last_beat = time(NULL);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ CC ?= clang
 CXX ?= clang++
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror
-CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel
+CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel -I../include
 LIBS = ../src-kernel/libkern_stubs.a ../src-lib/libipc/libipc.a
 
 OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o sched_stub.o mock_vm.o

--- a/tests/test_mailbox.c
+++ b/tests/test_mailbox.c
@@ -1,4 +1,5 @@
 #include "ipc.h"
+#include <exo_ipc.h>
 #include <stdio.h>
 
 int main(void)
@@ -10,13 +11,13 @@ int main(void)
     struct ipc_message msg = { .type = IPC_MSG_HEARTBEAT, .a = 123 };
     ipc_queue_send(&a->queue, &msg);
 
-    if (ipc_queue_recv_timed(&b->queue, &msg, 5) != IPC_STATUS_TIMEOUT) {
+    if (ipc_queue_recv_timed(&b->queue, &msg, 5) != EXO_IPC_TIMEOUT) {
         printf("unexpected message\n");
         return 1;
     }
 
     ipc_queue_send(&b->queue, &msg);
-    if (ipc_queue_recv_timed(&b->queue, &msg, 5) != IPC_STATUS_SUCCESS) {
+    if (ipc_queue_recv_timed(&b->queue, &msg, 5) != EXO_IPC_OK) {
         printf("recv failed\n");
         return 1;
     }


### PR DESCRIPTION
## Summary
- add new `exo_ipc_status` enumeration
- convert IPC helpers and wrappers to use the enum
- update kernel hooks, userland code, and tests
- document the new enum
- adjust Makefiles to include `include/`

## Testing
- `make -C tests` *(fails: unrecognized option '-std=c23')*