### PR TITLE
Add CMake migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@ Downloaded from: ftp://alge.anart.no/pub/BSD/4.4BSD-Lite/4.4BSD-Lite2.tar.gz
 
 For kernel build instructions see [docs/building_kernel.md](docs/building_kernel.md).
 Run `setup.sh` first to install required tools. The script installs `aptitude`
-and then uses `apt` to fetch **bmake** and its mk framework. It can optionally
-install **mk-configure**
-to provide an Autotools-style build system layered on top.
+and fetches **clang**, **bison** and **bmake** with its mk framework. It can
+optionally install **mk-configure** to provide an Autotools-style layer on top.
 The tree also ships a minimal **CMake** configuration.  Generate Ninja files
 with:
 
 ```sh
 cmake -S . -B build -G Ninja
-cmake --build build
+CC=clang cmake --build build
 ```
 `find_package(BISON)` checks that **bison** is available.  An example
-`meson.build` offers the same layout for Meson users.
+`meson.build` offers the same layout for Meson users.  See
+[docs/cmake_upgrade.md](docs/cmake_upgrade.md) for a gradual migration guide
+from the historic `bmake` system to CMake.
 `setup.sh` also checks `third_party/apt` for local `.deb` files and
 `third_party/pip` for Python wheels before contacting the network.
 Populate these directories with `apt-get download <pkg>` and

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,6 +4,7 @@ This folder stores notes about building and modernizing the tree.
 Key references:
 - `building_kernel.md` – instructions for compiling the kernel.
 - `modernization_plan.md` – high level refactor roadmap.
+- `cmake_upgrade.md` – steps for migrating from bmake to CMake.
 - `refactor_c23_tasks.md` – ongoing task list.
 - `exokernel_plan.md` – tasks for building an exokernel variant.
 - `file_tree.txt` – snapshot of the original layout.

--- a/docs/cmake_upgrade.md
+++ b/docs/cmake_upgrade.md
@@ -1,0 +1,50 @@
+# Transitioning from bmake to CMake
+
+This guide outlines a gradual approach to replace the historical `bmake` build system with a modern CMake workflow that leverages **clang** and **bison**.  The steps can be applied directory by directory so that existing makefiles continue to work during the migration.
+
+## 1. Prepare the environment
+
+Run `setup.sh` to install clang, bison and the other toolchain components.  CMake will detect these automatically.  Ensure `YACC="bison -y"` is exported in your shell.
+
+```sh
+sudo ./setup.sh
+```
+
+## 2. Create CMakeLists.txt next to each Makefile
+
+Start by introducing small `CMakeLists.txt` files beside the existing makefiles.  Mirror the source lists and include paths from the makefiles.  Use `add_library()` or `add_executable()` targets with the same output names.
+
+Example skeleton:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(example C)
+
+add_library(example STATIC example.c)
+```
+
+Invoke the compiler explicitly with clang when configuring:
+
+```sh
+CC=clang cmake -S . -B build -G Ninja
+cmake --build build
+```
+
+## 3. Replace yacc rules with bison
+
+For sources generated from `.y` files, use `BISON_TARGET()` from the CMake built-in Bison module.  Update the old `yacc` make rules to invoke the generated targets.
+
+```cmake
+find_package(BISON REQUIRED)
+BISON_TARGET(parser parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser.c)
+add_library(parser STATIC ${BISON_parser_OUTPUTS})
+```
+
+## 4. Incrementally convert subdirectories
+
+Convert each subdirectory in the tree and add it with `add_subdirectory()` from the top-level `CMakeLists.txt`.  Retain the existing makefiles until everything builds with CMake.
+
+## 5. Remove bmake when no longer needed
+
+Once every module builds via CMake, the legacy makefiles can be deleted and references to `bmake` in the documentation removed.  The build instructions in [building_kernel.md](building_kernel.md) already show how to invoke CMake.
+

--- a/docs/modernization_plan.md
+++ b/docs/modernization_plan.md
@@ -19,7 +19,7 @@ For a summary of directory mappings during the reorganization see
 - Configure modern compilers (e.g., GCC or Clang) with `-std=c2x`.
 - Maintain compatibility with existing BSD makefiles while introducing
   modern build options.
-- Prototype CMake build files using **CMake 3.16+** to evaluate a cross-platform build system.
+- Prototype CMake build files using **CMake 3.16+** to evaluate a cross-platform build system.  See `cmake_upgrade.md` for a directory-by-directory migration plan.
 - Integrate static analysis tools such as `clang-tidy`.
 - Set up a `pre-commit` hook to run `clang-format` and `clang-tidy`.
 - Generate a `compile_commands.json` database using `compiledb` for use with


### PR DESCRIPTION
## Summary
- document CMake migration steps
- reference the new guide from docs and README
- mention clang/bison install in README

## Testing
- `git status --short`