### PR TITLE
Add build environment check helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ from the historic `bmake` system to CMake.
 `third_party/pip` for Python wheels before contacting the network.
 Populate these directories with `apt-get download <pkg>` and
 `pip download <pkg>` while online to enable offline runs.
+You can verify which commands are available at any time by running
+`tools/check_build_env.sh`. It lists missing build tools and exits
+non-zero when any are absent.
 For GitHub CI examples see [docs/ci_workflows.md](docs/ci_workflows.md).
 For FHS migration steps see [docs/fhs_migration.md](docs/fhs_migration.md).
 For microkernel tasks see [docs/microkernel_plan.md](docs/microkernel_plan.md)

--- a/docs/debug_build_env.md
+++ b/docs/debug_build_env.md
@@ -1,0 +1,26 @@
+# Debugging the Build Environment
+
+This note captures the results of running `setup.sh` in a minimal container
+without network access. The script failed to install many packages, leaving
+several build tools missing. The `/tmp/setup.log` file showed `APT FAIL` and
+`PIP FAIL` entries for the following programs:
+
+- `aptitude`, `bmake`, `mk-configure`
+- `bison`, `byacc`, `flex`
+- `clang`, `clang-format`, `clang-tidy`, `lld`, `llvm`
+- `meson`, `autoconf`, `automake`, `libtool`, `m4`
+- `uncrustify`, `astyle`, `editorconfig`, `pre-commit`
+- math libraries such as `libopenblas-dev`, `liblapack-dev`, `libeigen3-dev`
+- various tracing tools (`strace`, `ltrace`, `linux-perf`, `systemtap`)
+
+Only `gcc`, `g++`, `make`, `ninja` and `cmake` were present.
+
+To quickly verify which tools are available, run:
+
+```sh
+./tools/check_build_env.sh
+```
+
+It prints a list of missing commands and exits non-zero if any are absent.
+Populate `third_party/apt` and `third_party/pip` with the corresponding
+packages while online to allow `setup.sh` to succeed offline.

--- a/tools/check_build_env.sh
+++ b/tools/check_build_env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Simple helper to verify core build tools.
+# Outputs missing tools and returns non-zero if any are absent.
+
+missing=()
+for cmd in cmake ninja meson clang bison bmake flex clang-format clang-tidy; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    missing+=("$cmd")
+  fi
+done
+
+# YACC should be set to "bison -y" after running setup.sh
+if [ -z "${YACC:-}" ]; then
+  missing+=("YACC env var")
+fi
+
+if [ ${#missing[@]} -eq 0 ]; then
+  echo "All required build tools are present."
+else
+  echo "Missing build tools: ${missing[*]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a simple script to check for core build tools
- document missing packages when running setup offline
- reference the helper in README

## Testing
- `./tools/check_build_env.sh`