### PR TITLE
Add runin/runout counters

### DIFF
--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -11,6 +11,16 @@ SPINLOCK_DECLARE(sched_lock);
 void sched_lock_acquire(void);
 void sched_lock_release(void);
 
+/*
+ * Counters tracking the number of processes swapped in and out.
+ * Derived from historic BSD scheduler variables.
+ */
+extern int runin;
+extern int runout;
+
+void sched_increment_runin(void);
+void sched_increment_runout(void);
+
 void kern_sched_init(void);
 int kern_open(const char *path, int flags);
 bool kern_vm_fault(void *addr);

--- a/src-lib/libkern_sched/Makefile
+++ b/src-lib/libkern_sched/Makefile
@@ -1,4 +1,4 @@
-OBJS = kern_sched.o sched_lock.o
+OBJS = kern_sched.o sched_lock.o runqueue.o
 LIB  = libkern_sched.a
 
 CC ?= cc

--- a/src-lib/libkern_sched/runqueue.c
+++ b/src-lib/libkern_sched/runqueue.c
@@ -1,0 +1,27 @@
+#include "exokernel.h"
+
+/*
+ * Global counters tracking swap-in and swap-out events.
+ * These variables mirror the historic runin/runout counters from
+ * the 4.4BSD scheduler.  They provide statistics on how many
+ * processes have been swapped into and out of memory.
+ */
+int runin = 0;
+int runout = 0;
+
+void
+sched_increment_runin(void)
+{
+    sched_lock_acquire();
+    runin++;
+    sched_lock_release();
+}
+
+void
+sched_increment_runout(void)
+{
+    sched_lock_acquire();
+    runout++;
+    sched_lock_release();
+}
+

--- a/src-lib/libvm/vm_glue.c
+++ b/src-lib/libvm/vm_glue.c
@@ -370,8 +370,9 @@ loop:
 		(void) splstatclock();
 		if (p->p_stat == SRUN)
 			setrunqueue(p);
-		p->p_flag |= P_INMEM;
-		(void) spl0();
+                p->p_flag |= P_INMEM;
+                sched_increment_runin();
+                (void) spl0();
 		p->p_swtime = 0;
 		goto loop;
 	}
@@ -517,9 +518,10 @@ swapout(p)
 	pmap_collect(vm_map_pmap(&p->p_vmspace->vm_map));
 #endif
 	(void) splhigh();
-	p->p_flag &= ~P_INMEM;
-	if (p->p_stat == SRUN)
-		remrq(p);
+        p->p_flag &= ~P_INMEM;
+        sched_increment_runout();
+        if (p->p_stat == SRUN)
+                remrq(p);
 	(void) spl0();
 	p->p_swtime = 0;
 }


### PR DESCRIPTION
## Summary
- define `runin` and `runout` counters in new `runqueue.c`
- expose the counters via `exokernel.h`
- build `runqueue.o` as part of `libkern_sched`
- update swapper routines to increment the counters

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build` *(fails: missing headers)*