### PR TITLE
Add run queue helpers to libkern_sched

### DIFF
--- a/src-headers/runqueue.h
+++ b/src-headers/runqueue.h
@@ -1,0 +1,11 @@
+#pragma once
+#ifndef RUNQUEUE_H
+#define RUNQUEUE_H
+
+#include <sys/proc.h>
+
+/* Run queue management helpers */
+void setrunqueue(struct proc *p);
+void remrq(struct proc *p);
+
+#endif /* RUNQUEUE_H */

--- a/src-lib/libkern_sched/Makefile
+++ b/src-lib/libkern_sched/Makefile
@@ -1,4 +1,4 @@
-OBJS = kern_sched.o sched_lock.o
+OBJS = kern_sched.o sched_lock.o runqueue.o
 LIB  = libkern_sched.a
 
 CC ?= cc

--- a/src-lib/libkern_sched/kern_sched.c
+++ b/src-lib/libkern_sched/kern_sched.c
@@ -52,6 +52,7 @@
 #endif
 
 #include <machine/cpu.h>
+#include "runqueue.h"
 
 u_char	curpriority;		/* usrpri of curproc */
 int	lbolt;			/* once a second sleep address */

--- a/src-lib/libkern_sched/runqueue.c
+++ b/src-lib/libkern_sched/runqueue.c
@@ -1,0 +1,56 @@
+#include "exokernel.h"
+#include <sys/proc.h>
+#include <sys/systm.h>
+
+/* Global run queue state */
+int whichqs;
+struct prochd qs[NQS];
+
+/*
+ * Insert process into the run queue determined by its priority.
+ */
+void
+setrunqueue(struct proc *p)
+{
+    struct prochd *q;
+    struct proc *oldlast;
+    int which = p->p_priority >> 2;
+
+    sched_lock_acquire();
+
+    if (p->p_back != NULL)
+        panic("setrunqueue");
+
+    q = &qs[which];
+    whichqs |= 1 << which;
+    p->p_forw = (struct proc *)q;
+    p->p_back = oldlast = q->ph_rlink;
+    q->ph_rlink = p;
+    oldlast->p_forw = p;
+
+    sched_lock_release();
+}
+
+/*
+ * Remove process from its run queue.  Panic if bookkeeping disagrees.
+ */
+void
+remrq(struct proc *p)
+{
+    int which = p->p_priority >> 2;
+    struct prochd *q;
+
+    sched_lock_acquire();
+
+    if ((whichqs & (1 << which)) == 0)
+        panic("remrq");
+
+    p->p_forw->p_back = p->p_back;
+    p->p_back->p_forw = p->p_forw;
+    p->p_back = NULL;
+    q = &qs[which];
+    if (q->ph_link == (struct proc *)q)
+        whichqs &= ~(1 << which);
+
+    sched_lock_release();
+}


### PR DESCRIPTION
## Summary
- implement `setrunqueue()` and `remrq()` in new runqueue.c
- export prototypes in `runqueue.h`
- link the new object in libkern_sched
- include the new header from kern_sched.c

## Testing
- `make -C src-lib/libkern_sched clean`
- `make -C src-lib/libkern_sched` *(fails: `cc: error: unrecognized command-line option '-std=c23'`)*