### PR TITLE
Centralize runqueue primitives

### DIFF
--- a/usr/src/sys/conf/files
+++ b/usr/src/sys/conf/files
@@ -35,6 +35,7 @@ kern/kern_resource.c	standard
 kern/kern_sig.c		standard
 kern/kern_subr.c	standard
 kern/kern_synch.c	standard
+kern/kern_runq.c	standard
 kern/kern_sysctl.c	standard
 kern/kern_time.c	standard
 kern/kern_xxx.c		standard

--- a/usr/src/sys/hp300/hp300/locore.s
+++ b/usr/src/sys/hp300/hp300/locore.s
@@ -1497,6 +1497,8 @@ ENTRY(longjmp)
  *
  * Call should be made at spl6(), and p->p_stat should be SRUN
  */
+/* replaced by sys/kern/kern_runq.c lines 15-30 */
+#if 0
 ENTRY(setrunqueue)
 	movl	sp@(4),a0
 	tstl	a0@(P_BACK)
@@ -1520,6 +1522,7 @@ Lset1:
 	movl	a0,a1@(P_FORW)
 	rts
 
+#endif
 Lset2:
 	.asciz	"setrunqueue"
 	.even
@@ -1529,6 +1532,8 @@ Lset2:
  *
  * Call should be made at spl6().
  */
+/* replaced by sys/kern/kern_runq.c lines 36-50 */
+#if 0
 ENTRY(remrq)
 	movl	sp@(4),a0
 	clrl	d0
@@ -1557,6 +1562,7 @@ Lrem1:
 Lrem2:
 	clrl	a0@(P_BACK)
 	rts
+#endif
 
 Lrem3:
 	.asciz	"remrq"

--- a/usr/src/sys/i386/i386/locore.s
+++ b/usr/src/sys/i386/i386/locore.s
@@ -1130,6 +1130,8 @@ movl	8(%esp),%eax
  * Call should be made at spl6(), and p->p_stat should be SRUN
  */
 	ALIGN32
+/* replaced by sys/kern/kern_runq.c lines 15-30 */
+#if 0
 ENTRY(setrunqueue)
 	movl	4(%esp),%eax
 	cmpl	$0,P_BACK(%eax)		# should not be on q already
@@ -1148,6 +1150,7 @@ set1:
 	movl	%eax,P_BACK(%edx)
 	movl	%eax,P_FORW(%ecx)
 	ret
+#endif
 
 set2:	.asciz	"setrunqueue"
 
@@ -1157,6 +1160,8 @@ set2:	.asciz	"setrunqueue"
  * Call should be made at spl6().
  */
 	ALIGN32
+/* replaced by sys/kern/kern_runq.c lines 36-50 */
+#if 0
 ENTRY(remrq)
 	movl	4(%esp),%eax
 	movzbl	P_PRIORITY(%eax),%edx
@@ -1184,6 +1189,7 @@ rem1:
 rem2:
 	movl	$0,P_BACK(%eax)		# zap reverse link to indicate off list
 	ret
+#endif
 
 rem3:	.asciz	"remrq"
 sw0:	.asciz	"Xswitch"

--- a/usr/src/sys/kern/kern_runq.c
+++ b/usr/src/sys/kern/kern_runq.c
@@ -1,0 +1,50 @@
+/*
+ * Shared run queue primitives extracted from per-arch locore.s files.
+ * Originally implemented in assembly for each machine.
+ * This version consolidates the logic in C so all kernels share
+ * the same implementation.
+ */
+#include <sys/param.h>
+#include <sys/proc.h>
+#include <sys/resourcevar.h>
+
+/*
+ * Insert process p on the run queue indicated by its priority.
+ * Calls should be made at splstatclock(), and p->p_stat should be SRUN.
+ */
+void
+setrunqueue(struct proc *p)
+{
+    struct prochd *q;
+    struct proc *oldlast;
+    int which = p->p_priority >> 2;
+
+    if (p->p_back != NULL)
+        panic("setrunqueue");
+    q = &qs[which];
+    whichqs |= 1 << which;
+    p->p_forw = (struct proc *)q;
+    p->p_back = oldlast = q->ph_rlink;
+    q->ph_rlink = p;
+    oldlast->p_forw = p;
+}
+
+/*
+ * Remove process p from its run queue, which should be the one
+ * indicated by its priority.  Calls should be made at splstatclock().
+ */
+void
+remrq(struct proc *p)
+{
+    int which = p->p_priority >> 2;
+    struct prochd *q;
+
+    if ((whichqs & (1 << which)) == 0)
+        panic("remrq");
+    p->p_forw->p_back = p->p_back;
+    p->p_back->p_forw = p->p_forw;
+    p->p_back = NULL;
+    q = &qs[which];
+    if (q->ph_link == (struct proc *)q)
+        whichqs &= ~(1 << which);
+}

--- a/usr/src/sys/luna68k/luna68k/locore.s
+++ b/usr/src/sys/luna68k/luna68k/locore.s
@@ -1326,6 +1326,8 @@ ENTRY(longjmp)
  *
  * Call should be made at spl6(), and p->p_stat should be SRUN
  */
+/* replaced by sys/kern/kern_runq.c lines 15-30 */
+#if 0
 ENTRY(setrunqueue)
 	movl	sp@(4),a0
 	tstl	a0@(P_BACK)
@@ -1348,6 +1350,7 @@ Lset1:
 	movl	a0@(P_BACK),a1
 	movl	a0,a1@(P_FORW)
 	rts
+#endif
 
 Lset2:
 	.asciz	"setrunqueue"
@@ -1358,6 +1361,8 @@ Lset2:
  *
  * Call should be made at spl6().
  */
+/* replaced by sys/kern/kern_runq.c lines 36-50 */
+#if 0
 ENTRY(remrq)
 	movl	sp@(4),a0
 	clrl	d0
@@ -1386,6 +1391,7 @@ Lrem1:
 Lrem2:
 	clrl	a0@(P_BACK)
 	rts
+#endif
 
 Lrem3:
 	.asciz	"remrq"

--- a/usr/src/sys/news3400/news3400/locore.s
+++ b/usr/src/sys/news3400/news3400/locore.s
@@ -811,6 +811,8 @@ END(copykstack)
  *
  * Call should be made at splclock(), and p->p_stat should be SRUN.
  */
+/* replaced by sys/kern/kern_runq.c lines 15-30 */
+#if 0
 NON_LEAF(setrunqueue, STAND_FRAME_SIZE, ra)
 	subu	sp, sp, STAND_FRAME_SIZE
 	.mask	0x80000000, (STAND_RA_OFFSET - STAND_FRAME_SIZE)
@@ -838,8 +840,11 @@ NON_LEAF(setrunqueue, STAND_FRAME_SIZE, ra)
 	j	ra
 END(setrunqueue)
 
+#endif
 /*
  * Remrq(p)
+/* replaced by sys/kern/kern_runq.c lines 36-50 */
+#if 0
  *
  * Call should be made at splclock().
  */
@@ -872,6 +877,7 @@ NON_LEAF(remrq, STAND_FRAME_SIZE, ra)
 	addu	sp, sp, STAND_FRAME_SIZE
 	j	ra
 END(remrq)
+#endif
 
 /*
  * switch_exit()

--- a/usr/src/sys/pmax/pmax/locore.s
+++ b/usr/src/sys/pmax/pmax/locore.s
@@ -780,6 +780,8 @@ END(copykstack)
  *
  * Call should be made at splclock(), and p->p_stat should be SRUN.
  */
+/* replaced by sys/kern/kern_runq.c lines 15-30 */
+#if 0
 NON_LEAF(setrunqueue, STAND_FRAME_SIZE, ra)
 	subu	sp, sp, STAND_FRAME_SIZE
 	.mask	0x80000000, (STAND_RA_OFFSET - STAND_FRAME_SIZE)
@@ -807,9 +809,12 @@ NON_LEAF(setrunqueue, STAND_FRAME_SIZE, ra)
 	j	ra
 	addu	sp, sp, STAND_FRAME_SIZE
 END(setrunqueue)
+#endif
 
 /*
  * Remrq(p)
+/* replaced by sys/kern/kern_runq.c lines 36-50 */
+#if 0
  *
  * Call should be made at splclock().
  */
@@ -845,6 +850,7 @@ NON_LEAF(remrq, STAND_FRAME_SIZE, ra)
 	j	ra
 	addu	sp, sp, STAND_FRAME_SIZE
 END(remrq)
+#endif
 
 /*
  * switch_exit()

--- a/usr/src/sys/sys/proc.h
+++ b/usr/src/sys/sys/proc.h
@@ -274,6 +274,7 @@ void	procinit __P((void));
 void	resetpriority __P((struct proc *));
 void	setrunnable __P((struct proc *));
 void	setrunqueue __P((struct proc *));
+void	remrq __P((struct proc *));
 void	sleep __P((void *chan, int pri));
 int	tsleep __P((void *chan, int pri, char *wmesg, int timo));
 void	unsleep __P((struct proc *));


### PR DESCRIPTION
## Summary
- implement `setrunqueue` and `remrq` in new `kern_runq.c`
- include `kern_runq.c` in kernel build
- declare `remrq` prototype
- mark and disable old assembly implementations

## Testing
- `make -C src-kernel` *(fails: unrecognized option -std=c23)*
- `make -C tests` *(fails: unrecognized option -std=c23)*