### PR TITLE
Add path translation wrappers

### DIFF
--- a/usr/src/libpathtrans/examples/Makefile
+++ b/usr/src/libpathtrans/examples/Makefile
@@ -1,0 +1,13 @@
+CC=gcc
+CFLAGS=-Wall -O2
+LDLIBS=-L.. -Wl,-rpath=.. -lpathtrans -pthread -ldl
+
+all: demo
+
+demo: demo.c
+$(CC) $(CFLAGS) -o $@ $< $(LDLIBS)
+
+clean:
+rm -f demo
+
+.PHONY: all clean

--- a/usr/src/libpathtrans/examples/demo.c
+++ b/usr/src/libpathtrans/examples/demo.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+extern char **environ;
+
+int main(void) {
+    char cwd[256];
+    if (getcwd(cwd, sizeof(cwd)))
+        printf("cwd=%s\n", cwd);
+
+    int fd = open("/tmp/pathtrans_test/orig/file.txt", O_RDONLY);
+    if (fd >= 0) {
+        printf("open success\n");
+        close(fd);
+    }
+
+    if (link("/tmp/pathtrans_test/orig/file.txt",
+             "/tmp/pathtrans_test/orig/link.txt") == 0) {
+        printf("link success\n");
+        unlink("/tmp/pathtrans_test/orig/link.txt");
+    }
+
+    if (chdir("/tmp/pathtrans_test/orig") == 0) {
+        getcwd(cwd, sizeof(cwd));
+        printf("after chdir cwd=%s\n", cwd);
+    }
+
+    char *const argv[] = {"/bin/echo", "demo", NULL};
+    execve("/bin/echo", argv, environ);
+    perror("execve");
+    return 1;
+}

--- a/usr/src/libpathtrans/src/pathtrans.c
+++ b/usr/src/libpathtrans/src/pathtrans.c
@@ -5,10 +5,16 @@
 #include <stdarg.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "path_database.h"
 
 static int (*real_open)(const char *, int, ... ) = NULL;
 static int (*real_stat)(const char *, struct stat *) = NULL;
+static int (*real_link)(const char *, const char *) = NULL;
+static int (*real_unlink)(const char *) = NULL;
+static char *(*real_getcwd)(char *, size_t) = NULL;
+static int (*real_chdir)(const char *) = NULL;
+static int (*real_execve)(const char *, char *const [], char *const []) = NULL;
 
 static __thread int translation_disabled = 0;
 
@@ -21,6 +27,11 @@ __attribute__((constructor))
 static void init(void) {
     real_open = dlsym(RTLD_NEXT, "open");
     real_stat = dlsym(RTLD_NEXT, "stat");
+    real_link = dlsym(RTLD_NEXT, "link");
+    real_unlink = dlsym(RTLD_NEXT, "unlink");
+    real_getcwd = dlsym(RTLD_NEXT, "getcwd");
+    real_chdir = dlsym(RTLD_NEXT, "chdir");
+    real_execve = dlsym(RTLD_NEXT, "execve");
     path_database_init();
 }
 
@@ -68,6 +79,76 @@ int stat(const char *pathname, struct stat *statbuf) {
     int ret;
     translation_disabled = 1;
     ret = real_stat(use_path, statbuf);
+    translation_disabled = 0;
+    return ret;
+}
+
+int link(const char *oldpath, const char *newpath) {
+    const char *use_old = oldpath;
+    const char *use_new = newpath;
+    char buf_old[MAX_PATH_LENGTH];
+    char buf_new[MAX_PATH_LENGTH];
+    if (!is_disabled() && path_needs_translation(oldpath)) {
+        if (translate_path(oldpath, buf_old, sizeof(buf_old)))
+            use_old = buf_old;
+    }
+    if (!is_disabled() && path_needs_translation(newpath)) {
+        if (translate_path(newpath, buf_new, sizeof(buf_new)))
+            use_new = buf_new;
+    }
+    int ret;
+    translation_disabled = 1;
+    ret = real_link(use_old, use_new);
+    translation_disabled = 0;
+    return ret;
+}
+
+int unlink(const char *pathname) {
+    const char *use_path = pathname;
+    char buf[MAX_PATH_LENGTH];
+    if (!is_disabled() && path_needs_translation(pathname)) {
+        if (translate_path(pathname, buf, sizeof(buf)))
+            use_path = buf;
+    }
+    int ret;
+    translation_disabled = 1;
+    ret = real_unlink(use_path);
+    translation_disabled = 0;
+    return ret;
+}
+
+char *getcwd(char *buf, size_t size) {
+    char *ret;
+    translation_disabled = 1;
+    ret = real_getcwd(buf, size);
+    translation_disabled = 0;
+    return ret;
+}
+
+int chdir(const char *path) {
+    const char *use_path = path;
+    char buf[MAX_PATH_LENGTH];
+    if (!is_disabled() && path_needs_translation(path)) {
+        if (translate_path(path, buf, sizeof(buf)))
+            use_path = buf;
+    }
+    int ret;
+    translation_disabled = 1;
+    ret = real_chdir(use_path);
+    translation_disabled = 0;
+    return ret;
+}
+
+int execve(const char *pathname, char *const argv[], char *const envp[]) {
+    const char *use_path = pathname;
+    char buf[MAX_PATH_LENGTH];
+    if (!is_disabled() && path_needs_translation(pathname)) {
+        if (translate_path(pathname, buf, sizeof(buf)))
+            use_path = buf;
+    }
+    int ret;
+    translation_disabled = 1;
+    ret = real_execve(use_path, argv, envp);
     translation_disabled = 0;
     return ret;
 }

--- a/usr/src/libpathtrans/tests/Makefile
+++ b/usr/src/libpathtrans/tests/Makefile
@@ -2,7 +2,8 @@ CC = gcc
 CFLAGS = -Wall -O2
 LDLIBS = -L.. -Wl,-rpath=.. -lpathtrans -pthread -ldl
 
-TARGETS = test_translation test_path_database test_disable_env
+TARGETS = test_translation test_path_database test_disable_env \
+          test_link_unlink test_chdir_getcwd test_execve
 
 all: $(TARGETS)
 
@@ -17,6 +18,15 @@ test_path_database: test_path_database.c
 
 test_disable_env: test_disable_env.c
 	$(CC) $(CFLAGS) -o $@ $^
+
+test_link_unlink: test_link_unlink.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
+test_chdir_getcwd: test_chdir_getcwd.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
+test_execve: test_execve.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
 clean:
 	rm -f $(TARGETS)

--- a/usr/src/libpathtrans/tests/run_tests.sh
+++ b/usr/src/libpathtrans/tests/run_tests.sh
@@ -9,6 +9,9 @@ rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR/orig" "$TMPDIR/new"
 
 echo "data" > "$TMPDIR/new/file.txt"
+echo "#!/bin/sh" > "$TMPDIR/new/prog.sh"
+echo "exit 0" >> "$TMPDIR/new/prog.sh"
+chmod +x "$TMPDIR/new/prog.sh"
 DB="$TMPDIR/db.txt"
 export PATHTRANS_DB="$DB"
 ../tools/pathtrans_db -a "$TMPDIR/orig" "$TMPDIR/new"
@@ -20,6 +23,9 @@ ret=0
 ./test_translation || ret=1
 ./test_path_database || ret=1
 PATHTRANS_DISABLE=1 ./test_disable_env || ret=1
+./test_link_unlink || ret=1
+./test_chdir_getcwd || ret=1
+./test_execve || ret=1
 set -e
 
 rm -rf "$TMPDIR"

--- a/usr/src/libpathtrans/tests/test_chdir_getcwd.c
+++ b/usr/src/libpathtrans/tests/test_chdir_getcwd.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+int main(void) {
+    char buf[256];
+    if (chdir("/tmp/pathtrans_test/orig") != 0) {
+        perror("chdir");
+        return 1;
+    }
+    if (!getcwd(buf, sizeof(buf))) {
+        perror("getcwd");
+        return 1;
+    }
+    if (strstr(buf, "/tmp/pathtrans_test/new") != buf) {
+        fprintf(stderr, "unexpected cwd: %s\n", buf);
+        return 1;
+    }
+    return 0;
+}

--- a/usr/src/libpathtrans/tests/test_execve.c
+++ b/usr/src/libpathtrans/tests/test_execve.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <unistd.h>
+
+extern char **environ;
+
+int main(void) {
+    const char *prog = "/tmp/pathtrans_test/orig/prog.sh";
+    char *const argv[] = {(char *)prog, NULL};
+    execve(prog, argv, environ);
+    perror("execve");
+    return 1;
+}

--- a/usr/src/libpathtrans/tests/test_link_unlink.c
+++ b/usr/src/libpathtrans/tests/test_link_unlink.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(void) {
+    const char *orig = "/tmp/pathtrans_test/orig/file.txt";
+    const char *linkpath = "/tmp/pathtrans_test/orig/link.txt";
+    if (link(orig, linkpath) != 0) {
+        perror("link");
+        return 1;
+    }
+    struct stat st;
+    if (stat(linkpath, &st) != 0) {
+        perror("stat link");
+        return 1;
+    }
+    if (unlink(linkpath) != 0) {
+        perror("unlink");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend libpathtrans with wrappers for link, unlink, getcwd, chdir and execve
- provide example program using the library
- expand tests to cover the new APIs

## Testing
- `./run_tests.sh`