### PR TITLE
Add simple in-memory dir enumeration example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: all inventory test
 
 CAPNP ?= 0
+CC ?= clang
 
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror
@@ -18,7 +19,8 @@ SUBDIRS = \
     src-uland/fs-server \
     src-uland/servers/proc_manager \
     src-uland/init \
-    tests
+    tests \
+    tests/posix
 
 ifeq ($(CAPNP),1)
 SUBDIRS += third_party/libcapnp tools/memserver modern/tests
@@ -26,14 +28,15 @@ endif
 
 all:
 	@for dir in $(SUBDIRS); do \
-	$(MAKE) -C $$dir CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" CAPNP="$(CAPNP)"; \
+		$(MAKE) -C $$dir CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" CC="$(CC)" CAPNP="$(CAPNP)"; \
 	done
-
+	
 inventory:
 	python3 tools/create_inventory.py
 
 test:
 	$(MAKE) -C tests
+	$(MAKE) -C tests/posix
 ifeq ($(CAPNP),1)
 	$(MAKE) -C modern/tests
 endif

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -1,0 +1,21 @@
+#ifndef DIRENT_H
+#define DIRENT_H
+#include <stddef.h>
+
+#define MAXNAMLEN 255
+
+struct dirent {
+    char d_name[MAXNAMLEN + 1];
+};
+
+typedef struct DIR {
+    size_t pos;
+    size_t count;
+    const char **names;
+} DIR;
+
+DIR *memfs_opendir(const char **names, size_t count);
+struct dirent *memfs_readdir(DIR *d);
+int memfs_closedir(DIR *d);
+
+#endif /* DIRENT_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-CC ?= clang
+CC = clang
 CXX ?= clang++
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror

--- a/tests/posix/Makefile
+++ b/tests/posix/Makefile
@@ -1,0 +1,16 @@
+CC=clang
+CFLAGS ?= -O2 -std=c23 -Wall -Werror
+CPPFLAGS = -I../../include
+
+all: dirlist
+
+dirlist: dirlist.o inmemfs.o
+	$(CC) $(CFLAGS) dirlist.o inmemfs.o -o $@
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	 rm -f dirlist dirlist.o inmemfs.o
+
+.PHONY: all clean

--- a/tests/posix/dirlist.c
+++ b/tests/posix/dirlist.c
@@ -1,0 +1,20 @@
+#include "../../include/dirent.h"
+#include <stdio.h>
+
+static const char *root_entries[] = {
+    "foo.txt",
+    "bar",
+    "baz",
+};
+
+int main(void)
+{
+    DIR *d = memfs_opendir(root_entries, sizeof(root_entries)/sizeof(root_entries[0]));
+    if (!d)
+        return 1;
+    struct dirent *de;
+    while ((de = memfs_readdir(d)) != NULL)
+        printf("%s\n", de->d_name);
+    memfs_closedir(d);
+    return 0;
+}

--- a/tests/posix/inmemfs.c
+++ b/tests/posix/inmemfs.c
@@ -1,0 +1,31 @@
+#include "../../include/dirent.h"
+#include <stdlib.h>
+#include <string.h>
+
+DIR *memfs_opendir(const char **names, size_t count)
+{
+    DIR *d = malloc(sizeof(DIR));
+    if (!d)
+        return NULL;
+    d->pos = 0;
+    d->count = count;
+    d->names = names;
+    return d;
+}
+
+struct dirent *memfs_readdir(DIR *d)
+{
+    static struct dirent de;
+    if (d->pos >= d->count)
+        return NULL;
+    strncpy(de.d_name, d->names[d->pos], MAXNAMLEN);
+    de.d_name[MAXNAMLEN] = '\0';
+    d->pos++;
+    return &de;
+}
+
+int memfs_closedir(DIR *d)
+{
+    free(d);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose a minimal `DIR` type in a new `dirent.h`
- implement `memfs_opendir`, `memfs_readdir`, and `memfs_closedir`
- add an example `dirlist.c` program exercising the helper
- build the example via new `tests/posix` directory
- include the posix tests in the main Makefile

## Testing
- `make -C tests/posix clean && make -C tests/posix`
- `make test` *(fails: clang can't find kernel stub libs)*