### PR TITLE
Add execve envp support and spawn/wait demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ SUBDIRS = \
     src-uland/fs-server \
     src-uland/servers/proc_manager \
     src-uland/init \
-    tests
+    tests \
+    tools/spawn_wait_demo
 
 ifeq ($(CAPNP),1)
 SUBDIRS += third_party/libcapnp tools/memserver modern/tests

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -25,6 +25,7 @@ void kern_sched_init(void);
 int kern_open(const char *path, int flags);
 bool kern_vm_fault(void *addr);
 int kern_fork(void);
-int kern_exec(const char *path, char *const argv[]);
+int kern_execve(const char *path, char *const argv[], char *const envp[]);
+int kern_waitpid(int pid, int *status, int options);
 
 #endif /* EXOKERNEL_H */

--- a/src-headers/ipc.h
+++ b/src-headers/ipc.h
@@ -18,6 +18,7 @@ enum ipc_msg_type {
     IPC_MSG_OPEN,
     IPC_MSG_PROC_FORK,
     IPC_MSG_PROC_EXEC,
+    IPC_MSG_PROC_WAITPID,
     IPC_MSG_HEARTBEAT
 };
 

--- a/src-headers/proc_manager.h
+++ b/src-headers/proc_manager.h
@@ -19,6 +19,7 @@ void fixjobc(struct proc *p, struct pgrp *pgrp, int entering);
 void pgrpdump(void);
 
 int pm_fork(void);
-int pm_exec(const char *path, char *const argv[]);
+int pm_execve(const char *path, char *const argv[], char *const envp[]);
+int pm_waitpid(int pid, int *status, int options);
 
 #endif /* PROC_MANAGER_H */

--- a/src-kernel/proc_hooks.c
+++ b/src-kernel/proc_hooks.c
@@ -4,7 +4,8 @@
 #include <exo_ipc.h>
 /* Stubs delegating to user-space process manager */
 extern int pm_fork(void);
-extern int pm_exec(const char *path, char *const argv[]);
+extern int pm_execve(const char *path, char *const argv[], char *const envp[]);
+extern int pm_waitpid(int pid, int *status, int options);
 
 int
 kern_fork(void)
@@ -22,18 +23,36 @@ kern_fork(void)
 }
 
 int
-kern_exec(const char *path, char *const argv[])
+kern_execve(const char *path, char *const argv[], char *const envp[])
 {
     struct ipc_message msg = {
         .type = IPC_MSG_PROC_EXEC,
         .a = (uintptr_t)path,
-        .b = (uintptr_t)argv
+        .b = (uintptr_t)argv,
+        .c = (uintptr_t)envp
     };
     (void)ipc_queue_send(&kern_ipc_queue, &msg);
     struct ipc_message reply;
     struct ipc_mailbox *mb2 = ipc_mailbox_current();
     if (ipc_queue_recv_timed(&mb2->queue, &reply, 1000) == EXO_IPC_OK)
         return (int)reply.a;
-    return pm_exec(path, argv);
+    return pm_execve(path, argv, envp);
+}
+
+int
+kern_waitpid(int pid, int *status, int options)
+{
+    struct ipc_message msg = {
+        .type = IPC_MSG_PROC_WAITPID,
+        .a = (uintptr_t)pid,
+        .b = (uintptr_t)status,
+        .c = (uintptr_t)options
+    };
+    (void)ipc_queue_send(&kern_ipc_queue, &msg);
+    struct ipc_message reply;
+    struct ipc_mailbox *mb = ipc_mailbox_current();
+    if (ipc_queue_recv_timed(&mb->queue, &reply, 1000) == EXO_IPC_OK)
+        return (int)reply.a;
+    return pm_waitpid(pid, status, options);
 }
 

--- a/src-uland/servers/proc_manager/pm_entry.c
+++ b/src-uland/servers/proc_manager/pm_entry.c
@@ -1,5 +1,6 @@
 /* Entry points used by kernel stubs to perform fork and exec in user space. */
 #include <unistd.h>
+#include <sys/wait.h>
 #include "proc_manager.h"
 
 int
@@ -9,7 +10,13 @@ pm_fork(void)
 }
 
 int
-pm_exec(const char *path, char *const argv[])
+pm_execve(const char *path, char *const argv[], char *const envp[])
 {
-    return execv(path, argv);
+    return execve(path, argv, envp);
+}
+
+int
+pm_waitpid(int pid, int *status, int options)
+{
+    return waitpid(pid, status, options);
 }

--- a/tests/include/proc_manager.h
+++ b/tests/include/proc_manager.h
@@ -1,5 +1,6 @@
 #ifndef PROC_MANAGER_H
 #define PROC_MANAGER_H
 int pm_fork(void);
-int pm_exec(const char *path, char *const argv[]);
+int pm_execve(const char *path, char *const argv[], char *const envp[]);
+int pm_waitpid(int pid, int *status, int options);
 #endif

--- a/tests/test_kern.c
+++ b/tests/test_kern.c
@@ -33,7 +33,7 @@ int main(void) {
     if (pid == 0) {
         exit(0);
     } else {
-        int status; waitpid(pid, &status, 0);
+        int status; kern_waitpid(pid, &status, 0);
         if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
             fprintf(stderr, "child failed: pid=%d status=%d\n", pid, status);
             return 1;

--- a/tools/spawn_wait_demo/Makefile
+++ b/tools/spawn_wait_demo/Makefile
@@ -1,0 +1,19 @@
+CC ?= cc
+CFLAGS ?= -O2 -std=c2x -Wall -Werror
+CPPFLAGS ?= -I../../src-headers -I../../include
+LIBS = ../../src-kernel/libkern_stubs.a ../../src-lib/libipc/libipc.a
+	
+PROG = spawn_wait_demo
+
+all: $(PROG)
+
+$(PROG): spawn_wait_demo.o $(LIBS)
+	$(CC) $(CFLAGS) spawn_wait_demo.o $(LIBS) -o $@
+	
+spawn_wait_demo.o: spawn_wait_demo.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f spawn_wait_demo.o $(PROG)
+
+.PHONY: all clean

--- a/tools/spawn_wait_demo/spawn_wait_demo.c
+++ b/tools/spawn_wait_demo/spawn_wait_demo.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "../../tests/include/proc_manager.h"
+#include "../../src-headers/exokernel.h"
+
+int pm_fork(void) { return fork(); }
+int pm_execve(const char *p, char *const a[], char *const e[]) { return execve(p, a, e); }
+int pm_waitpid(int pid, int *st, int opt) { return waitpid(pid, st, opt); }
+
+int main(void)
+{
+    char *argv[] = { "/bin/echo", "spawned", NULL };
+    char *envp[] = { "DEMO=1", NULL };
+
+    int pid = kern_fork();
+    if (pid < 0) {
+        perror("kern_fork");
+        return 1;
+    }
+    if (pid == 0) {
+        kern_execve(argv[0], argv, envp);
+        perror("kern_execve");
+        _exit(1);
+    }
+
+    int status;
+    if (kern_waitpid(pid, &status, 0) < 0) {
+        perror("kern_waitpid");
+        return 1;
+    }
+
+    if (WIFEXITED(status))
+        printf("child exited %d\n", WEXITSTATUS(status));
+
+    return 0;
+}

--- a/usr/src/sys/tests/benchmarks/pipeback.c
+++ b/usr/src/sys/tests/benchmarks/pipeback.c
@@ -6,8 +6,11 @@
  * over a pipe in a request-response fashion.
  */
 
-main(argc, argv)
-	char *argv[];
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
 {
 	char buf[512];
 	int fd[2], fd2[2], msgsize;
@@ -33,14 +36,18 @@ main(argc, argv)
 		perror("pipe");
 		exit(3);
 	}
-	if (fork() == 0)
-		for (i = 0; i < iter; i++) {
-			read(fd[0], buf, msgsize);
-			write(fd2[1], buf, msgsize);
-		}
-	else
-		for (i = 0; i < iter; i++) {
-			write(fd[1], buf, msgsize);
-			read(fd2[0], buf, msgsize);
-		}
+        int pid = fork();
+        if (pid == 0) {
+                for (i = 0; i < iter; i++) {
+                        read(fd[0], buf, msgsize);
+                        write(fd2[1], buf, msgsize);
+                }
+                _exit(0);
+        } else {
+                for (i = 0; i < iter; i++) {
+                        write(fd[1], buf, msgsize);
+                        read(fd2[0], buf, msgsize);
+                }
+                waitpid(pid, NULL, 0);
+        }
 }

--- a/usr/src/sys/tests/benchmarks/pipediscard.c
+++ b/usr/src/sys/tests/benchmarks/pipediscard.c
@@ -3,8 +3,11 @@
  * write and discard using pipes.
  */
 
-main(argc, argv)
-	char *argv[];
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
 {
 	char buf[512];
 	int fd[2], msgsize;
@@ -26,10 +29,14 @@ main(argc, argv)
 		perror("pipe");
 		exit(3);
 	}
-	if (fork() == 0)
-		for (i = 0; i < iter; i++)
-			read(fd[0], buf, msgsize);
-	else
-		for (i = 0; i < iter; i++)
-			write(fd[1], buf, msgsize);
+        int pid = fork();
+        if (pid == 0) {
+                for (i = 0; i < iter; i++)
+                        read(fd[0], buf, msgsize);
+                _exit(0);
+        } else {
+                for (i = 0; i < iter; i++)
+                        write(fd[1], buf, msgsize);
+                waitpid(pid, NULL, 0);
+        }
 }

--- a/usr/src/sys/tests/benchmarks/pipeself.c
+++ b/usr/src/sys/tests/benchmarks/pipeself.c
@@ -3,8 +3,11 @@
  * write to self using pipes.
  */
 
-main(argc, argv)
-	char *argv[];
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
 {
 	char buf[512];
 	int fd[2], msgsize;


### PR DESCRIPTION
## Summary
- support envp in execve stubs and expose in headers
- add kern_waitpid wrapper
- update pipe benchmarks for C23 prototypes and wait
- create a spawn/wait demo program

## Testing
- `make -C src-lib/libipc CFLAGS='-O2 -std=c2x -Wall -Werror'`
- `make -C src-kernel CFLAGS='-O2 -std=c2x -Wall -Werror'`
- `make -C tools/spawn_wait_demo CFLAGS='-O2 -std=c2x -Wall -Werror'`
- `make -C tests CFLAGS='-O2 -std=c2x -Wall -Werror'` *(fails: undefined reference to sched_lock)*