### PR TITLE
Implement FIFO support and tiny VFS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 add_library(ipc STATIC src-lib/libipc/ipc.c)
 target_include_directories(ipc PUBLIC ${CMAKE_SOURCE_DIR}/src-headers)
 
+add_library(posix STATIC src-lib/libposix/posix.c)
+target_include_directories(posix PUBLIC ${CMAKE_SOURCE_DIR}/src-headers)
+
 add_library(kern_stubs STATIC
   src-kernel/proc_hooks.c
   src-kernel/sched_hooks.c

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,12 @@ CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror
 
 SUBDIRS = \
     src-lib/libipc \
+    src-lib/libposix \
     src-lib/libkern_sched \
     src-lib/libvm \
     src-kernel \
     src-uland/libipc \
+    src-uland/libposix \
     src-uland/libkern_sched \
     src-uland/libvm \
     src-uland/fs-server \

--- a/src-headers/posix.h
+++ b/src-headers/posix.h
@@ -1,0 +1,14 @@
+#ifndef POSIX_H
+#define POSIX_H
+
+#include <stddef.h>
+#include <sys/types.h>
+
+int mkfifo(const char *path, int perm);
+int posix_open(const char *path, int flags);
+int posix_dup(int fd);
+ssize_t posix_read(int fd, void *buf, size_t n);
+ssize_t posix_write(int fd, const void *buf, size_t n);
+int posix_close(int fd);
+
+#endif /* POSIX_H */

--- a/src-lib/libposix/Makefile
+++ b/src-lib/libposix/Makefile
@@ -1,0 +1,22 @@
+OBJS = posix.o
+LIB  = libposix.a
+
+CC ?= cc
+AR ?= ar
+CPPFLAGS ?= -I../../src-headers -I../../include
+CFLAGS ?= -O2
+CSTD ?= -std=c23
+CFLAGS += $(CSTD) -Wall -Werror
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $(OBJS)
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/src-lib/libposix/posix.c
+++ b/src-lib/libposix/posix.c
@@ -1,0 +1,210 @@
+#include "posix.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#define MAX_FDS 32
+#define MAX_FIFOS 16
+#define FIFO_BUF_SIZE 1024
+
+enum fd_type { FD_NONE = 0, FD_FILE, FD_FIFO };
+
+struct fifo {
+    char *buf;
+    size_t size;
+    size_t rpos;
+    size_t wpos;
+    int refs;
+    int perm; /* bitmask: 1=read 2=write */
+    const char *name;
+};
+
+struct fd_entry {
+    enum fd_type type;
+    int perm;
+    union {
+        int file;
+        struct fifo *fifo;
+    } u;
+};
+
+static struct fifo fifos[MAX_FIFOS];
+static struct fd_entry fds[MAX_FDS];
+
+static struct fifo *find_fifo(const char *path)
+{
+    for (int i = 0; i < MAX_FIFOS; ++i) {
+        if (fifos[i].name && strcmp(fifos[i].name, path) == 0)
+            return &fifos[i];
+    }
+    return NULL;
+}
+
+int mkfifo(const char *path, int perm)
+{
+    if (find_fifo(path))
+        return -1;
+    for (int i = 0; i < MAX_FIFOS; ++i) {
+        if (!fifos[i].name) {
+            fifos[i].buf = malloc(FIFO_BUF_SIZE);
+            if (!fifos[i].buf)
+                return -1;
+            fifos[i].size = FIFO_BUF_SIZE;
+            fifos[i].rpos = fifos[i].wpos = 0;
+            fifos[i].refs = 0;
+            fifos[i].perm = perm;
+            fifos[i].name = strdup(path);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int alloc_fd(void)
+{
+    for (int i = 0; i < MAX_FDS; ++i) {
+        if (fds[i].type == FD_NONE) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int posix_open(const char *path, int flags)
+{
+    struct fifo *f = find_fifo(path);
+    int perm = 0;
+    if ((flags & O_ACCMODE) == O_RDONLY)
+        perm = 1;
+    else if ((flags & O_ACCMODE) == O_WRONLY)
+        perm = 2;
+    else
+        perm = 3;
+
+    int fd = alloc_fd();
+    if (fd < 0)
+        return -1;
+
+    if (f) {
+        if ((perm & f->perm) != perm)
+            return -1;
+        fds[fd].type = FD_FIFO;
+        fds[fd].perm = perm;
+        fds[fd].u.fifo = f;
+        f->refs++;
+        return fd;
+    }
+
+    int realfd = open(path, flags, 0);
+    if (realfd < 0)
+        return -1;
+    fds[fd].type = FD_FILE;
+    fds[fd].perm = perm;
+    fds[fd].u.file = realfd;
+    return fd;
+}
+
+int posix_dup(int fd)
+{
+    if (fd < 0 || fd >= MAX_FDS || fds[fd].type == FD_NONE)
+        return -1;
+    int newfd = alloc_fd();
+    if (newfd < 0)
+        return -1;
+    fds[newfd] = fds[fd];
+    if (fds[fd].type == FD_FILE) {
+        int dupfd = dup(fds[fd].u.file);
+        if (dupfd < 0)
+            return -1;
+        fds[newfd].u.file = dupfd;
+    } else if (fds[fd].type == FD_FIFO) {
+        fds[fd].u.fifo->refs++;
+    }
+    return newfd;
+}
+
+static size_t fifo_available(struct fifo *f)
+{
+    return f->wpos - f->rpos;
+}
+
+static size_t fifo_space(struct fifo *f)
+{
+    return f->size - (f->wpos - f->rpos);
+}
+
+static ssize_t fifo_read(struct fifo *f, void *buf, size_t n)
+{
+    size_t avail = fifo_available(f);
+    if (avail == 0)
+        return 0;
+    if (n > avail)
+        n = avail;
+    for (size_t i = 0; i < n; ++i)
+        ((char *)buf)[i] = f->buf[(f->rpos + i) % f->size];
+    f->rpos += n;
+    if (f->rpos >= f->size) {
+        f->rpos %= f->size;
+        f->wpos %= f->size;
+    }
+    return (ssize_t)n;
+}
+
+static ssize_t fifo_write(struct fifo *f, const void *buf, size_t n)
+{
+    size_t space = fifo_space(f);
+    if (space == 0)
+        return 0;
+    if (n > space)
+        n = space;
+    for (size_t i = 0; i < n; ++i)
+        f->buf[(f->wpos + i) % f->size] = ((const char *)buf)[i];
+    f->wpos += n;
+    if (f->wpos >= f->size) {
+        f->rpos %= f->size;
+        f->wpos %= f->size;
+    }
+    return (ssize_t)n;
+}
+
+ssize_t posix_read(int fd, void *buf, size_t n)
+{
+    if (fd < 0 || fd >= MAX_FDS || fds[fd].type == FD_NONE)
+        return -1;
+    if (!(fds[fd].perm & 1))
+        return -1;
+    if (fds[fd].type == FD_FILE)
+        return read(fds[fd].u.file, buf, n);
+    return fifo_read(fds[fd].u.fifo, buf, n);
+}
+
+ssize_t posix_write(int fd, const void *buf, size_t n)
+{
+    if (fd < 0 || fd >= MAX_FDS || fds[fd].type == FD_NONE)
+        return -1;
+    if (!(fds[fd].perm & 2))
+        return -1;
+    if (fds[fd].type == FD_FILE)
+        return write(fds[fd].u.file, buf, n);
+    return fifo_write(fds[fd].u.fifo, buf, n);
+}
+
+int posix_close(int fd)
+{
+    if (fd < 0 || fd >= MAX_FDS || fds[fd].type == FD_NONE)
+        return -1;
+    if (fds[fd].type == FD_FILE) {
+        close(fds[fd].u.file);
+    } else if (fds[fd].type == FD_FIFO) {
+        if (--fds[fd].u.fifo->refs == 0) {
+            free(fds[fd].u.fifo->buf);
+            free((char *)fds[fd].u.fifo->name);
+            memset(fds[fd].u.fifo, 0, sizeof(struct fifo));
+        }
+    }
+    fds[fd].type = FD_NONE;
+    return 0;
+}
+

--- a/src-uland/libposix/Makefile
+++ b/src-uland/libposix/Makefile
@@ -1,0 +1,24 @@
+LIB  = libposix.a
+DIR = ../../src-lib/libposix
+LIBFILE = $(DIR)/libposix.a
+
+CC ?= cc
+AR ?= ar
+CPPFLAGS ?= -I../../src-headers -I../../include
+CFLAGS ?= -O2
+CSTD ?= -std=c23
+CFLAGS += $(CSTD) -Wall -Werror
+
+all: $(LIBFILE) $(LIB)
+
+$(LIB): $(LIBFILE)
+	cp $(LIBFILE) $(LIB)
+
+$(LIBFILE):
+	$(MAKE) -C $(DIR)
+
+clean:
+	rm -f $(LIB)
+	$(MAKE) -C $(DIR) clean
+
+.PHONY: all clean

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,22 +2,27 @@ CC ?= clang
 CXX ?= clang++
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror
-CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel -I../include
-LIBS = ../src-kernel/libkern_stubs.a ../src-lib/libipc/libipc.a
-
+	CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel -I../include
+LIBS = ../src-kernel/libkern_stubs.a ../src-lib/libipc/libipc.a \
+	       ../src-lib/libposix/libposix.a
+	
 OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o sched_stub.o mock_vm.o
-MAILBOX_OBJS = test_mailbox.o
+FIFO_OBJS = fifo_test.o
+	MAILBOX_OBJS = test_mailbox.o
 
-all: test_kern spinlock_cpp mailbox_test
+all: test_kern spinlock_cpp mailbox_test fifo_test
 
 test_kern: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LIBS) -o $@
-
+	
 spinlock_cpp: test_spinlock.o
 	$(CXX) $(CXXFLAGS) test_spinlock.o -o $@
 
 mailbox_test: $(MAILBOX_OBJS)
 	$(CC) $(CFLAGS) $(MAILBOX_OBJS) $(LIBS) -o $@
+
+fifo_test: $(FIFO_OBJS)
+	$(CC) $(CFLAGS) $(FIFO_OBJS) $(LIBS) -o $@
 
 fs_open.o: ../src-uland/fs-server/fs_open.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
@@ -37,10 +42,13 @@ sched_stub.o: sched_stub.c
 test_mailbox.o: test_mailbox.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
+fifo_test.o: fifo_test.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
 test_spinlock.o: test_spinlock.cpp
 	$(CXX) $(CXXFLAGS) -I../src-headers -c $< -o $@
 
 clean:
-	rm -f $(OBJS) $(MAILBOX_OBJS) test_kern spinlock_cpp mailbox_test test_spinlock.o
+	rm -f $(OBJS) $(MAILBOX_OBJS) $(FIFO_OBJS) test_kern spinlock_cpp mailbox_test fifo_test test_spinlock.o
 
 .PHONY: all clean

--- a/tests/fifo_test.c
+++ b/tests/fifo_test.c
@@ -1,0 +1,40 @@
+#include "posix.h"
+#include <string.h>
+#include <stdio.h>
+#include <fcntl.h>
+
+int main(void)
+{
+    if (mkfifo("fifo1", 3) != 0) {
+        perror("mkfifo");
+        return 1;
+    }
+
+    int w = posix_open("fifo1", O_WRONLY);
+    int r = posix_open("fifo1", O_RDONLY);
+    if (w < 0 || r < 0) {
+        perror("posix_open");
+        return 1;
+    }
+
+    const char msg[] = "hello";
+    if (posix_write(w, msg, sizeof(msg)) != sizeof(msg)) {
+        fprintf(stderr, "write failed\n");
+        return 1;
+    }
+
+    char buf[16];
+    if (posix_read(r, buf, sizeof(msg)) != sizeof(msg)) {
+        fprintf(stderr, "read failed\n");
+        return 1;
+    }
+
+    if (memcmp(buf, msg, sizeof(msg)) != 0) {
+        fprintf(stderr, "data mismatch\n");
+        return 1;
+    }
+
+    posix_close(w);
+    posix_close(r);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- provide a small POSIX wrapper library
- expose FIFO APIs in new header
- hook new library into build
- extend tests with a fifo example

## Testing
- `make CC=clang -C src-lib/libposix`
- `make CC=clang -C src-uland/libposix`
- `make CC=clang -C tests` *(fails: libkern_stubs.a missing)*