### PR TITLE
Add posix mapping wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,12 @@ SUBDIRS = \
     src-lib/libipc \
     src-lib/libkern_sched \
     src-lib/libvm \
+    src-lib/posix \
     src-kernel \
     src-uland/libipc \
     src-uland/libkern_sched \
     src-uland/libvm \
+    src-uland/posix \
     src-uland/fs-server \
     src-uland/servers/proc_manager \
     src-uland/init \

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -3,15 +3,21 @@ CPPFLAGS ?= -I../../third_party/libcapnp
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 LIBS = ../../third_party/libcapnp/libcapnp.a
 
-all: memserver_test
+all: memserver_test mprotect_demo
 
 memserver_test: memserver_test.o $(LIBS)
 $(CC) $(CFLAGS) memserver_test.o $(LIBS) -o $@
 
+mprotect_demo: mprotect_demo.o ../../src-lib/posix/libposix.a
+$(CC) $(CFLAGS) mprotect_demo.o ../../src-lib/posix/libposix.a -o $@
+
 memserver_test.o: memserver_test.c
 $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
+mprotect_demo.o: mprotect_demo.c
+$(CC) -I../../src-headers -I../../include $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
 clean:
-rm -f memserver_test.o memserver_test
+rm -f memserver_test.o memserver_test mprotect_demo.o mprotect_demo
 
 .PHONY: all clean

--- a/modern/tests/mprotect_demo.c
+++ b/modern/tests/mprotect_demo.c
@@ -1,0 +1,26 @@
+#include "posix.h"
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+
+int main(void)
+{
+    void *p = posix_mmap(NULL, 4096, PROT_READ|PROT_WRITE,
+                         MAP_ANON|MAP_PRIVATE, -1, 0);
+    if (p == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+    strcpy(p, "demo");
+    if (posix_mprotect(p, 4096, PROT_READ) != 0) {
+        perror("mprotect");
+        return 1;
+    }
+    if (posix_msync(p, 4096, MS_SYNC) != 0) {
+        perror("msync");
+        return 1;
+    }
+    posix_munmap(p, 4096);
+    printf("demo ok\n");
+    return 0;
+}

--- a/src-headers/posix.h
+++ b/src-headers/posix.h
@@ -1,0 +1,14 @@
+#pragma once
+#ifndef POSIX_H
+#define POSIX_H
+
+#include <stddef.h>
+#include <sys/types.h>
+
+void *posix_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+int posix_munmap(void *addr, size_t len);
+int posix_mprotect(void *addr, size_t len, int prot);
+int posix_msync(void *addr, size_t len, int flags);
+int posix_get_prot(void *addr);
+
+#endif /* POSIX_H */

--- a/src-lib/posix/Makefile
+++ b/src-lib/posix/Makefile
@@ -1,0 +1,22 @@
+OBJS = posix.o
+LIB  = libposix.a
+
+CC ?= cc
+AR ?= ar
+CPPFLAGS ?= -I../../src-headers -I../../include
+CFLAGS ?= -O2
+CSTD ?= -std=c23
+CFLAGS += $(CSTD) -Wall -Werror
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $(OBJS)
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/src-lib/posix/posix.c
+++ b/src-lib/posix/posix.c
@@ -1,0 +1,80 @@
+#include "posix.h"
+#include <sys/mman.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#define MAX_MAPS 128
+
+struct mapping {
+    void *addr;
+    size_t len;
+    int prot;
+    bool used;
+};
+
+static struct mapping maps[MAX_MAPS];
+
+static struct mapping *find_mapping(void *addr, size_t len)
+{
+    for (int i = 0; i < MAX_MAPS; ++i) {
+        if (!maps[i].used)
+            continue;
+        char *start = maps[i].addr;
+        char *end = start + maps[i].len;
+        char *a = addr;
+        char *b = a + len;
+        if (a >= start && b <= end)
+            return &maps[i];
+    }
+    return NULL;
+}
+
+void *posix_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
+{
+    void *p = mmap(addr, len, prot, flags, fd, off);
+    if (p == MAP_FAILED)
+        return p;
+    for (int i = 0; i < MAX_MAPS; ++i) {
+        if (!maps[i].used) {
+            maps[i].addr = p;
+            maps[i].len = len;
+            maps[i].prot = prot;
+            maps[i].used = true;
+            break;
+        }
+    }
+    return p;
+}
+
+int posix_munmap(void *addr, size_t len)
+{
+    int r = munmap(addr, len);
+    if (r == 0) {
+        struct mapping *m = find_mapping(addr, len);
+        if (m)
+            m->used = false;
+    }
+    return r;
+}
+
+int posix_mprotect(void *addr, size_t len, int prot)
+{
+    int r = mprotect(addr, len, prot);
+    if (r == 0) {
+        struct mapping *m = find_mapping(addr, len);
+        if (m)
+            m->prot = prot;
+    }
+    return r;
+}
+
+int posix_msync(void *addr, size_t len, int flags)
+{
+    return msync(addr, len, flags);
+}
+
+int posix_get_prot(void *addr)
+{
+    struct mapping *m = find_mapping(addr, 0);
+    return m ? m->prot : -1;
+}

--- a/src-uland/posix/Makefile
+++ b/src-uland/posix/Makefile
@@ -1,0 +1,24 @@
+LIB = libposix.a
+LIBDIR = ../../src-lib/posix
+LIBFILE = $(LIBDIR)/libposix.a
+
+CC ?= cc
+AR ?= ar
+CPPFLAGS ?= -I../../src-headers -I../../include
+CFLAGS ?= -O2
+CSTD ?= -std=c23
+CFLAGS += $(CSTD) -Wall -Werror
+
+all: $(LIBFILE) $(LIB)
+
+$(LIB): $(LIBFILE)
+	cp $(LIBFILE) $(LIB)
+
+$(LIBFILE):
+	$(MAKE) -C $(LIBDIR)
+
+clean:
+	rm -f $(LIB)
+	$(MAKE) -C $(LIBDIR) clean
+
+.PHONY: all clean

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,9 +3,9 @@ CXX ?= clang++
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror
 CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel -I../include
-LIBS = ../src-kernel/libkern_stubs.a ../src-lib/libipc/libipc.a
+LIBS = ../src-kernel/libkern_stubs.a ../src-lib/libipc/libipc.a ../src-lib/posix/libposix.a
 
-OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o sched_stub.o mock_vm.o
+OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o posix.o sched_stub.o mock_vm.o
 MAILBOX_OBJS = test_mailbox.o
 
 all: test_kern spinlock_cpp mailbox_test
@@ -27,6 +27,9 @@ pm_entry.o: ../src-uland/servers/proc_manager/pm_entry.c
 
 vm_entry.o: ../src-lib/libvm/vm_entry.c
 	$(CC) -I../tests/include $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+posix.o: ../src-lib/posix/posix.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 mock_vm.o: mock_vm.c
 	$(CC) -I../tests/include $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
## Summary
- add simple libposix with mmap/mprotect/msync wrappers
- track protection flags per mapping
- expose prototypes through new header
- update compatibility tests to use the wrappers
- include demonstration program

## Testing
- `make -C src-lib/posix` *(fails: unrecognized command-line option ‘-std=c23’)*
- `make -C tests` *(fails: unrecognized command-line option ‘-std=c23’)*