### PR TITLE
Add minimal pthread compatibility layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 add_library(ipc STATIC src-lib/libipc/ipc.c)
 target_include_directories(ipc PUBLIC ${CMAKE_SOURCE_DIR}/src-headers)
 
+add_library(pthread_compat STATIC src-lib/pthread/pthread.c)
+target_include_directories(pthread_compat PUBLIC ${CMAKE_SOURCE_DIR}/src-headers)
+
 add_library(kern_stubs STATIC
   src-kernel/proc_hooks.c
   src-kernel/sched_hooks.c

--- a/docs/posix_compat.md
+++ b/docs/posix_compat.md
@@ -1,0 +1,11 @@
+# POSIX Compatibility Notes
+
+This repository provides a minimal pthread implementation under
+`src-lib/pthread`.  The current code uses `fork()` and `waitpid()` to
+simulate thread creation and joining.  Only `pthread_create()` and
+`pthread_join()` are available and thread attributes are ignored.
+
+This stub is sufficient for simple test programs but lacks most of the
+POSIX thread semantics such as detached state, mutexes and condition
+variables.  Future work may replace the process based approach with a
+true threading model.

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,9 @@ endif
 libipc = static_library('ipc', 'src-lib/libipc/ipc.c',
                         include_directories : include_directories('src-headers'))
 
+libpthread = static_library('pthread_compat', 'src-lib/pthread/pthread.c',
+                            include_directories : include_directories('src-headers'))
+
 kern_srcs = [
   'src-kernel/proc_hooks.c',
   'src-kernel/sched_hooks.c',

--- a/src-headers/pthread.h
+++ b/src-headers/pthread.h
@@ -1,0 +1,17 @@
+#pragma once
+#ifndef TARANTULA_PTHREAD_H
+#define TARANTULA_PTHREAD_H
+
+#include <unistd.h>
+
+typedef struct {
+    pid_t pid;
+} pthread_t;
+
+typedef int pthread_attr_t;
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg);
+int pthread_join(pthread_t thread, void **retval);
+
+#endif /* TARANTULA_PTHREAD_H */

--- a/src-lib/pthread/Makefile
+++ b/src-lib/pthread/Makefile
@@ -1,0 +1,22 @@
+OBJS = pthread.o
+LIB  = libpthread_compat.a
+
+CC ?= cc
+AR ?= ar
+CFLAGS ?= -O2
+CSTD ?= -std=c23
+CPPFLAGS ?= -I../../src-headers
+CFLAGS   += $(CSTD) -Wall -Werror
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+$(AR) rcs $@ $(OBJS)
+
+%.o: %.c
+$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/src-lib/pthread/pthread.c
+++ b/src-lib/pthread/pthread.c
@@ -1,0 +1,25 @@
+#include "pthread.h"
+#include <sys/wait.h>
+#include <unistd.h>
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg) {
+    (void)attr; /* attributes unused */
+    pid_t pid = fork();
+    if (pid < 0)
+        return -1;
+    if (pid == 0) {
+        start_routine(arg);
+        _exit(0);
+    }
+    thread->pid = pid;
+    return 0;
+}
+
+int pthread_join(pthread_t thread, void **retval) {
+    (void)retval; /* return value ignored */
+    int status;
+    if (waitpid(thread.pid, &status, 0) < 0)
+        return -1;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement simple process-based pthread_create and pthread_join
- expose new API in `src-headers/pthread.h`
- document limitations in `docs/posix_compat.md`
- build new library `pthread_compat` via Makefile, CMake and Meson

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build` *(fails: missing dependencies)*