### PR TITLE
Add nanosleep timer library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,12 @@ SUBDIRS = \
     src-lib/libipc \
     src-lib/libkern_sched \
     src-lib/libvm \
+    src-lib/libtimer \
     src-kernel \
     src-uland/libipc \
     src-uland/libkern_sched \
     src-uland/libvm \
+    src-uland/libtimer \
     src-uland/fs-server \
     src-uland/servers/proc_manager \
     src-uland/init \

--- a/docs/timer_library.md
+++ b/docs/timer_library.md
@@ -1,0 +1,11 @@
+# Timer Library
+
+The timer library implements a small wrapper around `nanosleep()` and
+records the total time each process has slept.  The implementation lives
+in `src-lib/libtimer/timer.c` with headers under `src-headers/timer.h`.
+
+## Usage
+
+Call `timer_init()` once at startup.  Use `nanosleep()` as usual.  The
+nanoseconds a process has slept can be queried with
+`timer_get_sleep(pid)`.

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,9 @@ endif
 libipc = static_library('ipc', 'src-lib/libipc/ipc.c',
                         include_directories : include_directories('src-headers'))
 
+libtimer = static_library('timer', 'src-lib/libtimer/timer.c',
+                         include_directories : include_directories('src-headers'))
+
 kern_srcs = [
   'src-kernel/proc_hooks.c',
   'src-kernel/sched_hooks.c',
@@ -38,4 +41,8 @@ executable('fs_server', fs_srcs,
                                                     'sys/i386/include'),
            c_args : ['-DKERNEL'],
            link_with : libipc)
+
+executable('timer_test', 'tests/test_timer.c',
+           include_directories : include_directories('src-headers', 'tests/include'),
+           link_with : [libtimer, libipc, libkern])
 

--- a/src-headers/timer.h
+++ b/src-headers/timer.h
@@ -1,0 +1,12 @@
+#pragma once
+#ifndef TIMER_H
+#define TIMER_H
+
+#include <stdint.h>
+#include <sys/types.h>
+
+void timer_init(void);
+void timer_add_sleep(pid_t pid, uint64_t ns);
+uint64_t timer_get_sleep(pid_t pid);
+
+#endif /* TIMER_H */

--- a/src-lib/libtimer/Makefile
+++ b/src-lib/libtimer/Makefile
@@ -1,0 +1,22 @@
+OBJS = timer.o
+LIB  = libtimer.a
+
+CC ?= cc
+AR ?= ar
+CPPFLAGS ?= -I../../src-headers -I../../include
+CFLAGS ?= -O2
+CSTD ?= -std=c23
+CFLAGS += $(CSTD) -Wall -Werror
+
+all: $(LIB)
+	
+$(LIB): $(OBJS)
+$(AR) rcs $@ $(OBJS)
+	
+%.o: %.c
+$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	
+clean:
+rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/src-lib/libtimer/timer.c
+++ b/src-lib/libtimer/timer.c
@@ -1,0 +1,91 @@
+#include "timer.h"
+#include "spinlock.h"
+#include <time.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define MAX_PROC_TIMERS 32
+
+struct proc_timer {
+    pid_t pid;
+    unsigned long long ns;
+};
+
+static struct proc_timer timers[MAX_PROC_TIMERS];
+SPINLOCK_DEFINE(timer_lock);
+
+void timer_init(void)
+{
+    for (int i = 0; i < MAX_PROC_TIMERS; ++i)
+        timers[i].pid = -1;
+    spinlock_init(&timer_lock);
+}
+
+static struct proc_timer *lookup_timer(pid_t pid)
+{
+    for (int i = 0; i < MAX_PROC_TIMERS; ++i) {
+        if (timers[i].pid == pid)
+            return &timers[i];
+    }
+    for (int i = 0; i < MAX_PROC_TIMERS; ++i) {
+        if (timers[i].pid == -1) {
+            timers[i].pid = pid;
+            timers[i].ns = 0;
+            return &timers[i];
+        }
+    }
+    return NULL;
+}
+
+void timer_add_sleep(pid_t pid, unsigned long long ns)
+{
+    SCOPED_SPINLOCK(g, &timer_lock);
+    struct proc_timer *t = lookup_timer(pid);
+    if (t)
+        t->ns += ns;
+}
+
+unsigned long long timer_get_sleep(pid_t pid)
+{
+    SCOPED_SPINLOCK(g, &timer_lock);
+    struct proc_timer *t = lookup_timer(pid);
+    return t ? t->ns : 0;
+}
+
+static unsigned long long diff_ns(const struct timespec *a, const struct timespec *b)
+{
+    return (b->tv_sec - a->tv_sec) * 1000000000ull + (b->tv_nsec - a->tv_nsec);
+}
+
+int nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    if (!req) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    struct timespec ts = *req;
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    int err;
+    do {
+        err = clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, &ts);
+    } while (err == EINTR);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    if (err) {
+        if (rem)
+            *rem = ts;
+        errno = err;
+        return -1;
+    }
+
+    if (rem) {
+        rem->tv_sec = 0;
+        rem->tv_nsec = 0;
+    }
+
+    timer_add_sleep(getpid(), diff_ns(&start, &end));
+    return 0;
+}
+

--- a/src-uland/libtimer/Makefile
+++ b/src-uland/libtimer/Makefile
@@ -1,0 +1,24 @@
+LIB = libtimer.a
+LIBDIR = ../../src-lib/libtimer
+LIBFILE = $(LIBDIR)/libtimer.a
+
+CC ?= cc
+AR ?= ar
+CPPFLAGS ?= -I../../src-headers -I../../include
+CFLAGS ?= -O2
+CSTD ?= -std=c23
+CFLAGS += $(CSTD) -Wall -Werror
+
+all: $(LIBFILE) $(LIB)
+
+$(LIB): $(LIBFILE)
+cp $(LIBFILE) $(LIB)
+
+$(LIBFILE):
+$(MAKE) -C $(LIBDIR)
+
+clean:
+rm -f $(LIB)
+$(MAKE) -C $(LIBDIR) clean
+
+.PHONY: all clean

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,12 +3,14 @@ CXX ?= clang++
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror
 CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel -I../include
-LIBS = ../src-kernel/libkern_stubs.a ../src-lib/libipc/libipc.a
+LIBS = ../src-kernel/libkern_stubs.a ../src-lib/libipc/libipc.a \
+       ../src-lib/libtimer/libtimer.a
 
 OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o sched_stub.o mock_vm.o
 MAILBOX_OBJS = test_mailbox.o
+TIMER_OBJS = test_timer.o
 
-all: test_kern spinlock_cpp mailbox_test
+all: test_kern spinlock_cpp mailbox_test timer_test
 
 test_kern: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LIBS) -o $@
@@ -18,6 +20,9 @@ spinlock_cpp: test_spinlock.o
 
 mailbox_test: $(MAILBOX_OBJS)
 	$(CC) $(CFLAGS) $(MAILBOX_OBJS) $(LIBS) -o $@
+
+timer_test: $(TIMER_OBJS)
+	$(CC) $(CFLAGS) $(TIMER_OBJS) $(LIBS) -o $@
 
 fs_open.o: ../src-uland/fs-server/fs_open.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
@@ -40,7 +45,11 @@ test_mailbox.o: test_mailbox.c
 test_spinlock.o: test_spinlock.cpp
 	$(CXX) $(CXXFLAGS) -I../src-headers -c $< -o $@
 
+test_timer.o: test_timer.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
 clean:
-	rm -f $(OBJS) $(MAILBOX_OBJS) test_kern spinlock_cpp mailbox_test test_spinlock.o
+rm -f $(OBJS) $(MAILBOX_OBJS) $(TIMER_OBJS) \
+      test_kern spinlock_cpp mailbox_test timer_test test_spinlock.o
 
 .PHONY: all clean

--- a/tests/test_timer.c
+++ b/tests/test_timer.c
@@ -1,0 +1,21 @@
+#include "timer.h"
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(void)
+{
+    timer_init();
+    struct timespec ts = { .tv_sec = 0, .tv_nsec = 50000000 }; /* 50ms */
+    if (nanosleep(&ts, NULL) != 0) {
+        perror("nanosleep");
+        return 1;
+    }
+    unsigned long long ns = timer_get_sleep(getpid());
+    if (ns < 50000000ull) {
+        printf("timer tracking failed: %llu\n", ns);
+        return 1;
+    }
+    printf("timer ok\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement `nanosleep()` wrapper with per-process accounting
- expose timer helpers in a new header
- compile timer test program via Makefile and Meson
- document the new timer library

## Testing
- `make -j$(nproc)` *(fails: unrecognized compiler option or missing deps)*
- `make CC=clang -j$(nproc)` *(fails: missing system headers)*
- `meson setup build` *(fails: command not found)*