### PR TITLE
Add basic POSIX IPC wrappers

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -99,3 +99,27 @@ int capnp_parse(const char *buf, size_t len, struct capnp_message *msg);
 The `tools/memserver` program links against this stub.  It loads a file into
 memory and prints the parsed message size.  A basic regression test lives under
 `modern/tests` and is built automatically when `CAPNP=1` is supplied to `make`.
+
+## POSIX IPC Wrappers
+
+`libipc` also provides lightweight wrappers around the standard POSIX
+message queue, semaphore and shared memory APIs.  The functions accept a
+directory file descriptor as their first argument to support future
+capability-based restrictions.  The current implementation simply calls
+the regular POSIX routines.
+
+```c
+mqd_t cap_mq_open(int dirfd, const char *name, int oflag, mode_t mode,
+                  struct mq_attr *attr);
+int   cap_mq_unlink(int dirfd, const char *name);
+
+sem_t *cap_sem_open(int dirfd, const char *name, int oflag, mode_t mode,
+                    unsigned value);
+int   cap_sem_unlink(int dirfd, const char *name);
+
+int cap_shm_open(int dirfd, const char *name, int oflag, mode_t mode);
+int cap_shm_unlink(int dirfd, const char *name);
+```
+
+The program `modern/tests/posix_ipc_demo.c` demonstrates basic usage of
+these helpers.

--- a/meson.build
+++ b/meson.build
@@ -39,3 +39,9 @@ executable('fs_server', fs_srcs,
            c_args : ['-DKERNEL'],
            link_with : libipc)
 
+executable('posix_ipc_demo',
+           'modern/tests/posix_ipc_demo.c',
+           include_directories : include_directories('src-headers'),
+           link_with : libipc,
+           link_args : ['-lrt'])
+

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -1,9 +1,9 @@
 CC ?= cc
-CPPFLAGS ?= -I../../third_party/libcapnp
+CPPFLAGS ?= -I../../src-headers -I../../third_party/libcapnp
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
 LIBS = ../../third_party/libcapnp/libcapnp.a
 
-all: memserver_test
+all: memserver_test posix_ipc_demo
 
 memserver_test: memserver_test.o $(LIBS)
 $(CC) $(CFLAGS) memserver_test.o $(LIBS) -o $@
@@ -11,7 +11,13 @@ $(CC) $(CFLAGS) memserver_test.o $(LIBS) -o $@
 memserver_test.o: memserver_test.c
 $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
+posix_ipc_demo: posix_ipc_demo.o
+$(CC) $(CFLAGS) posix_ipc_demo.o -lrt -o $@
+
+posix_ipc_demo.o: posix_ipc_demo.c
+$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
 clean:
-rm -f memserver_test.o memserver_test
+rm -f memserver_test.o memserver_test posix_ipc_demo.o posix_ipc_demo
 
 .PHONY: all clean

--- a/modern/tests/posix_ipc_demo.c
+++ b/modern/tests/posix_ipc_demo.c
@@ -1,0 +1,27 @@
+#include "../../src-headers/posix_ipc.h"
+#include <assert.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <semaphore.h>
+
+int main(void)
+{
+    mqd_t mq = cap_mq_open(AT_FDCWD, "/demo_q", O_CREAT | O_RDWR, 0600, NULL);
+    assert(mq != (mqd_t)-1);
+    assert(cap_mq_unlink(AT_FDCWD, "/demo_q") == 0);
+    assert(mq_close(mq) == 0);
+
+    sem_t *sem = cap_sem_open(AT_FDCWD, "/demo_sem", O_CREAT, 0600, 1);
+    assert(sem != SEM_FAILED);
+    assert(sem_post(sem) == 0);
+    assert(sem_close(sem) == 0);
+    assert(cap_sem_unlink(AT_FDCWD, "/demo_sem") == 0);
+
+    int fd = cap_shm_open(AT_FDCWD, "/demo_shm", O_CREAT | O_RDWR, 0600);
+    assert(fd >= 0);
+    assert(cap_shm_unlink(AT_FDCWD, "/demo_shm") == 0);
+    assert(close(fd) == 0);
+
+    return 0;
+}

--- a/src-headers/posix_ipc.h
+++ b/src-headers/posix_ipc.h
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef POSIX_IPC_H
+#define POSIX_IPC_H
+
+#include <mqueue.h>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+
+mqd_t cap_mq_open(int dirfd, const char *name, int oflag, mode_t mode,
+                  struct mq_attr *attr);
+int   cap_mq_unlink(int dirfd, const char *name);
+
+sem_t *cap_sem_open(int dirfd, const char *name, int oflag, mode_t mode,
+                    unsigned value);
+int    cap_sem_unlink(int dirfd, const char *name);
+
+int cap_shm_open(int dirfd, const char *name, int oflag, mode_t mode);
+int cap_shm_unlink(int dirfd, const char *name);
+
+#endif /* POSIX_IPC_H */

--- a/src-lib/libipc/ipc.c
+++ b/src-lib/libipc/ipc.c
@@ -111,3 +111,47 @@ struct ipc_mailbox *ipc_mailbox_current(void)
 {
     return ipc_mailbox_lookup(getpid());
 }
+
+#include "posix_ipc.h"
+#include <mqueue.h>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+
+mqd_t cap_mq_open(int dirfd, const char *name, int oflag, mode_t mode,
+                  struct mq_attr *attr)
+{
+    (void)dirfd;
+    return mq_open(name, oflag, mode, attr);
+}
+
+int cap_mq_unlink(int dirfd, const char *name)
+{
+    (void)dirfd;
+    return mq_unlink(name);
+}
+
+sem_t *cap_sem_open(int dirfd, const char *name, int oflag, mode_t mode,
+                    unsigned value)
+{
+    (void)dirfd;
+    return sem_open(name, oflag, mode, value);
+}
+
+int cap_sem_unlink(int dirfd, const char *name)
+{
+    (void)dirfd;
+    return sem_unlink(name);
+}
+
+int cap_shm_open(int dirfd, const char *name, int oflag, mode_t mode)
+{
+    (void)dirfd;
+    return shm_open(name, oflag, mode);
+}
+
+int cap_shm_unlink(int dirfd, const char *name)
+{
+    (void)dirfd;
+    return shm_unlink(name);
+}


### PR DESCRIPTION
## Summary
- define capability-based POSIX IPC prototypes in a new header
- implement minimal wrappers in libipc
- build a demo program under `modern/tests`
- hook the demo into Meson
- document the new helpers

## Testing
- `cmake -S . -B build -G Ninja` *(fails: exo_ipc.h missing)*
- `cmake --build build` *(fails to compile fs_server due to missing headers)*