### PR TITLE
Fix kernel Meson source list

### DIFF
--- a/src-kernel/meson.build
+++ b/src-kernel/meson.build
@@ -2,7 +2,6 @@ project('kern_stubs', 'c', default_options : ['c_std=c23'])
 add_project_arguments('-Wall', '-Werror', language : 'c')
 
 srcs = ['proc_hooks.c', 'sched_hooks.c', 'vm_hooks.c', 'vfs_hooks.c']
-srcs += ['ipc.c']
 libkern = static_library('kern_stubs', srcs,
                          include_directories : include_directories('../src-headers'))
 


### PR DESCRIPTION
## Summary
- remove stale `ipc.c` entry from `src-kernel/meson.build`

## Testing
- `make CC=clang -C src-kernel`
- `make CC=clang CXX=clang++ -C tests` *(fails: undefined reference to `sched_lock`)*
