### PR TITLE
Add POSIX signal helpers

### DIFF
--- a/docs/posix_signals.md
+++ b/docs/posix_signals.md
@@ -1,0 +1,14 @@
+# POSIX signal helpers
+
+`libposix` wraps a few signal-related system calls to keep the interface
+uniform across platforms.
+
+```c
+int posix_sigaction(int signum, const struct sigaction *act,
+                    struct sigaction *oldact);
+int posix_sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+int posix_killpg(int pgrp, int sig);
+```
+
+The program `modern/tests/posix_signal_demo.c` demonstrates installing a
+custom handler and sending a signal to the current process group.

--- a/modern/tests/posix_signal_demo.c
+++ b/modern/tests/posix_signal_demo.c
@@ -1,0 +1,33 @@
+#define _DEFAULT_SOURCE
+#define _XOPEN_SOURCE 700
+#include "../../src-headers/posix_signal.h"
+#include <assert.h>
+#include <unistd.h>
+#include <signal.h>
+
+static volatile sig_atomic_t got;
+
+static void handler(int signo)
+{
+    (void)signo;
+    got = 1;
+}
+
+int main(void)
+{
+    struct sigaction sa = {0};
+    sa.sa_handler = handler;
+    sigemptyset(&sa.sa_mask);
+    assert(posix_sigaction(SIGUSR1, &sa, NULL) == 0);
+
+    assert(posix_killpg(getpgrp(), SIGUSR1) == 0);
+    for (int i = 0; i < 100 && !got; ++i)
+        usleep(1000);
+    assert(got);
+
+    sigset_t set;
+    sigemptyset(&set);
+    assert(posix_sigprocmask(SIG_BLOCK, &set, NULL) == 0);
+
+    return 0;
+}

--- a/src-headers/posix_signal.h
+++ b/src-headers/posix_signal.h
@@ -1,0 +1,14 @@
+#ifndef POSIX_SIGNAL_H
+#define POSIX_SIGNAL_H
+
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+#endif
+#include <signal.h>
+
+int posix_sigaction(int signum, const struct sigaction *act,
+                    struct sigaction *oldact);
+int posix_sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+int posix_killpg(int pgrp, int sig);
+
+#endif /* POSIX_SIGNAL_H */

--- a/src-lib/libposix/Makefile
+++ b/src-lib/libposix/Makefile
@@ -1,4 +1,4 @@
-OBJS = posix.o
+OBJS = posix.o posix_signal.o
 LIB  = libposix.a
 
 CC ?= cc

--- a/src-lib/libposix/posix_signal.c
+++ b/src-lib/libposix/posix_signal.c
@@ -1,0 +1,19 @@
+#include "posix_signal.h"
+#include <signal.h>
+#include <unistd.h>
+
+int posix_sigaction(int signum, const struct sigaction *act,
+                    struct sigaction *oldact)
+{
+    return sigaction(signum, act, oldact);
+}
+
+int posix_sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
+{
+    return sigprocmask(how, set, oldset);
+}
+
+int posix_killpg(int pgrp, int sig)
+{
+    return killpg(pgrp, sig);
+}

--- a/tests/posix/Makefile
+++ b/tests/posix/Makefile
@@ -1,16 +1,20 @@
 CC=clang
 CFLAGS ?= -O2 -std=c23 -Wall -Werror
-CPPFLAGS = -I../../include
+CPPFLAGS = -I../../include -I../../src-headers
+LIBPOSIX = ../../src-lib/libposix/libposix.a
 
-all: dirlist
+all: dirlist signal_test
 
 dirlist: dirlist.o inmemfs.o
 	$(CC) $(CFLAGS) dirlist.o inmemfs.o -o $@
+
+signal_test: signal_test.o
+	$(CC) $(CFLAGS) signal_test.o $(LIBPOSIX) -o $@
 
 %.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
-	 rm -f dirlist dirlist.o inmemfs.o
+	rm -f dirlist signal_test *.o
 
 .PHONY: all clean

--- a/tests/posix/signal_test.c
+++ b/tests/posix/signal_test.c
@@ -1,0 +1,45 @@
+#define _DEFAULT_SOURCE
+#define _XOPEN_SOURCE 700
+#include "../../src-headers/posix_signal.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+
+static volatile sig_atomic_t got;
+
+static void handler(int s) {
+    (void)s;
+    got = 1;
+}
+
+int main(void)
+{
+    struct sigaction sa = {0};
+    sa.sa_handler = handler;
+    sigemptyset(&sa.sa_mask);
+    if (posix_sigaction(SIGUSR1, &sa, NULL) != 0) {
+        perror("sigaction");
+        return 1;
+    }
+
+    if (posix_killpg(getpgrp(), SIGUSR1) != 0) {
+        perror("killpg");
+        return 1;
+    }
+
+    for (int i = 0; i < 100 && !got; ++i)
+        usleep(1000);
+    if (!got) {
+        fprintf(stderr, "handler not called\n");
+        return 1;
+    }
+
+    sigset_t set;
+    sigemptyset(&set);
+    if (posix_sigprocmask(SIG_BLOCK, &set, NULL) != 0) {
+        perror("sigprocmask");
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- provide `posix_sigaction`, `posix_sigprocmask`, and `posix_killpg` in libposix
- document new signal helpers
- add demonstration program exercising custom handlers
- build new regression test in `tests/posix`

## Testing
- `make -C src-lib/libposix clean all CC=clang`
- `make -C tests/posix signal_test CC=clang`
- `./tests/posix/signal_test`