### PR TITLE
Document Codex bootstrapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,10 @@ It mirrors a BSD root filesystem layout.
 - `SOURCE_TREE_OVERVIEW.md` gives a summary of the top-level directories.
 - The `docs/` directory holds build instructions and modernization plans.
 
+The optional document `docs/codex_bootstrap.md` explains how to run the
+OpenAI Codex CLI at boot so `setup.sh` stays up to date even on hosts that
+drop network connectivity shortly after start.
+
 Each major subdirectory includes its own `AGENTS.md` describing that area.
 
 ## Workflow Guidelines

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ invoked directly or via `.codex/setup.sh` which adds extra packages like the
 Coq proof assistant, TLA+ utilities, Agda and Isabelle/HOL for CI. The wrapper
 automatically switches to `--offline` when network access is unavailable. It can optionally install
 **mk-configure** to provide an Autotools-style layer on top.
+See `docs/codex_bootstrap.md` for automating this process with a systemd unit
+that runs Codex at boot.
 The tree also ships a minimal **CMake** configuration.  Generate Ninja files
 with:
 

--- a/docs/codex_bootstrap.md
+++ b/docs/codex_bootstrap.md
@@ -1,0 +1,22 @@
+# Codex Bootstrapping and Offline Setup
+
+This repository can be used with the OpenAI Codex CLI to keep `setup.sh` in sync and to fetch packages before network access disappears. The common workflow is:
+
+1. **Install Codex CLI** – `npm i -g @openai/codex` or include it in your devcontainer.
+2. **Automate setup.sh** – Codex checks `setup.sh` against a template and patches any drift. Run:
+   ```sh
+   codex -q -a full-auto "doctor setup.sh"
+   ```
+   before executing the script. The wrapper `.codex/setup.sh` does this automatically when run inside CI.
+3. **Run during boot** – A sample systemd unit file lives at `etc/systemd/system/codex-setup.service`. Enabling it ensures Codex repairs `setup.sh` and launches it before `network-pre.target` so the script can still download packages.
+
+The service is enabled with:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable codex-setup.service
+```
+
+After a reboot you can inspect `/var/log/syslog` or use `journalctl -b -u codex-setup` to verify that Codex ran.
+
+Offline runs place pre-downloaded `.deb` files under `offline_packages/` and Python wheels under `third_party/pip/`. Invoke `setup.sh --offline` when the network is not available. Codex detects network access automatically when called via `.codex/setup.sh`.

--- a/etc/systemd/system/codex-setup.service
+++ b/etc/systemd/system/codex-setup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Heal and run setup.sh before networking
+DefaultDependencies=no
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/codex -q -a full-auto "doctor setup.sh" && /usr/local/bin/setup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- describe boot-level Codex automation in `docs/codex_bootstrap.md`
- note the new doc in `AGENTS.md` and `README.md`
- add a sample systemd unit `etc/systemd/system/codex-setup.service`

## Testing
- `git status --short`