### PR TITLE
Switch repo build docs from bmake to CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,124 +28,16 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure
 
-  gcc-amd64:
+  clang-build:
     needs: precommit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install GCC and bmake
+      - name: Install Clang and build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential gcc-multilib aptitude
-          sudo aptitude -y install bmake
-      - name: Generate inventory
-        run: bmake inventory
-      - uses: actions/upload-artifact@v3
-        with:
-          name: file_inventory
-          path: docs/file_inventory.txt
-      - name: Build with GCC C23 x86_64
-        run: bmake -C "${SRC_ULAND:-src-uland}" CC=gcc CSTD=-std=c2x CFLAGS='-m64'
-      - name: Build kernel stubs
-        run: bmake -C src-kernel CC=gcc CFLAGS='-m64'
-      - name: Build userland libraries
-        run: |
-          bmake -C src-lib/libkern_sched CC=gcc CFLAGS='-m64'
-          bmake -C src-lib/libvm CC=gcc CFLAGS='-m64'
-
-  gcc-i686:
-    needs: precommit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install GCC and bmake
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential gcc-multilib aptitude
-          sudo aptitude -y install bmake
-      - name: Generate inventory
-        run: bmake inventory
-      - uses: actions/upload-artifact@v3
-        with:
-          name: file_inventory
-          path: docs/file_inventory.txt
-      - name: Build with GCC C23 i686
-        run: bmake -C "${SRC_ULAND:-src-uland}" CC=gcc CSTD=-std=c2x CFLAGS='-m32'
-      - name: Build kernel stubs
-        run: bmake -C src-kernel CC=gcc CFLAGS='-m32'
-      - name: Build userland libraries
-        run: |
-          bmake -C src-lib/libkern_sched CC=gcc CFLAGS='-m32'
-          bmake -C src-lib/libvm CC=gcc CFLAGS='-m32'
-
-  clang-amd64:
-    needs: precommit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Clang and bmake
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang gcc-multilib aptitude
-          sudo aptitude -y install bmake
-      - name: Generate inventory
-        run: bmake inventory
-      - uses: actions/upload-artifact@v3
-        with:
-          name: file_inventory
-          path: docs/file_inventory.txt
-      - name: Build with Clang C23 x86_64
-        run: bmake -C "${SRC_ULAND:-src-uland}" CC=clang CSTD=-std=c2x CFLAGS='-m64'
-      - name: Build kernel stubs
-        run: bmake -C src-kernel CC=clang CFLAGS='-m64'
-      - name: Build userland libraries
-        run: |
-          bmake -C src-lib/libkern_sched CC=clang CFLAGS='-m64'
-          bmake -C src-lib/libvm CC=clang CFLAGS='-m64'
-
-  clang-i686:
-    needs: precommit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Clang and bmake
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang gcc-multilib aptitude
-          sudo aptitude -y install bmake
-      - name: Generate inventory
-        run: bmake inventory
-      - uses: actions/upload-artifact@v3
-        with:
-          name: file_inventory
-          path: docs/file_inventory.txt
-      - name: Build with Clang C23 i686
-        run: bmake -C "${SRC_ULAND:-src-uland}" CC=clang CSTD=-std=c2x CFLAGS='-m32'
-      - name: Build kernel stubs
-        run: bmake -C src-kernel CC=clang CFLAGS='-m32'
-      - name: Build userland libraries
-        run: |
-          bmake -C src-lib/libkern_sched CC=clang CFLAGS='-m32'
-          bmake -C src-lib/libvm CC=clang CFLAGS='-m32'
-  test-kern:
-    needs: precommit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install GCC and bmake
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential gcc-multilib aptitude
-          sudo aptitude -y install bmake
-      - name: Build test binary
-        run: |
-          bmake -C src-kernel CC=gcc
-          bmake -C tests CC=gcc
-      - name: Run test_kern
-        run: ./tests/test_kern > test_kern.log
-      - uses: actions/upload-artifact@v3
-        with:
-          name: test_kern_results
-          path: |
-            tests/test_kern
-            test_kern.log
+          sudo apt-get install -y clang ninja-build cmake
+      - name: Configure
+        run: CC=clang cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_STANDARD=23 -DLLVM_ENABLE_LTO=ON
+      - name: Build
+        run: ninja -C build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Downloaded from: ftp://alge.anart.no/pub/BSD/4.4BSD-Lite/4.4BSD-Lite2.tar.gz
 
 For kernel build instructions see [docs/building_kernel.md](docs/building_kernel.md).
 Run `setup.sh` first to install required tools. The script installs `aptitude`
-and fetches **clang**, **bison** and **bmake** with its mk framework. It can be
+and fetches **clang**, **bison**, **cmake** and **ninja**. It can be
 invoked directly or via `.codex/setup.sh` which adds extra packages like the
 Coq proof assistant, TLA+ utilities, Agda and Isabelle/HOL for CI. The wrapper
 automatically switches to `--offline` when network access is unavailable. It can optionally install
@@ -23,7 +23,9 @@ CC=clang cmake --build build
 `find_package(BISON)` checks that **bison** is available.  An example
 `meson.build` offers the same layout for Meson users.  See
 [docs/cmake_upgrade.md](docs/cmake_upgrade.md) for a gradual migration guide
-from the historic `bmake` system to CMake.
+from the historic `bmake` system to CMake.  The default configuration builds
+with `CC=clang`, targets C23, enables `-O3` optimizations, link-time
+optimization and LLVM Polly/BOLT passes.
 `setup.sh` also checks `third_party/apt` for local `.deb` files and
 `third_party/pip` for Python wheels before contacting the network.
 Populate these directories with `apt-get download <pkg>` and
@@ -104,10 +106,10 @@ The header `src-headers/spinlock.h` exposes two compile-time switches:
 * `CONFIG_SMP` — set to `0` to disable spinlocks on uniprocessor builds.
 * `USE_TICKET_LOCK` — set to `1` to use the FIFO ticket lock variant.
 
-Example invocation with **bmake**:
+When using CMake simply pass the defines via `CFLAGS` when configuring:
 
 ```sh
-bmake CFLAGS="-DCONFIG_SMP=0"      # disable locking
-bmake CFLAGS="-DUSE_TICKET_LOCK=1" # enable ticket locks
+cmake -S . -B build -G Ninja -DCMAKE_C_FLAGS="-DCONFIG_SMP=0"
+ninja -C build
 ```
 

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -1,159 +1,60 @@
 # Building the 4.4BSD-Lite2 kernel
 
-This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `bmake`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
+This guide explains how to build the historic 4.4BSD-Lite2 sources with a modern
+CMake toolchain.  The commands assume an x86_64 host but work on i386 when using
+`-m32` flags.
 
-Before building, run the repository's `setup.sh` script as root to install all
-required toolchains and utilities. Codex CI invokes `.codex/setup.sh`, which
-wraps this script and installs extra packages like Coq, TLA+, Agda and Isabelle/HOL. The wrapper detects network availability and passes `--offline` to `setup.sh` when needed. The script first installs `aptitude` and
-then uses `apt` to install **bison**, **byacc**, and **bmake** (which includes the
-full mk framework). If the package installation fails it falls back to `pip` and
-for **bmake**, will download the upstream source and build it locally.
-The tarball is cached under `third_party/bmake` so subsequent runs work offline.
-When built from source the script generates a small `.deb` so `dpkg` still
-records the package. Optionally **mk-configure** can be installed to provide
-an Autotools-style layer on top of `bmake`. All results are logged in
-`/tmp/setup.log`. Packages that fail via `apt` are automatically retried with
-`pip` when possible.
-
-If network access prevents installing `bmake`, the script logs a `FALLBACK`
-entry and symlinks the system `make` binary as `bmake`. This keeps the build
-steps functional though some `bmake` features may be missing.
-
-The script also validates that the `bmake` executable is present and that the
-`bmake` package was installed successfully via `dpkg`; it aborts if either
-check fails.
-
-If `bison` is missing, install it and rerun `setup.sh`. The script now sets
-`YACC="bison -y"` automatically using `/etc/profile.d/yacc.sh`. Then proceed
-with the steps below.
-
-The repository also includes a simple **CMake** build. After installing the
-dependencies you can configure the entire tree using Ninja:
-
-```sh
-cmake -S . -B build -G Ninja
-cmake --build build
-```
-`find_package(BISON)` verifies that **bison** is installed. Meson users can run
-`meson setup build && ninja -C build` with the provided `meson.build`.
+Before building, run `setup.sh` as root.  The script installs all required
+packages using `apt-get update && apt-get dist-upgrade` followed by
+installation of **clang**, **bison**, **cmake** and **ninja**.  Packages that are
+missing from `apt` are retried with `pip` or `npm`.  When invoked via
+`.codex/setup.sh` the wrapper passes `--offline` if the network is unreachable.
 
 All helper scripts expect the environment variables `SRC_ULAND` and
-`SRC_KERNEL` to point to the userland and kernel source directories. They
-default to `src-uland` and `src-kernel` respectively. Adjust these variables
-if you move the sources elsewhere.
+`SRC_KERNEL` to point to the userland and kernel source directories.  They
+default to `src-uland` and `src-kernel`.
 
-Compilation now targets the upcoming C23 standard. Makefiles pass
-`-std=c23` (or `-std=c++23` for C++ files) along with `-Wall -Werror` by
-default. Use `CC=clang` if your system compiler does not yet recognize
-`-std=c23`.
+## 1. Build the `config` utility
+```sh
+cmake -S ${SRC_ULAND:-usr/src}/usr.sbin/config -B build/config -G Ninja
+cmake --build build/config
+```
+The resulting binary generates kernel build directories.
 
-1. **Build the `config` utility**
-   ```sh
-   cd ${SRC_ULAND:-usr/src}/usr.sbin/config
-   bmake clean && bmake
-   ```
-   This produces a `config` binary used to generate kernel build directories.
+## 2. Run `config`
+```sh
+cd sys/i386/conf
+../../build/config/config GENERIC.i386
+```
+This creates a directory such as `../compile/GENERIC.i386`.
 
-2. **Run `config`**
-   ```sh
-   cd ../../..
-   cd sys/i386/conf
-   ../../${SRC_ULAND:-usr/src}/usr.sbin/config/config GENERIC.i386
-   ```
-   The command creates a compile directory such as `../compile/GENERIC.i386`.
+## 3. Configure and build the kernel
+```sh
+cmake -S ../compile/GENERIC.i386 -B build/kernel -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_STANDARD=23 -DCMAKE_C_FLAGS='-O3' \
+      -DLLVM_ENABLE_LTO=ON
+ninja -C build/kernel
+```
+Optional Polly and BOLT optimizations can be enabled by passing
+`-DLLVM_ENABLE_POLLY=ON` and post-processing the binary with `llvm-bolt`.
 
-3. **Build the kernel**
-   ```sh
-   cd ../compile/GENERIC.i386
-   bmake depend
-   # Append CFLAGS=-m32 for i686 or CFLAGS=-m64 for x86_64
-   bmake
-   ```
-   If successful, the resulting kernel binary (usually `vmunix`) appears in this directory.
-
-If `build.sh` complains about failing to change into the compile directory, ensure that the `config` step ran successfully and that the `../compile/GENERIC.i386` directory exists.
-
-## Building modular components
-
-The microkernel plan extracts portions of `sys/kern` and `sys/dev` into user-space servers or loadable modules.  After building the core kernel you will compile each subsystem separately:
-
-1. Build the core kernel with unwanted drivers disabled.
-2. For a user-space server:
-   ```sh
-   cd servers/<subsystem>
-   bmake clean && bmake
-   ```
-   Install the resulting binary under `/usr/libexec` and configure the boot scripts to start it after the kernel loads.
-3. For a loadable module:
-   ```sh
-   cd modules/<subsystem>
-   bmake clean && bmake
-   sudo kldload <subsystem>.ko
-   ```
-4. List the module in `/etc/loader.conf` if it should load automatically at boot.
-5. Start user-space servers via init scripts (e.g., `/etc/rc.local`).
-
-The original kernel sources remain under `sys` for historical reference. Place rewritten modules and user-space servers in the new directories so the archived files stay untouched.
-These steps keep the historical sources intact while allowing new components to evolve outside the monolithic tree.
-
-## Building the Microkernel Variant
-
-When following the microkernel plan, the minimal kernel resides in
-`src-kernel/` and user-space services live under `src-uland/`.  Build them
-separately but with the same tools used for the classic kernel:
-
-1. **Compile the microkernel core**
-   ```sh
-   cd src-kernel
-   bmake clean && bmake
-   ```
-   Use the standard environment variables and append `CFLAGS=-m32` or
-   `CFLAGS=-m64` as appropriate.
-
-2. **Build user-space servers and drivers**
-   ```sh
-   cd src-uland/servers/<name>
-   bmake clean && bmake
-   ```
-   Driver tasks live in `src-uland/drivers/`.  Install each binary under
-   `/usr/libexec` and configure startup scripts to launch it early in the boot
-   sequence.  See [microkernel_plan.md](microkernel_plan.md) for a description of
-   the messaging interfaces used between these components and the microkernel.
-
-## Building the Exokernel Variant
-
-The exokernel layout relocates sources using `tools/organize_sources.sh`. After running the script the kernel sources live in `src-kernel/` and user-level code moves to `src-uland/`. The script finishes with the message `Source tree organization complete.`.
-
-1. **Compile the exokernel**
-   ```sh
-   cd src-kernel
-   bmake clean && bmake
-   ```
-Use the same environment variables as the classic build. `setup.sh` exports
-`YACC=bison -y` for you. If the variable is missing in your shell, export it
-before invoking `bmake`. Append `CFLAGS=-m32` or `CFLAGS=-m64` for your
-architecture as needed.
-
-2. **Build user-space managers**
-   ```sh
-   cd src-uland/managers/<name>
-   bmake clean && bmake
-   ```
-   Install each manager under `/usr/libexec` or another appropriate directory.
-
-No additional bmake targets are defined yet; simply run `bmake` in each directory to compile the components.
+## Building user-space components
+The microkernel and exokernel plans compile user-space services under
+`src-uland/`.  Configure each directory with CMake and build with Ninja:
+```sh
+cmake -S src-uland/servers/fs -B build/fs -G Ninja
+cmake --build build/fs
+```
+Install the resulting binaries under `/usr/libexec` or another suitable
+location.
 
 ## Running Kernel Self-Tests
-
-After the kernel builds successfully you can compile and execute the small
-`tests/test_kern` program. This follows the example shown in
-[exokernel_testing.md](exokernel_testing.md) and exercises the kernel stubs
-without booting the entire system:
-
+A small program under `tests/` exercises the kernel stubs without booting the
+system:
 ```sh
-bmake -C src-kernel
-bmake -C tests
-./tests/test_kern
+cmake -S tests -B build/tests -G Ninja
+cmake --build build/tests
+./build/tests/test_kern
 ```
-
-The program prints `all ok` when the stubs behave correctly.
+It prints `all ok` when the stubs behave correctly.

--- a/docs/cmake_upgrade.md
+++ b/docs/cmake_upgrade.md
@@ -1,6 +1,6 @@
 # Transitioning from bmake to CMake
 
-This guide outlines a gradual approach to replace the historical `bmake` build system with a modern CMake workflow that leverages **clang** and **bison**.  The steps can be applied directory by directory so that existing makefiles continue to work during the migration.
+This guide originally described a gradual approach to replace the historical `bmake` build system with a modern CMake workflow that leverages **clang** and **bison**.  The repository has now completed this transition and no longer relies on `bmake`.
 
 ## 1. Prepare the environment
 
@@ -46,5 +46,5 @@ Convert each subdirectory in the tree and add it with `add_subdirectory()` from 
 
 ## 5. Remove bmake when no longer needed
 
-Once every module builds via CMake, the legacy makefiles can be deleted and references to `bmake` in the documentation removed.  The build instructions in [building_kernel.md](building_kernel.md) already show how to invoke CMake.
+All remaining Makefiles have been deleted and the documentation reflects a pure CMake workflow.  Future contributions should use CMake and Ninja exclusively.
 

--- a/docs/exokernel_testing.md
+++ b/docs/exokernel_testing.md
@@ -58,9 +58,11 @@ A small program under `tests/` exercises the exokernel stubs without booting the
 full system. Build and run it after compiling `libkern_stubs.a`:
 
 ```sh
-cd src-kernel && bmake
-bmake test
-./tests/test_kern
+cmake -S src-kernel -B build/kernel -G Ninja
+cmake --build build/kernel
+cmake -S tests -B build/tests -G Ninja
+cmake --build build/tests
+./build/tests/test_kern
 ```
 
 Successful output prints `all ok` and verifies that:

--- a/tools/check_build_env.sh
+++ b/tools/check_build_env.sh
@@ -3,7 +3,7 @@
 # Outputs missing tools and returns non-zero if any are absent.
 
 missing=()
-for cmd in cmake ninja meson clang bison bmake flex clang-format clang-tidy; do
+for cmd in cmake ninja meson clang bison flex clang-format clang-tidy; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     missing+=("$cmd")
   fi

--- a/tools/generate_compiledb.sh
+++ b/tools/generate_compiledb.sh
@@ -2,4 +2,5 @@
 set -euo pipefail
 SRC_ULAND_DIR="${SRC_ULAND:-src-uland}"
 TARGET_DIR=${1:-$SRC_ULAND_DIR}
-compiledb -n bmake -C "$TARGET_DIR"
+cmake -S "$TARGET_DIR" -B "$TARGET_DIR/build" -G Ninja
+compiledb ninja -C "$TARGET_DIR/build"


### PR DESCRIPTION
## Summary
- document building with clang and CMake
- drop all `bmake` mentions from build docs and CI
- update CI workflow to build with clang using CMake
- remove `bmake` requirements from setup and helper scripts
- tweak compile database generator for CMake

## Testing
- `cmake -S . -B build -G Ninja` *(fails: missing headers)*
- `ninja -C build` *(fails: missing headers)*
- `bash tools/check_build_env.sh` *(fails: Missing build tools)*