### PR TITLE
Update docs for CMake workflow

### DIFF
--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -2,26 +2,7 @@
 
 This short guide explains how to compile the historic 4.4BSD-Lite2 kernel on an i386 host. The steps mirror the classic workflow using `config` and `bmake`. The same procedure works on modern x86_64 systems when passing the appropriate compiler flags.
 
-Before building, run the repository's `setup.sh` script as root to install all
-required toolchains and utilities. Codex CI invokes `.codex/setup.sh`, which
-wraps this script and installs extra packages like Coq, TLA+, Agda and Isabelle/HOL. The wrapper detects network availability and passes `--offline` to `setup.sh` when needed. The script first installs `aptitude` and
-then uses `apt` to install **bison**, **byacc**, and **bmake** (which includes the
-full mk framework). If the package installation fails it falls back to `pip` and
-for **bmake**, will download the upstream source and build it locally.
-The tarball is cached under `third_party/bmake` so subsequent runs work offline.
-When built from source the script generates a small `.deb` so `dpkg` still
-records the package. Optionally **mk-configure** can be installed to provide
-an Autotools-style layer on top of `bmake`. All results are logged in
-`/tmp/setup.log`. Packages that fail via `apt` are automatically retried with
-`pip` when possible.
-
-If network access prevents installing `bmake`, the script logs a `FALLBACK`
-entry and symlinks the system `make` binary as `bmake`. This keeps the build
-steps functional though some `bmake` features may be missing.
-
-The script also validates that the `bmake` executable is present and that the
-`bmake` package was installed successfully via `dpkg`; it aborts if either
-check fails.
+Before building, run the repository's `setup.sh` script as root to install all required toolchains. Codex CI calls `.codex/setup.sh`, which passes `--offline` when needed. The script installs **clang**, **bison**, `cmake` and related packages, logging to `/tmp/setup.log`.
 
 If `bison` is missing, install it and rerun `setup.sh`. The script now sets
 `YACC="bison -y"` automatically using `/etc/profile.d/yacc.sh`. Then proceed

--- a/docs/ci_workflows.md
+++ b/docs/ci_workflows.md
@@ -128,29 +128,23 @@ These snippets should be placed in `.github/workflows/` to enable deterministic 
 
 ## Kernel Test Job
 
-The `build.yml` workflow also compiles and runs `tests/test_kern`. This job
-builds the microkernel stubs and the test program using `bmake` and GCC, then
-executes the binary. The test output and resulting executable are uploaded as
-artifacts for later inspection.
-
-A simplified example of the steps is:
+The `build.yml` workflow also compiles and runs `tests/test_kern`. This job builds the microkernel stubs and the test program using `clang` and CMake. The test output and resulting executable are uploaded as artifacts for later inspection.
 
 ```yaml
 test-kern:
   runs-on: ubuntu-latest
   steps:
     - uses: actions/checkout@v3
-    - name: Install GCC and bmake
+    - name: Install clang and CMake
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential gcc-multilib aptitude
-        sudo apt-get install -y bmake
-    - name: Build test binary
+        sudo apt-get install -y clang cmake ninja-build
+    - name: Configure
+      run: cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=clang
+    - name: Build and test
       run: |
-        bmake -C src-kernel CC=gcc
-        bmake test CC=gcc
-    - name: Run test_kern
-      run: ./tests/test_kern > test_kern.log
+        cmake --build build
+        ./tests/test_kern > test_kern.log
     - uses: actions/upload-artifact@v3
       with:
         name: test_kern_results

--- a/third_party/AGENTS.md
+++ b/third_party/AGENTS.md
@@ -1,7 +1,5 @@
 # Third Party Sources
 
 This directory caches source archives and packages used by `setup.sh`.
-When run with network access, the script fetches the latest `bmake` tarball
-from <http://www.crufty.net/ftp/pub/sjg/> and stores it under `bmake/`.
-Debian packages are looked up under `apt/` and Python wheels under `pip/`
-when operating offline.
+When run with network access, the script caches clang, cmake and related archives under this directory for offline installs.
+Debian packages are looked up under `apt/` and Python wheels under `pip/` when operating offline.

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,4 +1,4 @@
 Cached third party source archives used by `setup.sh`.
-The `bmake/` subdirectory stores the upstream tarball.
+Various archives such as clang and cmake are stored here for offline installation.
 `apt/` holds pre-downloaded Debian packages and `pip/` holds
 Python wheels or source archives for offline installs.


### PR DESCRIPTION
## Summary
- update kernel build instructions and CI example to focus on CMake and clang
- update third_party notes to describe caching of clang/cmake packages

## Testing
- `git status --short`