### PR TITLE
Add EXTRA_URLS download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Populate these directories with `apt-get download <pkg>` and
 For a fully offline installation, place `.deb` files under
 `offline_packages/` and invoke `setup.sh --offline` to install them
 using `dpkg -i`.
+`setup.sh` also defines an `EXTRA_URLS` list for additional archives.
+Each URL is downloaded with `curl` (falling back to `wget`) and extracted
+under `/usr/local`. Failures are appended to `/tmp/setup.log` without
+interrupting the remainder of the installation.
 You can verify which commands are available at any time by running
 `tools/check_build_env.sh`. It lists missing build tools and exits
 non-zero when any are absent.


### PR DESCRIPTION
## Summary
- extend setup.sh to optionally download extra archives
- mention EXTRA_URLS feature in README

## Testing
- `cmake -S . -B build -G Ninja`
- `ninja -C build` *(fails: exo_ipc.h missing)*
- `bash -n setup.sh`
- `pre-commit run --files setup.sh README.md` *(fails: pre-commit not found)*