### PR TITLE
Add formal tools install to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ Downloaded from: ftp://alge.anart.no/pub/BSD/4.4BSD-Lite/4.4BSD-Lite2.tar.gz
 
 For kernel build instructions see [docs/building_kernel.md](docs/building_kernel.md).
 Run `setup.sh` first to install required tools. The script installs `aptitude`
-and fetches **clang**, **bison**, **cmake** and **ninja**. It can be
-invoked directly or via `.codex/setup.sh` which adds extra packages like the
-Coq proof assistant, TLA+ utilities, Agda and Isabelle/HOL for CI. The wrapper
-automatically switches to `--offline` when network access is unavailable. It can optionally install
-**mk-configure** to provide an Autotools-style layer on top.
+and fetches **clang**, **bison**, **cmake**, **ninja** and linters such as
+`shellcheck` and `codespell`. It can be invoked directly or via
+`.codex/setup.sh` which also installs the Coq proof assistant, TLA+ utilities,
+Agda and Isabelle/HOL for CI. The root script additionally pulls in Graphviz,
+Doxygen and Sphinx for automatic documentation. The wrapper automatically
+switches to `--offline` when network access is unavailable. It can optionally
+install **mk-configure** to provide an Autotools-style layer on top.
 See `docs/codex_bootstrap.md` for automating this process with a systemd unit
 that runs Codex at boot.
 The tree also ships a minimal **CMake** configuration.  Generate Ninja files

--- a/setup.sh
+++ b/setup.sh
@@ -212,6 +212,7 @@ for pkg in \
   libbsd0 libbsd-dev \
   strace ltrace linux-perf systemtap systemtap-sdt-dev crash \
   valgrind kcachegrind trace-cmd kernelshark \
+  llvm-polly llvm-bolt \
   libasan6 libubsan1 likwid hwloc; do
   apt_pin_install "$pkg" || install_with_pip "$pkg" || npm_install "$pkg"
 done
@@ -340,6 +341,15 @@ for pkg in \
   docker.io podman buildah virt-manager libvirt-daemon-system qemu-kvm \
   gdb lldb perf gcovr lcov bcc-tools bpftrace \
   openmpi-bin libopenmpi-dev mpich; do
+  apt_pin_install "$pkg" || install_with_pip "$pkg" || npm_install "$pkg"
+done
+
+# formal verification and documentation utilities
+for pkg in \
+  coq coqide coq-theories \
+  agda agda-stdlib agda-mode \
+  isabelle tlaplus tla-bin \
+  graphviz doxygen python3-sphinx; do
   apt_pin_install "$pkg" || install_with_pip "$pkg" || npm_install "$pkg"
 done
 


### PR DESCRIPTION
## Summary
- expand the setup script with formal verification and documentation tools
- mention new packages in README

## Testing
- `bash tools/check_build_env.sh`
- `cmake -S . -B build -G Ninja`
- `cmake --build build` *(fails: missing exo_ipc.h)*
- `ctest --test-dir build`