### PR TITLE
Improve setup offline detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Populate these directories with `apt-get download <pkg>` and
 For a fully offline installation, place `.deb` files under
 `offline_packages/` and invoke `setup.sh --offline` to install them
 using `dpkg -i`.
+When run without the flag, `setup.sh` now tests network access with
+`apt-get update` and automatically enables offline mode if the command
+fails.
 You can verify which commands are available at any time by running
 `tools/check_build_env.sh`. It lists missing build tools and exits
 non-zero when any are absent.

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,8 @@ if [ "${1:-}" = "--offline" ]; then
   shift
 fi
 
+# automatically switch to offline mode when network access is unavailable
+
 # log all successes and failures with timestamps
 LOG_FILE=/tmp/setup.log
 rm -f "$LOG_FILE"
@@ -30,6 +32,16 @@ export DEBIAN_FRONTEND=noninteractive
 APT_FAILED=()
 PIP_FAILED=()
 NPM_FAILED=()
+
+# automatically switch to offline mode when network access is unavailable
+if [ $OFFLINE_MODE -eq 0 ]; then
+  if ! apt-get update -y >/dev/null 2>&1; then
+    OFFLINE_MODE=1
+    log_msg "Network unavailable, enabling offline mode"
+  else
+    log_msg "APT OK   initial update"
+  fi
+fi
 
 # attempt to reinstall any packages that failed during the first pass
 retry_failures(){


### PR DESCRIPTION
## Summary
- detect network connectivity inside `setup.sh`
- fall back to offline mode automatically
- document new behavior in the README

## Testing
- `bash -n setup.sh`
- `./tools/check_build_env.sh` *(fails: Missing build tools)*