### PR TITLE
Update cdefs static_assert logic

### DIFF
--- a/docs/refactor_c23_tasks.md
+++ b/docs/refactor_c23_tasks.md
@@ -80,8 +80,9 @@ This roadmap is intentionally high level. Full conversion of the 4.4BSD-Lite2 tr
 ## Recent Progress
 
 - Added a `CSTD` variable to `share/mk/sys.mk` so builds can pass `CSTD=-std=c2x`.
-- Introduced a fallback definition of `_Static_assert` in `sys/sys/cdefs.h` to
-  allow compile-time checks on pre-C11 compilers.
+- `sys/sys/cdefs.h` now maps `_Static_assert` to the `static_assert`
+  keyword when building with C23 and retains a typedef-based fallback for
+  pre-C11 compilers.
 - Created a workflow in `.github/workflows/build.yml` to build the tree with
   both GCC and Clang using the C23 standard flag.
 - New script `tools/build_collect_warnings.sh` builds the tree and captures

--- a/usr/src/sys/sys/cdefs.h
+++ b/usr/src/sys/sys/cdefs.h
@@ -119,10 +119,17 @@
 #define	__dead
 #define	__pure
 /*
- * Provide a fallback for the C11 `_Static_assert` keyword so headers can
- * use compile-time checks even when compiled with older C dialects.
+ * Portable compile-time assertions.
+ *
+ * C23 introduces the `static_assert` keyword.  Map `_Static_assert` to it
+ * so existing code continues to build.  Older dialects either provide the
+ * C11 `_Static_assert` keyword or fall back to a typedef trick.
  */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #ifndef _Static_assert
+#define _Static_assert static_assert
+#endif
+#elif !defined(_Static_assert)
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ < 201112L
 #define _Static_assert(expr, msg) typedef char __static_assert_t[(expr) ? 1 : -1]
 #endif


### PR DESCRIPTION
## Summary
- use `static_assert` keyword when building with C23
- keep typedef fallback for older dialects
- document the change in the C23 refactor notes

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_C_STANDARD=23` *(fails: exo_ipc.h: No such file or directory)*