### PR TITLE
Add ARCH_BITS header and update libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,4 +36,6 @@ target_include_directories(fs_server PRIVATE
 target_compile_definitions(fs_server PRIVATE KERNEL)
 target_link_libraries(fs_server PRIVATE ipc)
 
+install(FILES src-headers/arch.h DESTINATION include)
+
 

--- a/docs/cross_architecture_porting.md
+++ b/docs/cross_architecture_porting.md
@@ -9,6 +9,9 @@ platform specific optimisation.
 
 - Introduce `<src-headers/arch.h>` which exposes `ARCH_BITS` and helper
   macros derived from `__SIZEOF_POINTER__`.
+- The header defines `ARCH_16BIT`, `ARCH_32BIT`, `ARCH_64BIT` and the
+  `ARCH_UNREACHABLE()` helper. Source files include it and perform checks
+  such as `#if ARCH_BITS == 32` when special casing logic.
 - Build common sources with `-std=c2x` and rely on the new header for
   pointer-width checks.
 - Place generic assembly routines under `asm/` with per‑architecture

--- a/src-headers/arch.h
+++ b/src-headers/arch.h
@@ -10,27 +10,14 @@
 
 #include <stdint.h>
 
-#if defined(__SIZEOF_POINTER__)
-#  if __SIZEOF_POINTER__ == 2
-#    define ARCH_16BIT 1
-#  elif __SIZEOF_POINTER__ == 4
-#    define ARCH_32BIT 1
-#  elif __SIZEOF_POINTER__ == 8
-#    define ARCH_64BIT 1
-#  else
-#    error "Unsupported pointer width"
-#  endif
-#else
-#  error "__SIZEOF_POINTER__ not defined"
+#ifndef __SIZEOF_POINTER__
+#  error "compiler must define __SIZEOF_POINTER__"
 #endif
 
-#if defined(ARCH_64BIT)
-#  define ARCH_BITS 64
-#elif defined(ARCH_32BIT)
-#  define ARCH_BITS 32
-#else
-#  define ARCH_BITS 16
-#endif
+#define ARCH_BITS (__SIZEOF_POINTER__ * 8)
+#define ARCH_16BIT (ARCH_BITS == 16)
+#define ARCH_32BIT (ARCH_BITS == 32)
+#define ARCH_64BIT (ARCH_BITS == 64)
 
 #if __STDC_VERSION__ >= 202000L
 #  define ARCH_UNREACHABLE() __builtin_unreachable()

--- a/src-lib/libvm/vm_glue.c
+++ b/src-lib/libvm/vm_glue.c
@@ -69,6 +69,8 @@
 #include <sys/user.h>
 #include "runqueue.h"
 
+#include <arch.h>
+
 #include <vm/vm.h>
 #include <vm/vm_page.h>
 #include <vm/vm_kern.h>
@@ -198,7 +200,7 @@ vm_fork(p1, p2, isvfork)
 	register struct user *up;
 	vm_offset_t addr;
 
-#ifdef i386
+#if ARCH_BITS == 32
 	/*
 	 * avoid copying any of the parent's pagetables or other per-process
 	 * objects that reside in the map by marking all of them non-inheritable
@@ -213,7 +215,7 @@ vm_fork(p1, p2, isvfork)
 		shmfork(p1, p2, isvfork);
 #endif
 
-#ifndef	i386
+#if ARCH_BITS != 32
 	/*
 	 * Allocate a wired-down (for now) pcb and kernel stack for the process
 	 */
@@ -248,7 +250,7 @@ not yet clear, yet it does... */
 	    ((caddr_t)&up->u_stats.pstat_endcopy -
 	     (caddr_t)&up->u_stats.pstat_startcopy));
 
-#ifdef i386
+#if ARCH_BITS == 32
 	{ u_int addr = UPT_MIN_ADDRESS - UPAGES*NBPG; struct vm_map *vp;
 
 	vp = &p2->p_vmspace->vm_map;
@@ -514,7 +516,7 @@ swapout(p)
 		}
 	}
 #endif
-#ifndef	i386 /* temporary measure till we find spontaineous unwire of kstack */
+#if ARCH_BITS != 32 /* temporary measure till we find spontaineous unwire of kstack */
 	vm_map_pageable(kernel_map, addr, addr+size, TRUE);
 	pmap_collect(vm_map_pmap(&p->p_vmspace->vm_map));
 #endif

--- a/src-lib/libvm/vm_page.c
+++ b/src-lib/libvm/vm_page.c
@@ -69,6 +69,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <arch.h>
 
 #include <vm/vm.h>
 #include <vm/vm_page.h>
@@ -260,17 +261,17 @@ vm_page_startup(start, end)
 		m->flags = 0;
 		m->object = NULL;
 		m->phys_addr = pa;
-#ifdef i386
-		if (pmap_isvalidphys(m->phys_addr)) {
-			TAILQ_INSERT_TAIL(&vm_page_queue_free, m, pageq);
-		} else {
-			/* perhaps iomem needs it's own type, or dev pager? */
-			m->flags |= PG_FICTITIOUS | PG_BUSY;
-			cnt.v_free_count--;
-		}
-#else /* i386 */
-		TAILQ_INSERT_TAIL(&vm_page_queue_free, m, pageq);
-#endif /* i386 */
+#if ARCH_BITS == 32
+        if (pmap_isvalidphys(m->phys_addr)) {
+                TAILQ_INSERT_TAIL(&vm_page_queue_free, m, pageq);
+        } else {
+                /* perhaps iomem needs it's own type, or dev pager? */
+                m->flags |= PG_FICTITIOUS | PG_BUSY;
+                cnt.v_free_count--;
+        }
+#else /* ARCH_BITS == 32 */
+        TAILQ_INSERT_TAIL(&vm_page_queue_free, m, pageq);
+#endif /* ARCH_BITS == 32 */
 		m++;
 		pa += PAGE_SIZE;
 	}


### PR DESCRIPTION
## Summary
- implement arch.h with ARCH_BITS detection helpers
- use the new header in VM sources
- install arch.h from the CMake build
- document ARCH_BITS usage for porting

## Testing
- `cmake -S . -B build -G Ninja`
- `ninja -C build` *(fails: exo_ipc.h not found and other errors)*