### PR TITLE
Add arch.h usage docs and integrate header

### DIFF
--- a/docs/cross_architecture_porting.md
+++ b/docs/cross_architecture_porting.md
@@ -20,6 +20,24 @@ platform specific optimisation.
 - Prefer compiler intrinsics over handwritten assembly except where
   specific tuning is required.
 
+### Example usage
+
+Include the header and branch on the pointer width when implementing
+architecture specific code:
+
+```c
+#include <arch.h>
+
+#if ARCH_64BIT
+    /* 64-bit optimised path */
+#else
+    /* generic fallback */
+#endif
+```
+
+The CMake build installs `arch.h` under `${CMAKE_INSTALL_PREFIX}/include`
+so out-of-tree projects can rely on it as well.
+
 ## Next Steps
 
 1. Audit existing `.s` files and move them into the `asm/` hierarchy.

--- a/src-headers/spinlock.h
+++ b/src-headers/spinlock.h
@@ -5,6 +5,7 @@
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <arch.h>
 
 
 #ifndef SPINLOCK_CACHELINE

--- a/src-uland/fs-server/vfs_bio.c
+++ b/src-uland/fs-server/vfs_bio.c
@@ -48,7 +48,8 @@
 #include <sys/trace.h>
 #include <sys/malloc.h>
 #include <sys/resourcevar.h>
-#if defined(__x86_64__) || defined(__i386__)
+#include <arch.h>
+#if ARCH_32BIT || ARCH_64BIT
 #include <immintrin.h>
 #endif
 #include <sys/time.h>
@@ -312,7 +313,7 @@ count_lock_queue()
 
 #ifdef DIAGNOSTIC
 
-#if defined(__x86_64__) || defined(__i386__)
+#if ARCH_32BIT || ARCH_64BIT
 static inline void
 zero_counts(int *c, size_t len)
 {

--- a/usr/src/sys/kern/vfs_bio.c
+++ b/usr/src/sys/kern/vfs_bio.c
@@ -47,7 +47,8 @@
 #include <sys/trace.h>
 #include <sys/malloc.h>
 #include <sys/resourcevar.h>
-#if defined(__x86_64__) || defined(__i386__)
+#include <arch.h>
+#if ARCH_32BIT || ARCH_64BIT
 #include <immintrin.h>
 #endif
 
@@ -309,7 +310,7 @@ count_lock_queue()
 
 #ifdef DIAGNOSTIC
 
-#if defined(__x86_64__) || defined(__i386__)
+#if ARCH_32BIT || ARCH_64BIT
 static inline void
 zero_counts(int *c, size_t len)
 {


### PR DESCRIPTION
## Summary
- add example of using `<arch.h>` in cross-arch porting notes
- include `<arch.h>` in spinlock implementation
- include `<arch.h>` and use ARCH_BITS checks in vfs_bio.c

## Testing
- `cmake -S . -B build -G Ninja` *(fails: 'exo_ipc.h' file not found)*
- `cmake --build build` *(fails to build due to missing headers)*