### PR TITLE
Enable multi-compiler build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential clang cmake ninja-build
+      - name: Configure
+        run: |
+          if [ "${{ matrix.compiler }}" = "gcc" ]; then
+            CC=gcc
+            CXX=g++
+          else
+            CC=clang
+            CXX=clang++
+          fi
+          cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX
+      - name: Build
+        run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.16)
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
+
+# Default to clang if no compiler was specified at configure time so callers
+# can override these via -DCMAKE_C_COMPILER and -DCMAKE_CXX_COMPILER.
+if(NOT DEFINED CMAKE_C_COMPILER)
+  set(CMAKE_C_COMPILER clang)
+endif()
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+  set(CMAKE_CXX_COMPILER clang++)
+endif()
+
 project(tarantula C)
 set(CMAKE_C_STANDARD 23)
 find_package(BISON)


### PR DESCRIPTION
## Summary
- allow overriding the compiler when configuring CMake
- set up GitHub Actions workflow to build with GCC and Clang

## Testing
- `cmake -S . -B build_clang -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` *(fails: 'exo_ipc.h' file not found)*
- `ninja -C build_clang` *(fails: missing headers)*
- `cmake -S . -B build_gcc -G Ninja -DCMAKE_C_COMPILER=gcc` *(fails: missing headers)*
- `ninja -C build_gcc` *(fails: missing headers)*