### PR TITLE
Update docs and scripts for pure CMake build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build bison flex
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_STANDARD=23 \
+                -DCMAKE_C_FLAGS='-O3' \
+                -DLLVM_ENABLE_LTO=ON
+      - name: Build
+        run: ninja -C build

--- a/README.md
+++ b/README.md
@@ -27,18 +27,23 @@ switches to `--offline` when network access is unavailable. It can optionally
 install **mk-configure** to provide an Autotools-style layer on top.
 See `docs/codex_bootstrap.md` for automating this process with a systemd unit
 that runs Codex at boot.
-The tree also ships a minimal **CMake** configuration.  Generate Ninja files
-with:
+The tree also ships a minimal **CMake** configuration.  Configure the build
+with **clang** and **Ninja** using C23 and full optimizations:
 
 ```sh
-cmake -S . -B build -G Ninja
-cmake --build build
+cmake -S . -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_STANDARD=23 \
+      -DCMAKE_C_FLAGS='-O3' \
+      -DLLVM_ENABLE_LTO=ON
+ninja -C build
 ```
 `find_package(BISON)` checks that **bison** is available.  See
 [docs/cmake_upgrade.md](docs/cmake_upgrade.md) for a gradual migration guide
 from the historic `bmake` system to CMake.  The build system always uses
-**clang** and targets C23 with `-O3`, link-time optimization and optional
-LLVM Polly/BOLT passes.
+**clang** with optional Polly and BOLT passes enabled by
+`-DLLVM_ENABLE_POLLY=ON` and post-processing the resulting binaries with
+`llvm-bolt`.
 `setup.sh` also checks `third_party/apt` for local `.deb` files and
 `third_party/pip` for Python wheels before contacting the network.
 Populate these directories with `apt-get download <pkg>` and

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -10,19 +10,13 @@ If `bison` is missing, install it and rerun `setup.sh`. The script now sets
 `YACC="bison -y"` automatically using `/etc/profile.d/yacc.sh`. Then proceed
 with the steps below.
 
-The repository also includes a simple **CMake** build. After installing the
-dependencies you can configure the entire tree using Ninja:
-
-Before building, ensure the root script `setup.sh` is run as as root to configure the environment.  The script installs all required
-packages using `apt-get update && apt-get dist-upgrade` followed by
-installation of **clang**, **bison**, **cmake** and **ninja**.  Packages that are
-missing from `apt` are retried with `pip` or `npm`.  When invoked via
-`.codex/setup.sh` the wrapper passes `--offline` if the network is unreachable.
+The repository uses **CMake** and **Ninja** exclusively.  After running
+`setup.sh` to install **clang**, **bison** and the rest of the toolchain you can
+configure the entire tree as follows:
 
 All helper scripts expect the environment variables `SRC_ULAND` and
 `SRC_KERNEL` to point to the userland and kernel source directories.  They
 default to `src-uland` and `src-kernel`.
-=
 ## 1. Build the `config` utility
 ```sh
 cmake -S ${SRC_ULAND:-usr/src}/usr.sbin/config -B build/config -G Ninja

--- a/docs/cmake_upgrade.md
+++ b/docs/cmake_upgrade.md
@@ -1,6 +1,6 @@
 # Transitioning from bmake to CMake
 
-This guide originally described a gradual approach to replace the historical `bmake` build system with a modern CMake workflow that leverages **clang** and **bison**.  The repository has now completed this transition and no longer relies on `bmake`.
+This guide originally described a gradual approach to replace the historical `bmake` build system with a modern CMake workflow that leverages **clang** and **bison**.  The repository has now completed this transition and all remaining Makefiles have been removed.
 
 ## 1. Prepare the environment
 
@@ -43,11 +43,8 @@ add_library(parser STATIC ${BISON_parser_OUTPUTS})
 
 ## 4. Incrementally convert subdirectories
 
-Convert each subdirectory in the tree and add it with `add_subdirectory()` from the top-level `CMakeLists.txt`.  Retain the existing makefiles until everything builds with CMake.
-
-## 5. Remove bmake when no longer needed
-
-Most makefiles have now been deleted. A few remain while their CMake
-equivalents are validated. Future contributions should use CMake and
-Ninja exclusively.
+Originally each subdirectory was ported one at a time using
+`add_subdirectory()` while the old makefiles remained.  The conversion is
+now complete and every target builds with CMake.  Future contributions
+should rely solely on CMake and Ninja.
 

--- a/docs/exokernel_testing.md
+++ b/docs/exokernel_testing.md
@@ -1,6 +1,6 @@
 # Booting the Exokernel with Minimal Managers
 
-This guide explains how to start the exokernel with only the essential user-level managers and verify that low-level resource allocation works. It assumes the exokernel and user managers have been built as described in [building_kernel.md](building_kernel.md).
+This guide explains how to start the exokernel with only the essential user-level managers and verify that low-level resource allocation works. Build all components using **CMake** and **Ninja** as outlined in [building_kernel.md](building_kernel.md).
 
 ## Requirements
 

--- a/tools/check_build_env.sh
+++ b/tools/check_build_env.sh
@@ -3,7 +3,8 @@
 # Outputs missing tools and returns non-zero if any are absent.
 
 missing=()
-for cmd in cmake ninja meson clang bison flex clang-format clang-tidy; do
+# verify the minimal toolchain for the CMake/Ninja build
+for cmd in cmake ninja clang bison flex clang-format clang-tidy; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     missing+=("$cmd")
   fi

--- a/tools/generate_compiledb.sh
+++ b/tools/generate_compiledb.sh
@@ -2,5 +2,7 @@
 set -euo pipefail
 SRC_ULAND_DIR="${SRC_ULAND:-src-uland}"
 TARGET_DIR=${1:-$SRC_ULAND_DIR}
-cmake -S "$TARGET_DIR" -B "$TARGET_DIR/build" -G Ninja
-compiledb ninja -C "$TARGET_DIR/build"
+cmake -S "$TARGET_DIR" -B "$TARGET_DIR/build" -G Ninja \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+ninja -C "$TARGET_DIR/build"
+cp "$TARGET_DIR/build/compile_commands.json" "$TARGET_DIR/compile_commands.json"


### PR DESCRIPTION
## Summary
- document building the tree with clang, CMake and Ninja
- remove bmake references from docs
- update CMake upgrade notes
- add a simple GitHub workflow using CMake
- adjust helper scripts for CMake

## Testing
- `cmake -S . -B build -G Ninja` *(fails: bison not found)*
- `ninja -C build` *(fails: missing headers)*
- `tools/generate_compiledb.sh src-uland` *(fails: does not contain CMakeLists.txt)*