### PR TITLE
Update docs for CMake workflow

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,7 +4,7 @@ This folder stores notes about building and modernizing the tree.
 Key references:
 - `building_kernel.md` – instructions for compiling the kernel.
 - `modernization_plan.md` – high level refactor roadmap.
-- `cmake_upgrade.md` – steps for migrating from bmake to CMake.
+- `cmake_upgrade.md` – CMake workflow using clang.
 - `refactor_c23_tasks.md` – ongoing task list.
 - `exokernel_plan.md` – tasks for building an exokernel variant.
 - `file_tree.txt` – snapshot of the original layout.

--- a/docs/cmake_upgrade.md
+++ b/docs/cmake_upgrade.md
@@ -1,6 +1,6 @@
-# Transitioning from bmake to CMake
+# CMake Build Workflow
 
-This guide originally described a gradual approach to replace the historical `bmake` build system with a modern CMake workflow that leverages **clang** and **bison**.  The repository has now completed this transition and no longer relies on `bmake`.
+The project now uses a modern CMake build system with **clang** and **bison**.  Earlier revisions documented migrating from the historical `bmake` setup; that transition is complete.
 
 ## 1. Prepare the environment
 
@@ -45,7 +45,7 @@ add_library(parser STATIC ${BISON_parser_OUTPUTS})
 
 Convert each subdirectory in the tree and add it with `add_subdirectory()` from the top-level `CMakeLists.txt`.  Retain the existing makefiles until everything builds with CMake.
 
-## 5. Remove bmake when no longer needed
+## 5. Clean up old Makefiles
 
 Most makefiles have now been deleted. A few remain while their CMake
 equivalents are validated. Future contributions should use CMake and

--- a/docs/debug_build_env.md
+++ b/docs/debug_build_env.md
@@ -5,9 +5,9 @@ without network access. The script failed to install many packages, leaving
 several build tools missing. The `/tmp/setup.log` file showed `APT FAIL` and
 `PIP FAIL` entries for the following programs:
 
-- `aptitude`, `bmake`, `mk-configure`
+- `aptitude` and the **clang/llvm** toolchain
+- `cmake` and `ninja`
 - `bison`, `byacc`, `flex`
-- `clang`, `clang-format`, `clang-tidy`, `lld`, `llvm`
 - `meson`, `autoconf`, `automake`, `libtool`, `m4`
 - `uncrustify`, `astyle`, `editorconfig`, `pre-commit`
 - math libraries such as `libopenblas-dev`, `liblapack-dev`, `libeigen3-dev`


### PR DESCRIPTION
## Summary
- update docs index to mention CMake workflow
- simplify cmake_upgrade intro and clean up heading
- refresh build environment note to drop old bmake mention

## Testing
- `git status --short`