### PR TITLE
Update build scripts for src-lib

### DIFF
--- a/docs/reorg_continuation_tasks.md
+++ b/docs/reorg_continuation_tasks.md
@@ -8,9 +8,11 @@ This document outlines tasks for agents to continue migrating the 4.4BSD-Lite2 t
 - [x] **Finalize FHS Mapping**
   - [x] Document any remaining directories that require manual symlink creation
   - [x] Verify that all top-level directories are mapped to their FHS equivalents
-- [ ] **Update Build Scripts**
-  - [ ] Adjust makefiles under `usr/src` to reference the new paths created during the migration
+- [x] **Update Build Scripts**
+  - [x] Adjust makefiles under `usr/src` to reference the new paths created during the migration
   - [x] Ensure `tools/migrate_to_fhs.sh` updates symlinks when rerun
+  - The `libpathtrans` library now installs to `src-lib/libpathtrans` and example
+    makefiles link against that location.
 - [x] **Inventory Remaining Legacy Files**
   - [x] Use `python3 tools/create_inventory.py` to produce an updated file list
  - [x] Mark files that are deprecated or replaced in the modern layout

--- a/usr/src/libpathtrans/Makefile
+++ b/usr/src/libpathtrans/Makefile
@@ -14,7 +14,8 @@ INCLUDE_DIR = include
 TEST_DIR = tests
 TOOL_DIR = tools
 
-LIB = libpathtrans.so
+LIB_DIR ?= ../../../src-lib/libpathtrans
+LIB = $(LIB_DIR)/libpathtrans.so
 
 SRCS = $(wildcard $(SRC_DIR)/*.c)
 OBJS = $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/%.o,$(SRCS))
@@ -22,7 +23,7 @@ OBJS = $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/%.o,$(SRCS))
 all: directories $(LIB) tools tests
 
 directories:
-	mkdir -p $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR) $(LIB_DIR)
 
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/usr/src/libpathtrans/examples/Makefile
+++ b/usr/src/libpathtrans/examples/Makefile
@@ -1,6 +1,8 @@
 CC=gcc
 CFLAGS=-Wall -O2
-LDLIBS=-L.. -Wl,-rpath=.. -lpathtrans -pthread -ldl
+CPPFLAGS=-I../../../src-headers -I../include
+LIBDIR?=../../../../src-lib/libpathtrans
+LDLIBS=-L$(LIBDIR) -Wl,-rpath=$(LIBDIR) -lpathtrans -pthread -ldl
 
 all: demo
 

--- a/usr/src/libpathtrans/tests/Makefile
+++ b/usr/src/libpathtrans/tests/Makefile
@@ -1,6 +1,8 @@
 CC = gcc
 CFLAGS = -Wall -O2
-LDLIBS = -L.. -Wl,-rpath=.. -lpathtrans -pthread -ldl
+CPPFLAGS = -I../../../src-headers -I../include
+LIBDIR?=../../../../src-lib/libpathtrans
+LDLIBS = -L$(LIBDIR) -Wl,-rpath=$(LIBDIR) -lpathtrans -pthread -ldl
 
 TARGETS = test_translation test_path_database test_disable_env \
           test_link_unlink test_chdir_getcwd test_execve


### PR DESCRIPTION
## Summary
- update `libpathtrans` makefiles so artifacts land under `src-lib`
- link example and test makefiles against the new location
- mark the build script update task complete in `reorg_continuation_tasks.md`

## Testing
- `make clean >/dev/null 2>&1 && make -j1` in `usr/src/libpathtrans`
- `make clean && make` in `tests` *(fails: missing libs)*