### PR TITLE
Update FHS docs for new source layout script

### DIFF
--- a/docs/fhs_migration.md
+++ b/docs/fhs_migration.md
@@ -64,11 +64,11 @@ when modernizing historic BSD trees.
    `tools/migrate_to_fhs.sh --dry-run` to review the planned actions.
 3. Execute `tools/migrate_to_fhs.sh` without `--dry-run` to copy directories
    under `/usr` and replace the originals with symlinks.
-4. Run `tools/migrate_to_src_layout.sh --dry-run` to preview how the source tree
-   will be reorganized. The script performs the same moves as
+4. **Immediately** run `tools/migrate_to_src_layout.sh --dry-run` to preview how
+   the source tree will be reorganized. The script performs the same moves as
    `tools/organize_sources.sh` and supersedes the old
    `tools/post_fhs_cleanup.sh` helper.
-5. Execute `tools/migrate_to_src_layout.sh` (add `--force` when outside the chroot)
+5. Run `tools/migrate_to_src_layout.sh` (add `--force` when outside the chroot)
    to relocate the sources. The script moves the kernel into `src-kernel`, user
    programs into `src-uland`, headers into `src-headers` and collects archive
    libraries into `src-lib`. The `src-lib` directory keeps these libraries

--- a/docs/microkernel_plan.md
+++ b/docs/microkernel_plan.md
@@ -94,19 +94,20 @@ Following this plan will separate kernel responsibilities into a microkernel whi
 
 ## Organizing Sources Under `src-*`
 
-After completing the FHS migration steps (running `migrate_to_fhs.sh` and
-`post_fhs_cleanup.sh` as described in [fhs_migration.md](fhs_migration.md)), the
-repository can be reorganized so that code lives under the `src-*` directories.
-Use `tools/organize_sources.sh` to perform this move. Preview the changes with:
+After completing the FHS migration steps (running `migrate_to_fhs.sh` as
+outlined in [fhs_migration.md](fhs_migration.md)), **immediately** run
+`tools/migrate_to_src_layout.sh` (or `tools/organize_sources.sh`) to reorganize
+the sources under the `src-*` directories. Preview the changes with:
 
 ```sh
-tools/organize_sources.sh --dry-run
+tools/migrate_to_src_layout.sh --dry-run
 ```
 
 When executed without `--dry-run`, the script relocates `sys/` into
-`src-kernel/` and `usr/src/` into `src-uland/`, leaving symlinks at the original
-paths. Running it after the migration scripts ensures the microkernel build
-operates on the consolidated layout referenced throughout this plan.
+`src-kernel/`, moves `usr/src/` into `src-uland/`, gathers headers under
+`src-headers/` and collects archive libraries under `src-lib/`. Symlinks are
+left at the old paths so the build continues to operate on the consolidated
+layout referenced throughout this plan.
 
 ## Reincarnation Server
 


### PR DESCRIPTION
## Summary
- clarify that `migrate_to_src_layout.sh` should run right after the FHS migration
- note the relocation of headers and libraries in the microkernel plan

## Testing
- `git status --short`