### PR TITLE
Add optional x86-64 optimization flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,18 @@ endif()
 
 project(tarantula C)
 set(CMAKE_C_STANDARD 23)
+
+# Optionally enable x86-64 specific optimizations. These flags target
+# baseline 64-bit CPUs with SSE2 and MMX support. The option defaults to
+# ON so users get reasonable performance out of the box, but it can be
+# disabled or overridden by specifying custom CMAKE_C_FLAGS/CMAKE_CXX_FLAGS.
+option(ENABLE_NATIVE_OPT "Use x86-64 SSE2 optimizations" ON)
+
+if(ENABLE_NATIVE_OPT AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+  set(_NATIVE_FLAGS "-march=x86-64 -mmmx -msse -msse2")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_NATIVE_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_NATIVE_FLAGS}")
+endif()
 find_package(BISON)
 if(BISON_FOUND)
   message(STATUS "Bison found: ${BISON_EXECUTABLE}")

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ cmake --build build
 from the historic `bmake` system to CMake.  The build system always uses
 **clang** and targets C23 with `-O3`, link-time optimization and optional
 LLVM Polly/BOLT passes.
+When configuring on x86‑64 hosts, the build automatically enables the
+`ENABLE_NATIVE_OPT` option, appending `-march=x86-64 -mmmx -msse -msse2`
+to the default compiler flags.  This provides conservative SIMD support
+that works on all modern 64‑bit processors.  Disable it with
+`-DENABLE_NATIVE_OPT=OFF` or by setting your own `CMAKE_C_FLAGS`.
 `setup.sh` also checks `third_party/apt` for local `.deb` files and
 `third_party/pip` for Python wheels before contacting the network.
 Populate these directories with `apt-get download <pkg>` and

--- a/docs/cmake_upgrade.md
+++ b/docs/cmake_upgrade.md
@@ -10,6 +10,12 @@ Run `setup.sh` to install clang, bison and the other toolchain components.  Code
 sudo ./setup.sh
 ```
 
+By default the top-level `CMakeLists.txt` enables a modest set of
+SSE2-related optimizations when configuring on x86‑64.  These flags
+(`-march=x86-64 -mmmx -msse -msse2`) provide a baseline that works on
+all 64‑bit processors.  Pass `-DENABLE_NATIVE_OPT=OFF` if you need to
+disable them or supply custom `CMAKE_C_FLAGS` values.
+
 ## 2. Create CMakeLists.txt next to each Makefile
 
 Start by introducing small `CMakeLists.txt` files beside the existing makefiles.  Mirror the source lists and include paths from the makefiles.  Use `add_library()` or `add_executable()` targets with the same output names.


### PR DESCRIPTION
## Summary
- add ENABLE_NATIVE_OPT option in root CMakeLists
- apply x86-64 SSE2 flags by default when ENABLE_NATIVE_OPT is on
- document the option in the build README and cmake upgrade notes

## Testing
- `cmake -S tests -B build/tests -G Ninja` *(fails: source directory does not contain CMakeLists.txt)*
- `cmake -S . -B build -G Ninja`
- `ninja -C build` *(fails to compile fs_server due to missing headers)*

------
https://chatgpt.com/codex/tasks/task_e_685a1e761e0c8331b511192877a58e65