### PR TITLE
Configure clang for baseline x86‑64‑v1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,15 @@ endif()
 
 project(tarantula C)
 set(CMAKE_C_STANDARD 23)
+
+# When using Clang, compile for a baseline x86 CPU and enable
+# SSE2/MMX support.  The baseline can be overridden with
+# -DBASELINE_CPU=<arch> at configure time.
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+  set(BASELINE_CPU "x86-64-v1" CACHE STRING "Architecture passed to -march")
+  set(BASE_CFLAGS -march=${BASELINE_CPU} -msse2 -mmmx -mfpmath=sse -O3)
+  set(BASE_LDFLAGS -fuse-ld=lld)
+endif()
 find_package(BISON)
 if(BISON_FOUND)
   message(STATUS "Bison found: ${BISON_EXECUTABLE}")
@@ -50,5 +59,14 @@ target_compile_definitions(fs_server PRIVATE KERNEL)
 target_link_libraries(fs_server PRIVATE ipc)
 
 install(FILES src-headers/arch.h DESTINATION include)
+
+# Apply baseline compile and link options to all targets when using Clang.
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+  set(ALL_TARANTULA_TARGETS ipc posix kern_stubs fs_server)
+  foreach(t ${ALL_TARANTULA_TARGETS})
+    target_compile_options(${t} PRIVATE ${BASE_CFLAGS})
+    target_link_options(${t} PRIVATE ${BASE_LDFLAGS})
+  endforeach()
+endif()
 
 

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -13,7 +13,13 @@ with the steps below.
 The repository also includes a simple **CMake** build. After installing the
 dependencies you can configure the entire tree using Ninja:
 
-Before building, ensure the root script `setup.sh` is run as as root to configure the environment.  The script installs all required
+The toolchain targets the baseline **x86-64-v1** CPU so that the resulting
+binaries run on a wide range of 64‑bit hardware.  Clang is invoked with
+`-march=x86-64-v1`, `-msse2`, `-mmmx` and `-mfpmath=sse`; linking defaults to
+`lld` with `-O3` optimization.  The CPU baseline can be overridden by passing
+`-DBASELINE_CPU=x86-64` (or another value) when invoking **CMake**.
+
+Before building, ensure the root script `setup.sh` is run as root to configure the environment.  The script installs all required
 packages using `apt-get update && apt-get dist-upgrade` followed by
 installation of **clang**, **bison**, **cmake** and **ninja**.  Packages that are
 missing from `apt` are retried with `pip` or `npm`.  When invoked via
@@ -41,7 +47,9 @@ This creates a directory such as `../compile/GENERIC.i386`.
 ```sh
 cmake -S ../compile/GENERIC.i386 -B build/kernel -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_C_STANDARD=23 -DCMAKE_C_FLAGS='-O3' \
+      -DCMAKE_C_STANDARD=23 \
+      -DCMAKE_C_FLAGS='-O3 -fuse-ld=lld' \
+      -DCMAKE_CXX_FLAGS='-O3 -fuse-ld=lld' \
       -DLLVM_ENABLE_LTO=ON
 ninja -C build/kernel
 ```


### PR DESCRIPTION
## Summary
- add BASELINE_CPU option and clang guard in root CMake
- apply compile/link options per target
- clarify the new option and fix typo in building instructions

## Testing
- `cmake -S . -B build -G Ninja -DBASELINE_CPU=x86-64`
- `ninja -C build` *(fails: unknown type name 'off_t')*

------
https://chatgpt.com/codex/tasks/task_e_685a1ebaea0c83318f5f3fe32e115783