### PR TITLE
Add pre-commit config and update docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v15.0.7
+    hooks:
+      - id: clang-format
+  - repo: https://github.com/pre-commit/mirrors-clang-tidy
+    rev: v15.0.7
+    hooks:
+      - id: clang-tidy
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.1
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+        args: [--ignore-words-list=hte,teh]

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -1,9 +1,11 @@
 # Using pre-commit
 
 This repository provides a `.pre-commit-config.yaml` with hooks for
-`clang-format`, `clang-tidy`, `shellcheck` and `codespell`. Running `setup.sh`
-installs the `pre-commit` tool via both `apt` and `pip`, installs `codespell`,
-and Codex automation calls `.codex/setup.sh` to ensure these tools are present in CI.
+`clang-format`, `clang-tidy`, `shellcheck` and `codespell`. After cloning the
+repository run `pre-commit install --install-hooks` to set up the local git
+hooks. Running `setup.sh` installs the `pre-commit` tool via both `apt` and
+`pip`, installs `codespell`, and Codex automation calls `.codex/setup.sh` to
+ensure these tools are present in CI.
 The wrapper also installs additional theorem provers such as Agda and Isabelle/HOL to
 support formal verification tasks and automatically configures the git hooks.
 The script also installs `shellcheck` using `apt_pin_install` with a fallback to `pip`. Additional Python


### PR DESCRIPTION
## Summary
- add a `.pre-commit-config.yaml` with clang-format, clang-tidy, shellcheck and codespell
- clarify how to install hooks in `docs/precommit.md`

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/precommit.md` *(fails: asks for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685a1eda9e388331a94b37e7804dd894