### PR TITLE
Update optimization flags

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -65,8 +65,8 @@ fi
 cat <<'ENV' | sudo tee /etc/profile.d/tarantula.sh >/dev/null
 export CC=clang
 export CXX=clang++
-export CFLAGS="-O3 -march=native"
-export CXXFLAGS="-O3 -march=native"
+export CFLAGS="-O3 -march=x86-64-v1 -mfpmath=sse -msse"
+export CXXFLAGS="-O3 -march=x86-64-v1 -mfpmath=sse -msse"
 export LDFLAGS="-fuse-ld=lld"
 ENV
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 
 project(tarantula C)
 set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -march=x86-64-v1 -mfpmath=sse -msse")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=x86-64-v1 -mfpmath=sse -msse")
 find_package(BISON)
 if(BISON_FOUND)
   message(STATUS "Bison found: ${BISON_EXECUTABLE}")

--- a/docs/performance_notes.md
+++ b/docs/performance_notes.md
@@ -13,3 +13,16 @@ vector 0.0020s
 
 The AVX2 path offers a small win over the scalar implementation. Systems
 without AVX2/SSE2 automatically fall back to the portable code path.
+
+## Default optimization flags
+
+The build system now defaults to SSE-backed math operations for consistent
+floating-point semantics on modern hardware. Both `.codex/setup.sh` and the
+top-level `CMakeLists.txt` export the flags:
+
+```sh
+-O3 -march=x86-64-v1 -mfpmath=sse -msse
+```
+
+These options tune the generated binaries for a minimal x86-64 baseline while
+ensuring the compiler emits SSE instructions instead of the legacy x87 stack.


### PR DESCRIPTION
## Summary
- export SSE-focused optimization flags in `.codex/setup.sh`
- append those flags to the global CMake configuration
- document the new defaults in `docs/performance_notes.md`

## Testing
- `cmake -S ${SRC_ULAND:-usr/src}/usr.sbin/config -B build/config -G Ninja` *(fails: The source directory does not appear to contain CMakeLists.txt)*
- `cmake -S tests -B build/tests -G Ninja` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_685a1ec9f8a083318d234868f2b31e25