### PR TITLE
Remove KERNEL flag for fs_server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ target_include_directories(fs_server PRIVATE
   ${CMAKE_SOURCE_DIR}/sys
   ${CMAKE_SOURCE_DIR}/sys/sys
   ${CMAKE_SOURCE_DIR}/sys/i386/include)
-target_compile_definitions(fs_server PRIVATE KERNEL)
 target_link_libraries(fs_server PRIVATE ipc)
 
 install(FILES src-headers/arch.h DESTINATION include)

--- a/src-uland/fs-server/fs_open.c
+++ b/src-uland/fs-server/fs_open.c
@@ -1,6 +1,7 @@
 /* Simple wrapper used by the exokernel file hook. */
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/types.h>
 #include "fs_server.h"
 
 int


### PR DESCRIPTION
## Summary
- drop `KERNEL` compile definition from fs_server build
- include `<sys/types.h>` for explicit system types

## Testing
- `cmake -S . -B build -G Ninja`
- `ninja -C build fs_server` *(fails: unknown type names)*

------
https://chatgpt.com/codex/tasks/task_e_685a1ecade708331b38b3927306428fe