### PR TITLE
Fix header types and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 compile/                       # legacy compile output directory
 build/                         # top-level build output
 **/build/                      # per-module build dirs
+build_*/                       # numbered build directories
+builds/                        # aggregated build outputs
+*/CMakeFiles/                  # CMake intermediate files
 
 # ── 2. Compiled files ───────────────────────────────────────────────────────
 **/*.o                         # object files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,0 +1,8 @@
+# Project Status
+
+## Recent Updates
+- Added compatibility typedef for run counters in `src-headers/exokernel.h`.
+- Included `<stdio.h>` and `<math.h>` in `src-headers/sys/systm.h` to avoid warnings.
+- Updated `.gitignore` to exclude `build_*`, `builds/`, and `*/CMakeFiles/` directories.
+- Removed the temporary `build/` directory.
+

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -15,8 +15,18 @@ void sched_lock_release(void);
  * Counters tracking the number of processes swapped in and out.
  * Derived from historic BSD scheduler variables.
  */
-extern _BitInt(32) runin;
-extern _BitInt(32) runout;
+/* Use the C23 _BitInt type when available, otherwise fall back
+ * to a standard 32-bit integer.  This keeps the headers compatible
+ * with older compilers that may not yet implement _BitInt. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+typedef _BitInt(32) run_counter_t;
+#else
+#include <stdint.h>
+typedef int32_t run_counter_t;
+#endif
+
+extern run_counter_t runin;
+extern run_counter_t runout;
 
 void sched_increment_runin(void);
 void sched_increment_runout(void);

--- a/src-headers/sys/systm.h
+++ b/src-headers/sys/systm.h
@@ -43,6 +43,8 @@
 #define _SYS_SYSTM_H_
 
 #include <stdnoreturn.h>
+#include <stdio.h>   /* for printf prototype */
+#include <math.h>    /* for log prototype */
 
 /*
  * The `securelevel' variable controls the security level of the system.


### PR DESCRIPTION
## Summary
- update `.gitignore` with additional build artifact patterns
- add `_BitInt` fallback typedef to `exokernel.h`
- include std headers in `systm.h` to silence warnings
- record cleanup steps in `PROJECT_STATUS.md`

## Testing
- `tools/check_build_env.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a9e5aeb548331bd6f02cb1b6d81f2