### PR TITLE
tools: enforce strict mode in build warning collector

### DIFF
--- a/tools/build_collect_warnings.sh
+++ b/tools/build_collect_warnings.sh
@@ -1,10 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 # Build userland with optional CSTD and ARCH flags and store warnings.
-set -e
+#
+# Enable strict mode:
+#   -e  : exit immediately on errors
+#   -u  : treat unset variables as an error
+#   -o pipefail : capture failures across piped commands
+set -euo pipefail
 LOGDIR="build_logs"
 mkdir -p "$LOGDIR"
 ARCH_FLAGS=""
-case "${ARCH}" in
+# Evaluate optional ARCH flag; default to native when unset.
+case "${ARCH:-}" in
     i686)
         ARCH_FLAGS="-m32"
         ;;
@@ -14,5 +20,8 @@ case "${ARCH}" in
 esac
 
 SRC_ULAND_DIR="${SRC_ULAND:-src-uland}"
-make -C "$SRC_ULAND_DIR" CC="${CC:-cc}" CSTD="${CSTD:--std=c2x}" CFLAGS="${CFLAGS} ${ARCH_FLAGS}" \
+make -C "$SRC_ULAND_DIR" \
+    CC="${CC:-cc}" \
+    CSTD="${CSTD:--std=c2x}" \
+    CFLAGS="${CFLAGS:-} ${ARCH_FLAGS}" \
     2>&1 | tee "$LOGDIR/build_${ARCH:-native}.log"


### PR DESCRIPTION
## Summary
- strengthen build warnings script with `set -euo pipefail`
- default optional environment variables for robust execution
- switch to bash shebang for pipefail support

## Testing
- `bash tools/build_collect_warnings.sh >/tmp/build_log.txt` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6892eb9ec6588331a00b0f99aed646a8