### PR TITLE
fs-server: remove redundant sys/types include

### DIFF
--- a/src-uland/fs-server/fs_open.c
+++ b/src-uland/fs-server/fs_open.c
@@ -1,12 +1,7 @@
 /* Simple wrapper used by the exokernel file hook. */
-#include <sys/types.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/types.h>
 #include "fs_server.h"
+#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-int
-fs_open(const char *path, int flags)
-{
-    return open(path, flags, 0);
-}
+int fs_open(const char *path, int flags) { return open(path, flags, 0); }


### PR DESCRIPTION
## Summary
- remove duplicate `sys/types.h` include from `fs_open.c`
- run `clang-format` for consistent style

## Testing
- `make -C tests fs_open.o`
- `pre-commit run --files src-uland/fs-server/fs_open.c` *(fails: prompts for GitHub username)*

------
https://chatgpt.com/codex/tasks/task_e_6892eb96be48833186f3e8b5e15ec962