### PR TITLE
docs: normalize code fences in performance notes

### DIFF
--- a/docs/performance_notes.md
+++ b/docs/performance_notes.md
@@ -1,16 +1,13 @@
-```markdown
 # Performance Notes
 
 ## Vectorized `vfs_bufstats`
 
 A microbenchmark located at `tools/bench_vfs_bufstats.c` compares the new vectorized zeroing routine against the previous scalar loop. On the CI container (x86-64, clang -O2) running 10 million iterations:
 
-```
-
+```text
 scalar 0.0021 s
 vector 0.0020 s
-
-````
+```
 
 The AVX2 path offers a small win over the scalar implementation. Systems without AVX2/SSE2 automatically fall back to the portable code path.
 
@@ -20,7 +17,7 @@ The build system now defaults to SSE-backed math operations for consistent float
 
 ```sh
 -O3 -march=x86-64-v1 -mfpmath=sse -msse2 -mmmx
-````
+```
 
 These options tune the generated binaries for a minimal x86-64 baseline while ensuring the compiler emits SSE and MMX instructions (and avoids legacy x87) for predictable performance.
 
@@ -44,3 +41,4 @@ On an Intel i7-8650U laptop, our `bench_fs_rpc` microbenchmark shows approximate
 * **Additional for Clang-built `fs_server`**: `-msse -msse2 -mavx2`
 
 Systems lacking SSE2/AVX2 automatically fall back to portable scalar code paths without any manual intervention.
+


### PR DESCRIPTION
## Summary
- standardize code fences in `docs/performance_notes.md`
- ensure benchmarks, shell flags, and CMake examples render with explicit languages

## Testing
- `pandoc docs/performance_notes.md -o /tmp/performance_notes.html`
- `pre-commit run --files docs/performance_notes.md` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_6892eb962434833195328373c9876c88