### PR TITLE
tools: clean up temp mount on failure

### DIFF
--- a/tools/create_exokernel_image.sh
+++ b/tools/create_exokernel_image.sh
@@ -26,6 +26,8 @@ dd if=/dev/zero of="$IMAGE" bs=1 count=0 seek=$SIZE
 mke2fs -q "$IMAGE"
 
 MNT=$(mktemp -d)
+# Ensure the mount point is dismantled even on premature exit.
+trap 'umount "$MNT" && rmdir "$MNT"' EXIT
 mount -o loop "$IMAGE" "$MNT"
 
 mkdir -p "$MNT/boot" "$MNT/bin" "$MNT/sbin"
@@ -35,7 +37,5 @@ cp "$FS_SERVER_BIN" "$MNT/bin/"
 cp "$PROC_MGR_BIN" "$MNT/bin/"
 
 sync
-umount "$MNT"
-rmdir "$MNT"
 
 echo "Created $IMAGE"


### PR DESCRIPTION
## Summary
- ensure `create_exokernel_image.sh` unmounts and removes its temporary mount directory via a trap

## Testing
- `PATH="$(pwd)/fakebin:$PATH" sh -x tools/create_exokernel_image.sh test.img 2>&1 && echo success || echo failure`
- `ls /tmp | grep 3LaxYJ5vmo && echo exists || echo cleaned`

------
https://chatgpt.com/codex/tasks/task_e_6892eb9f50488331b12af3a55e68c1ac