### PR TITLE
Document Meson/Bison tooling in build setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ endif()
 # ────────────────────────────────────────────────────────────────────────────
 # Native optimization flags
 # ────────────────────────────────────────────────────────────────────────────
-option(ENABLE_NATIVE_OPT "Enable baseline x86-64-v1 + SSE2 + MMX optimizations" ON)
-set(BASELINE_CPU "x86-64-v1" CACHE STRING "Architecture passed to -march")
+option(ENABLE_NATIVE_OPT "Enable baseline x86-64 + SSE2 + MMX optimizations" ON)
+set(BASELINE_CPU "x86-64" CACHE STRING "Architecture passed to -march")
 
 if(ENABLE_NATIVE_OPT AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Enabling native optimizations: -march=${BASELINE_CPU} -msse2 -mmmx -mfpmath=sse -O3")
@@ -41,9 +41,9 @@ else()
   set(BASE_LDFLAGS -fuse-ld=lld)
 endif()
 
-# Apply flags globally to all C targets
-string(APPEND CMAKE_C_FLAGS          " ${BASE_CFLAGS}")
-string(APPEND CMAKE_EXE_LINKER_FLAGS " ${BASE_LDFLAGS}")
+# Apply flags globally to all C targets using list-aware helpers
+add_compile_options(${BASE_CFLAGS})
+add_link_options(${BASE_LDFLAGS})
 
 # ────────────────────────────────────────────────────────────────────────────
 # Bison detection

--- a/docs/building_kernel.md
+++ b/docs/building_kernel.md
@@ -4,7 +4,7 @@
 This guide shows how to compile the historic **4.4BSD-Lite2** sources on an **x86_64** (or **i386** with `-m32`) Linux host using **Clang**, **CMake**, and **Ninja**. It assumes you have root privileges to install toolchains and that your repo includes:
 
 - `docs/setup_guide.md`       – outlines required packages and environment variables
-- `tools/check_build_env.sh`  – enforces `$YACC="bison -y"`
+- `tools/check_build_env.sh`  – verifies presence of build tools like `clang` and `bison`
 
 All helper scripts respect:
 
@@ -20,21 +20,15 @@ export SRC_KERNEL=${SRC_KERNEL:-src-kernel} # kernel sources
 1. **Install the toolchain** using your system package manager:
 
    ```bash
-   sudo apt-get update
-   sudo apt-get install -y \
+   sudo apt update
+   sudo apt install -y \
      build-essential cmake ninja-build \
      clang lld lldb llvm \
-     bison byacc flex \
+     bison flex \
      bear ccache gdb ripgrep \
      clang-format clang-tidy pre-commit
    ```
-2. **Ensure** `$YACC` is correct for legacy Makefiles:
-
-   ```bash
-   source /etc/profile.d/yacc.sh       # sets YACC="bison -y"
-   tools/check_build_env.sh            # validates YACC value
-   ```
-3. **Verify** required tools:
+2. **Verify** required tools:
 
    ```bash
    command -v clang
@@ -47,11 +41,11 @@ export SRC_KERNEL=${SRC_KERNEL:-src-kernel} # kernel sources
 
 ## 2 · Baseline CPU & Linker Flags
 
-By default we target **x86-64-v1** with SSE2/MMX and LLVM’s `lld`.  To set this globally, pass:
+By default we target **x86-64** with SSE2/MMX and LLVM’s `lld`.  To set this globally, pass:
 
 ```bash
--DCMAKE_C_FLAGS="-O3 -fuse-ld=lld -march=x86-64-v1 -msse2 -mmmx -mfpmath=sse" \
--DCMAKE_CXX_FLAGS="-O3 -fuse-ld=lld -march=x86-64-v1 -msse2 -mmmx -mfpmath=sse"
+-DCMAKE_C_FLAGS="-O3 -fuse-ld=lld -march=x86-64 -msse2 -mmmx -mfpmath=sse" \
+-DCMAKE_CXX_FLAGS="-O3 -fuse-ld=lld -march=x86-64 -msse2 -mmmx -mfpmath=sse"
 ```
 
 If you need a different microarchitecture, override with:

--- a/docs/performance_notes.md
+++ b/docs/performance_notes.md
@@ -16,7 +16,7 @@ The AVX2 path offers a small win over the scalar implementation. Systems without
 The build system now defaults to SSE-backed math operations for consistent floating-point semantics on modern hardware. The top-level `CMakeLists.txt` exports the following baseline flags:
 
 ```sh
--O3 -march=x86-64-v1 -mfpmath=sse -msse2 -mmmx
+-O3 -march=x86-64 -mfpmath=sse -msse2 -mmmx
 ```
 
 These options tune the generated binaries for a minimal x86-64 baseline while ensuring the compiler emits SSE and MMX instructions (and avoids legacy x87) for predictable performance.
@@ -37,7 +37,7 @@ On an Intel i7-8650U laptop, our `bench_fs_rpc` microbenchmark shows approximate
 
 **Summary of Flags Across All Targets**
 
-* **Baseline (all targets)**: `-O3 -march=x86-64-v1 -mfpmath=sse -msse2 -mmmx`
+* **Baseline (all targets)**: `-O3 -march=x86-64 -mfpmath=sse -msse2 -mmmx`
 * **Additional for Clang-built `fs_server`**: `-msse -msse2 -mavx2`
 
 Systems lacking SSE2/AVX2 automatically fall back to portable scalar code paths without any manual intervention.

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -7,11 +7,11 @@ This guide documents how to provision a development host for the Tarantula tree.
 Update the package index and install the required packages:
 
 ```bash
-sudo apt-get update
-sudo apt-get install -y \
-  build-essential cmake ninja-build \
+sudo apt update
+sudo apt install -y \
+  build-essential cmake ninja-build meson \
   clang lld lldb llvm \
-  bison byacc flex \
+  bison flex \
   bear ccache gdb ripgrep \
   clang-format clang-tidy pre-commit
 ```
@@ -19,8 +19,8 @@ sudo apt-get install -y \
 | Tool                     | Purpose                                                         |
 |--------------------------|-----------------------------------------------------------------|
 | `clang`, `lld`, `lldb`, `llvm` | LLVM-based compiler, linker and debugger suite                 |
-| `bison`, `byacc`, `flex` | Yacc/Lex implementations required by legacy build scripts       |
-| `cmake`, `ninja-build`   | Configure and drive the modern CMake build                      |
+| `bison`, `flex` | Parser and lexer generators used by legacy build scripts       |
+| `cmake`, `ninja-build`, `meson`   | Configure and drive modern build systems                      |
 | `bear`                   | Generate `compile_commands.json` for `clang-tidy` and `clangd`  |
 | `ccache`                 | Cache object files to speed up repeated builds                  |
 | `gdb`, `lldb`            | Native and LLVM debuggers                                       |
@@ -28,10 +28,9 @@ sudo apt-get install -y \
 | `clang-format`, `clang-tidy` | Code formatting and static analysis                         |
 | `pre-commit`             | Manage git hooks and linting                                   |
 
-After provisioning, export the legacy `YACC` variable and verify the toolchain:
+After provisioning, verify the toolchain:
 
 ```bash
-export YACC="bison -y"
 tools/check_build_env.sh
 ```
 
@@ -46,15 +45,15 @@ JavaScript tools, and source builds when no distribution package exists.
 | Tool       | Installation Method | Example Command                                                                 |
 |------------|---------------------|---------------------------------------------------------------------------------|
 | lizard     | pip                  | `pip install lizard`                                                           |
-| cloc       | apt                  | `sudo apt-get install cloc`                                                    |
-| cscope     | apt                  | `sudo apt-get install cscope`                                                  |
+| cloc       | apt                  | `sudo apt install cloc`                                                        |
+| cscope     | apt                  | `sudo apt install cscope`                                                      |
 | diffoscope | pip                  | `pip install diffoscope`                                                       |
 | dtrace     | source build        | `git clone https://github.com/dtrace4linux/linux.git && cd linux && make && sudo make install` |
-| valgrind   | apt                  | `sudo apt-get install valgrind`                                                |
-| cppcheck   | apt                  | `sudo apt-get install cppcheck`                                                |
-| sloccount  | apt                  | `sudo apt-get install sloccount`                                               |
-| flawfinder | apt                  | `sudo apt-get install flawfinder`                                              |
-| gdb        | apt                  | `sudo apt-get install gdb`                                                     |
+| valgrind   | apt                  | `sudo apt install valgrind`                                                    |
+| cppcheck   | apt                  | `sudo apt install cppcheck`                                                    |
+| sloccount  | apt                  | `sudo apt install sloccount`                                                   |
+| flawfinder | apt                  | `sudo apt install flawfinder`                                                  |
+| gdb        | apt                  | `sudo apt install gdb`                                                         |
 | pylint     | pip                  | `pip install pylint`                                                           |
 | flake8     | pip                  | `pip install flake8`                                                           |
 | mypy       | pip                  | `pip install mypy`                                                             |
@@ -70,7 +69,7 @@ For configuration details see [tool_config.md](tool_config.md). Sample outputs f
 
 The `tools/` directory contains utilities that complement the build environment:
 
-- `check_build_env.sh` – validates variables such as `YACC="bison -y"`.
+- `check_build_env.sh` – confirms required build tools like `meson` and `bison`.
 - `build_collect_warnings.sh` – compiles sources and aggregates compiler warnings.
 - `generate_compiledb.sh` – emits a `compile_commands.json` database.
 - `run_clang_tidy.sh` – runs `clang-tidy` across the tree using the database.

--- a/tools/check_build_env.sh
+++ b/tools/check_build_env.sh
@@ -9,11 +9,6 @@ for cmd in cmake ninja meson clang bison flex clang-format clang-tidy; do
   fi
 done
 
-# YACC must be explicitly set to "bison -y" after provisioning
-if [ "${YACC:-}" != "bison -y" ]; then
-  missing+=("YACC=\"bison -y\"")
-fi
-
 if [ ${#missing[@]} -eq 0 ]; then
   echo "All required build tools are present."
 else


### PR DESCRIPTION
## Summary
- Standardize setup and build docs on `apt` commands and drop legacy YACC references
- Correct CMake flag handling and default to `-march=x86-64` for portable builds

## Testing
- `sudo apt update`
- `sudo apt install -y build-essential cmake ninja-build meson clang lld lldb llvm bison flex bear ccache gdb ripgrep clang-format clang-tidy pre-commit`
- `tools/check_build_env.sh`
- `cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=clang`
- `cmake --build build` *(fails: unknown type name 'off_t')*

------
https://chatgpt.com/codex/tasks/task_e_6897f82061048331b87ba541f0d3a56a

## Summary by Sourcery

Integrate Meson into the documented build workflow, remove legacy YACC/byacc tooling, standardize on apt commands, simplify environment checks, and update default CPU architecture and CMake flag handling for portable x86-64 builds.

New Features:
- Document Meson as a supported build tool in the setup guide

Enhancements:
- Default baseline architecture updated from x86-64-v1 to x86-64 in CMake and documentation
- Switch CMake to use add_compile_options and add_link_options instead of string(APPEND) for global flags

Documentation:
- Standardize installation instructions on apt instead of apt-get across all setup and kernel build docs
- Remove legacy byacc/YACC references from setup guide, kernel build guide, and build environment check script
- Update performance notes to reflect the new baseline -march=x86-64 flags

Chores:
- Clean up tools/check_build_env.sh to drop YACC validation and include Meson in required tool list