### PR TITLE
Fix config Makefile for BSD make and modern toolchains

### DIFF
--- a/usr/src/usr.sbin/config/Makefile
+++ b/usr/src/usr.sbin/config/Makefile
@@ -2,18 +2,18 @@
 
 PROG=   config
 SRCS=   config.c main.c lang.c mkioconf.c mkmakefile.c mkglue.c mkheaders.c \
-        mkswapconf.c mkubglue.c
-CFLAGS+=-I${.CURDIR} -I.
+	mkswapconf.c mkubglue.c
+CFLAGS+=-I${.CURDIR} -I. -fcommon
 DPADD=  ${LIBL}
 LDADD=  -ll
 CLEANFILES=config.c y.tab.c y.tab.h lang.c lex.yy.c
 
 config.c y.tab.h: config.y
-        ${YACC} -d ${.CURDIR}/config.y
-        mv y.tab.c config.c
+	${YACC} -d ${.CURDIR}/config.y
+	mv y.tab.c config.c
 
 lang.c: lang.l
-        ${LEX} ${.CURDIR}/lang.l
-        mv lex.yy.c lang.c
+	${LEX} ${.CURDIR}/lang.l
+	mv lex.yy.c lang.c
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
## Summary
- Use tabs and add `-fcommon` in `usr/src/usr.sbin/config/Makefile` for BSD make compatibility and modern compilers.

## Testing
- `tools/check_build_env.sh`
- `bmake` (fails: multiple definition/undefined reference errors)

------
https://chatgpt.com/codex/tasks/task_e_689da1d72714833186efff0abd6a1944