### PR TITLE
Include POSIX signal wrappers and install IPC headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ target_compile_options(ipc PRIVATE ${BASE_CFLAGS})
 # ────────────────────────────────────────────────────────────────────────────
 add_library(posix STATIC
   src-lib/libposix/posix.c
+  src-lib/libposix/posix_signal.c
 )
 target_include_directories(posix PUBLIC
   ${CMAKE_SOURCE_DIR}/src-headers
@@ -124,7 +125,15 @@ endif()
 # ────────────────────────────────────────────────────────────────────────────
 # Installation & Subdirectories
 # ────────────────────────────────────────────────────────────────────────────
-install(FILES src-headers/arch.h DESTINATION include)
+install(FILES
+  src-headers/arch.h
+  src-headers/ipc.h
+  src-headers/libipc.h
+  src-headers/posix.h
+  src-headers/posix_signal.h
+  src-headers/posix_ipc.h
+  DESTINATION include
+)
 
 # Build userland servers converted from historical Makefiles
 add_subdirectory(src-uland/servers/proc_manager)

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -4,6 +4,21 @@ This document describes the lightweight mailbox mechanism used by the
 microkernel stubs and user–space servers.  The API lives in
 `src-headers/ipc.h` and is implemented by `src-lib/libipc/ipc.c`.
 
+## Building and Installing
+
+Build the IPC and POSIX helper libraries and install their public headers
+with CMake:
+
+```bash
+cmake -S . -B build
+cmake --build build --target ipc posix
+cmake --install build --prefix /usr/local
+```
+
+The install step places `ipc.h`, `libipc.h`, `posix.h`, `posix_signal.h`,
+and `posix_ipc.h` under `/usr/local/include` for use by downstream
+projects.
+
 ## Mailbox Creation
 
 A mailbox is represented by `struct ipc_queue`.  The queue stores a fixed
@@ -122,4 +137,10 @@ int cap_shm_unlink(int dirfd, const char *name);
 ```
 
 The program `tests/modern/posix_ipc_demo.c` demonstrates basic usage of
-these helpers.
+these helpers. Build and run the example with the host's default
+compilers (override with `CC`/`CXX` as needed):
+
+```
+make -C tests posix_ipc_demo
+./tests/posix_ipc_demo
+```

--- a/docs/posix_signals.md
+++ b/docs/posix_signals.md
@@ -11,4 +11,10 @@ int posix_killpg(int pgrp, int sig);
 ```
 
 The program `tests/modern/posix_signal_demo.c` demonstrates installing a
-custom handler and sending a signal to the current process group.
+custom handler and sending a signal to the current process group. Build and
+run the example via
+
+```
+make -C tests posix_signal_demo
+./tests/posix_signal_demo
+```

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,16 +1,18 @@
-CC = clang
-CXX ?= clang++
-CFLAGS ?= -O2 -std=c23 -Wall -Werror
-CXXFLAGS ?= -O2 -std=c++23 -Wall -Werror
+CC ?= cc
+CXX ?= c++
+CFLAGS ?= -O2 -pipe -std=c2x -Wall -Wextra -Werror
+CXXFLAGS ?= -O2 -pipe -std=c++23 -Wall -Wextra -Werror
 CXXFLAGS += -D_Static_assert=static_assert
-	CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel -I../include
+CPPFLAGS = -I../tests/include -I../src-headers -I../src-headers/machine -I../src-kernel -I../include
 LIBS = ../build/libkern_stubs.a ../build/libipc.a ../build/libposix.a
 	
 OBJS = test_kern.o fs_open.o pm_entry.o vm_entry.o sched_stub.o mock_vm.o
 FIFO_OBJS = fifo_test.o
-	MAILBOX_OBJS = test_mailbox.o
+MAILBOX_OBJS = test_mailbox.o
+POSIX_SIG_OBJS = modern/posix_signal_demo.o
+POSIX_IPC_OBJS = modern/posix_ipc_demo.o
 
-all: test_kern spinlock_cpp mailbox_test fifo_test
+all: test_kern spinlock_cpp mailbox_test fifo_test posix_signal_demo posix_ipc_demo
 
 test_kern: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LIBS) -o $@
@@ -23,6 +25,12 @@ mailbox_test: $(MAILBOX_OBJS)
 
 fifo_test: $(FIFO_OBJS)
 	$(CC) $(CFLAGS) $(FIFO_OBJS) $(LIBS) -o $@
+
+posix_signal_demo: $(POSIX_SIG_OBJS)
+	$(CC) $(CFLAGS) $(POSIX_SIG_OBJS) $(LIBS) -o $@
+
+posix_ipc_demo: $(POSIX_IPC_OBJS)
+	$(CC) $(CFLAGS) $(POSIX_IPC_OBJS) $(LIBS) -o $@
 
 fs_open.o: ../src-uland/fs-server/fs_open.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
@@ -42,6 +50,12 @@ sched_stub.o: sched_stub.c
 test_mailbox.o: test_mailbox.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
+modern/posix_signal_demo.o: modern/posix_signal_demo.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+modern/posix_ipc_demo.o: modern/posix_ipc_demo.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
 fifo_test.o: fifo_test.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
@@ -49,6 +63,6 @@ test_spinlock.o: test_spinlock.cpp
 	$(CXX) $(CXXFLAGS) -I../src-headers -c $< -o $@
 
 clean:
-	rm -f $(OBJS) $(MAILBOX_OBJS) $(FIFO_OBJS) test_kern spinlock_cpp mailbox_test fifo_test test_spinlock.o
+	rm -f $(OBJS) $(MAILBOX_OBJS) $(FIFO_OBJS) $(POSIX_SIG_OBJS) $(POSIX_IPC_OBJS) test_spinlock.o test_kern spinlock_cpp mailbox_test fifo_test posix_signal_demo posix_ipc_demo test_spinlock
 
 .PHONY: all clean

--- a/tests/modern/posix_ipc_demo.c
+++ b/tests/modern/posix_ipc_demo.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE  /* expose AT_FDCWD on glibc */
 #include "../../src-headers/posix_ipc.h"
 #include <assert.h>
 #include <unistd.h>

--- a/tests/sched_stub.c
+++ b/tests/sched_stub.c
@@ -5,8 +5,8 @@ SPINLOCK_DEFINE(sched_lock);
 void sched_lock_acquire(void) {}
 void sched_lock_release(void) {}
 
-_BitInt(32) runin = 0;
-_BitInt(32) runout = 0;
+run_counter_t runin = 0;
+run_counter_t runout = 0;
 void sched_increment_runin(void) { runin++; }
 void sched_increment_runout(void) { runout++; }
 


### PR DESCRIPTION
## Summary
- compile posix_signal.c into the POSIX compatibility library
- install IPC and POSIX headers for downstream use
- add posix_signal_demo test target and document usage
- add POSIX IPC demo exercising message queue, semaphore and shared memory helpers
- default test Makefile to system compilers and remove _BitInt dependency in scheduler stub

## Testing
- `cmake -S . -B build`
- `cmake --build build --target ipc posix kern_stubs`
- `make -C tests` *(GNU cc without clang)*
- `./tests/fifo_test`
- `./tests/mailbox_test`
- `./tests/spinlock_cpp`
- `./tests/posix_signal_demo`
- `./tests/posix_ipc_demo`
- `./tests/test_kern` *(segmentation fault)*
- `pre-commit run --files tests/Makefile docs/IPC.md tests/sched_stub.c` *(GitHub credential prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c26ba6c483319e4a44497fc6df4c