### PR TITLE
Point setup offline cache to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ that works on all modern 64‑bit processors.  Disable it with
 `-DENABLE_NATIVE_OPT=OFF` or by setting your own `CMAKE_C_FLAGS`.
 For offline work, pre-download `.deb` packages into `third_party/apt` and Python
 wheels into `third_party/pip` using `apt-get download <pkg>` and `pip download
-<pkg>`. Copy those archives into `offline_packages/` and install them with
-`dpkg -i` when the network is unavailable. You can verify which commands are
-available at any time by running `tools/check_build_env.sh`; it lists missing
-tools and exits non-zero when any are absent.
+<pkg>`. Copy those archives into the repository's `offline_packages/` directory
+and install them with `dpkg -i` when the network is unavailable. You can verify
+which commands are available at any time by running `tools/check_build_env.sh`;
+it lists missing tools and exits non-zero when any are absent.
 
 ## Running Tests
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# setup.sh - Provision offline package directories for BSD/Tarantula.
+#
+# This script configures paths for caching dependencies when network access is
+# restricted.  It establishes an OFFLINE_PKG_DIR environment variable pointing
+# to the repository's `offline_packages/` directory and ensures that all
+# required directories exist for later use by packaging tools or manual
+# installation steps.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+# Resolve the absolute path to the repository root, i.e. the directory that
+# contains this script. This allows the script to be invoked from any working
+# directory while still locating the offline cache correctly.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Directory for offline package archives.  Exported so subshells and invoked
+# tools can rely on this location.
+export OFFLINE_PKG_DIR="${REPO_ROOT}/offline_packages"
+
+# Ensure the required directory hierarchy exists.  The script maintains a flat
+# structure for Debian packages under OFFLINE_PKG_DIR and prepares auxiliary
+# caches for `apt` and `pip` under `third_party`.
+mkdir -p "${OFFLINE_PKG_DIR}" \
+         "${REPO_ROOT}/third_party/apt" \
+         "${REPO_ROOT}/third_party/pip"
+
+# Provide feedback so callers know where the offline cache resides.
+printf 'Offline packages will be loaded from: %s\n' "${OFFLINE_PKG_DIR}"


### PR DESCRIPTION
## Summary
- add setup.sh script that exports OFFLINE_PKG_DIR pointing to repo offline_packages and ensures required directories exist
- clarify README to mention repository's offline_packages directory

## Testing
- `./setup.sh`
- `shellcheck setup.sh`
- `pre-commit run --files setup.sh README.md` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_68b370718e908331a265768729a98157