### PR TITLE
chore: normalize variable assignment indentation

### DIFF
--- a/etc/security
+++ b/etc/security
@@ -116,7 +116,7 @@ list="/etc/csh.cshrc /etc/csh.login ${rhome}/.cshrc ${rhome}/.login"
 for i in $list ; do
 	if [ -f $i ] ; then
 		if egrep umask $i > /dev/null ; then
-			umaskset=yes
+umaskset=yes
 		fi
 		egrep umask $i |
 		awk '$2 % 100 < 20 \
@@ -158,7 +158,7 @@ list="${rhome}/.profile"
 for i in $list; do
 	if [ -f $i ] ; then
 		if egrep umask $i > /dev/null ; then
-			umaskset=yes
+umaskset=yes
 		fi
 		egrep umask $i |
 		awk '$2 % 100 < 20 \
@@ -166,9 +166,9 @@ for i in $list; do
 		     $2 % 10 < 2 \
 			{ print "Root umask is other writeable" }' >> $OUTPUT
 		/bin/sh << end-of-sh > /dev/null 2>&1
-			PATH=
+PATH=
 			. $i
-			list=\`echo \$PATH | /usr/bin/sed -e 's/:/ /g'\`
+list=\`echo \$PATH | /usr/bin/sed -e 's/:/ /g'\`
 			/bin/ls -ldgT \$list > $TMP1
 end-of-sh
 		awk '{
@@ -227,7 +227,7 @@ awk -F: '$1 != "root" && $1 != "toor" && \
 		{ print $1 " " $6 }' /etc/passwd |
 while read uid homedir; do
 	if [ -f ${homedir}/.rhosts ] ; then
-		rhost=`ls -ldgT ${homedir}/.rhosts`
+rhost=`ls -ldgT ${homedir}/.rhosts`
 		printf "$uid: $rhost\n"
 	fi
 done > $OUTPUT
@@ -253,7 +253,7 @@ fi
 awk -F: '{ print $1 " " $6 }' /etc/passwd | \
 while read uid homedir; do
 	if [ -d ${homedir}/ ] ; then
-		file=`ls -ldgT ${homedir}`
+file=`ls -ldgT ${homedir}`
 		printf "$uid $file\n"
 	fi
 done |
@@ -273,7 +273,7 @@ list=".netrc .rhosts"
 awk -F: '{ print $1 " " $6 }' /etc/passwd | \
 while read uid homedir; do
 	for f in $list ; do
-		file=${homedir}/${f}
+file=${homedir}/${f}
 		if [ -f $file ] ; then
 			printf "$uid $f `ls -ldgT $file`\n"
 		fi
@@ -296,7 +296,7 @@ list=".bashrc .cshrc .emacsrc .exrc .forward .klogin .login .logout \
 awk -F: '{ print $1 " " $6 }' /etc/passwd | \
 while read uid homedir; do
 	for f in $list ; do
-		file=${homedir}/${f}
+file=${homedir}/${f}
 		if [ -f $file ] ; then
 			printf "$uid $f `ls -ldgT $file`\n"
 		fi
@@ -326,10 +326,10 @@ fi
 
 # File systems should not be globally exported.
 awk '{
-	readonly = 0;
+readonly = 0;
 	for (i = 2; i <= NF; ++i) {
 		if ($i ~ /-ro/)
-			readonly = 1;
+readonly = 1;
 		else if ($i !~ /^-/)
 			next;
 	}
@@ -365,8 +365,8 @@ if [ -s $TMP1 ] ; then
 		printf "\nUudecode is setuid.\n"
 	fi
 
-	CUR=/var/backups/setuid.current
-	BACK=/var/backups/setuid.backup
+CUR=/var/backups/setuid.current
+BACK=/var/backups/setuid.backup
 
 	if [ -s $CUR ] ; then
 		if cmp -s $CUR $TMP1 ; then
@@ -427,8 +427,8 @@ fi
 # Display any changes in the device file list.
 egrep '^[bc]' $LIST | sort +10 > $TMP1
 if [ -s $TMP1 ] ; then
-	CUR=/var/backups/device.current
-	BACK=/var/backups/device.backup
+CUR=/var/backups/device.current
+BACK=/var/backups/device.backup
 
 	if [ -s $CUR ] ; then
 		if cmp -s $CUR $TMP1 ; then
@@ -495,7 +495,7 @@ if cd /etc/mtree; then
 
 	> $OUTPUT
 	for file in *.secure; do
-		tree=`sed -n -e '3s/.* //p' -e 3q $file`
+tree=`sed -n -e '3s/.* //p' -e 3q $file`
 		mtree -f $file -p $tree > $TMP1
 		if [ -s $TMP1 ]; then
 			printf "\nChecking $tree:\n" >> $OUTPUT
@@ -513,8 +513,8 @@ fi
 # Any changes cause the files to rotate.
 if [ -s /etc/changelist ] ; then
 	for file in `cat /etc/changelist`; do
-		CUR=/var/backups/`basename $file`.current
-		BACK=/var/backups/`basename $file`.backup
+CUR=/var/backups/`basename $file`.current
+BACK=/var/backups/`basename $file`.backup
 		if [ -s $file ]; then
 			if [ -s $CUR ] ; then
 				diff $CUR $file > $OUTPUT

--- a/tests/test_kern.c
+++ b/tests/test_kern.c
@@ -10,8 +10,8 @@
 #include "ipc.h"
 
 int main(void) {
-    /* Scheduler initialization would normally set up IPC queues.
-       For this lightweight smoke test it is skipped. */
+    ipc_mailbox_init();
+    kern_sched_init();
 
     int fd = kern_open("README.md", O_RDONLY);
     if (fd < 0) {


### PR DESCRIPTION
## Summary
- remove leading tabs from variable assignments in `etc/security`
- initialize IPC and scheduler stubs in `tests/test_kern.c` so the kernel smoke test runs

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build --target ipc posix kern_stubs`
- `make -C tests`
- `./tests/test_kern`


------
https://chatgpt.com/codex/tasks/task_e_68b37072cb4c8331a708c8c6b48668a5