### PR TITLE
tests: add IPC loopback smoke test and document build steps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: v15.0.7
     hooks:
       - id: clang-format
-  - repo: https://github.com/pre-commit/mirrors-clang-tidy
-    rev: v15.0.7
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
     hooks:
       - id: clang-tidy
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/README.md
+++ b/README.md
@@ -55,34 +55,29 @@ tools and exits non-zero when any are absent.
 
 ## Running Tests
 
-Ensure the toolchain from [docs/setup_guide.md](docs/setup_guide.md) is
-installed before running the tests.
+Install the prerequisites described in
+[docs/setup_guide.md](docs/setup_guide.md) — the successor to the
+historical `setup.sh` script — before building the test suite.
 
-### Makefile targets
-
-The historical `tests/Makefile` builds four self-contained binaries:
-
-```sh
-make -C tests          # builds test_kern, spinlock_cpp, mailbox_test, fifo_test
-make -C tests clean    # removes objects and binaries
-```
-
-Execute the resulting programs directly, for example:
+### Makefile
 
 ```sh
-./tests/test_kern
-./tests/mailbox_test
+cmake -S . -B build -G Ninja
+cmake --build build --target ipc posix kern_stubs
+make -C tests        # build all test binaries (test_kern, spinlock_cpp,
+                     # mailbox_test, fifo_test, posix_signal_demo,
+                     # posix_ipc_demo)
+make -C tests clean  # remove objects and binaries
 ```
 
-### CMake option
+Run the resulting binaries from the `tests/` directory.
 
-An experimental CMake configuration can also generate the test
-executables:
+### CMake
 
 ```sh
 cmake -S tests -B build/tests -G Ninja
 cmake --build build/tests
-./build/tests/test_kern   # should print "all ok"
+ctest --test-dir build/tests    # or run ./build/tests/test_kern
 ```
 
 Refer to [docs/building_kernel.md](docs/building_kernel.md) for a more


### PR DESCRIPTION
## Summary
- replace crashing test_kern file-open path with an IPC queue loopback smoke test
- clarify Makefile-based test build requires building libipc/libposix via cmake first

## Testing
- `pre-commit run --files README.md tests/test_kern.c`
- `cmake -S . -B build -G Ninja`
- `cmake --build build --target ipc posix kern_stubs`
- `make -C tests`
- `./tests/test_kern`
- `./tests/spinlock_cpp`
- `./tests/mailbox_test`
- `./tests/fifo_test`
- `./tests/posix_signal_demo`
- `./tests/posix_ipc_demo`


------
https://chatgpt.com/codex/tasks/task_e_68b3706e3afc8331a6b46aed696bc57e

## Summary by Sourcery

Replace the crashing file-open smoke test with an IPC loopback heartbeat test in test_kern, update the README with clarified CMake and Makefile build steps for the tests, and update the pre-commit configuration to use pocc/pre-commit-hooks for clang-tidy.

New Features:
- Replace the file-open smoke test in test_kern.c with an IPC queue loopback heartbeat test

CI:
- Switch the clang-tidy pre-commit hook to use pocc/pre-commit-hooks v1.3.5

Documentation:
- Clarify prerequisites and document updated Makefile and CMake commands for building and running the test suite in README.md

Tests:
- Require building IPC, POSIX, and kernel stubs via CMake before running tests and update tests/Makefile to include additional demo binaries